### PR TITLE
Refaktorering av Bosituasjon

### DIFF
--- a/src/components/dato/Datovelger.tsx
+++ b/src/components/dato/Datovelger.tsx
@@ -45,7 +45,6 @@ const Datovelger: React.FC<Props> = ({
   useEffect(() => {
     settDato(valgtDato ? valgtDato : dagensDato);
     setDefaultLocale('nb');
-
     // eslint-disable-next-line
   }, []);
 

--- a/src/context/SøknadContext.tsx
+++ b/src/context/SøknadContext.tsx
@@ -1,31 +1,7 @@
-import { useReducer } from 'react';
+import { useState } from 'react';
 import createUseContext from 'constate';
 import { ISøknad } from '../models/søknad';
 import mockPerson from '../mock/person.json';
-
-// ----------- ACTIONS & TYPES -----------
-export enum SøknadActionType {
-  settSøknad = 'settSøknad',
-}
-
-export type IAction = {
-  type: SøknadActionType;
-  payload: ISøknad;
-};
-
-// ----------- REDUCER -----------
-const reducer = (state: ISøknad, action: IAction): ISøknad => {
-  const søknad: ISøknad = action.payload;
-
-  switch (action.type) {
-    case SøknadActionType.settSøknad: {
-      return { ...søknad };
-    }
-
-    default:
-      return søknad;
-  }
-};
 
 // -----------  CONTEXT  -----------
 const initialState: ISøknad = {
@@ -43,12 +19,7 @@ const initialState: ISøknad = {
 };
 
 const useSøknad = () => {
-  const [state, dispatch] = useReducer(reducer, initialState);
-  const søknad = state;
-
-  const settSøknad = (søknad: ISøknad) => {
-    dispatch({ type: SøknadActionType.settSøknad, payload: søknad });
-  };
+  const [søknad, settSøknad] = useState<ISøknad>(initialState);
 
   return { søknad, settSøknad };
 };

--- a/src/models/person.ts
+++ b/src/models/person.ts
@@ -40,7 +40,7 @@ export interface IBarn {
 }
 
 export interface IPersonDetaljer {
-  navn: string;
-  fødselsdato: Date;
-  fødselsnummer: string;
+  navn?: string;
+  fødselsdato?: Date;
+  fødselsnummer?: string;
 }

--- a/src/søknad/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/søknad/steg/2-bosituasjon/Bosituasjon.tsx
@@ -27,14 +27,14 @@ const Bosituasjon: FC = () => {
     settSøknad({ ...søknad, bosituasjon: bosituasjon });
   }, [bosituasjon, settSøknad, søknad]);
 
-  const updateBosituasjon = (nyBosituasjon: IBosituasjon) =>
+  const oppdaterBosituasjon = (nyBosituasjon: IBosituasjon) =>
     settBosituasjon({ ...bosituasjon, ...nyBosituasjon });
 
   const hovedSpørsmål: ISpørsmål = delerSøkerBoligMedAndreVoksne;
 
   const settBosituasjonFelt = (spørsmål: string, svar: string) => {
     if (!bosituasjon.søkerDelerBoligMedAndreVoksne.verdi) {
-      updateBosituasjon({
+      oppdaterBosituasjon({
         søkerDelerBoligMedAndreVoksne: {
           label: spørsmål,
           verdi: svar,

--- a/src/søknad/steg/2-bosituasjon/OmSamboerenDin.tsx
+++ b/src/søknad/steg/2-bosituasjon/OmSamboerenDin.tsx
@@ -1,34 +1,35 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
 import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
 import FeltGruppe from '../../../components/gruppe/FeltGruppe';
 import Datovelger, {
   DatoBegrensning,
 } from '../../../components/dato/Datovelger';
 import PersonInfoGruppe from '../../../components/gruppe/PersonInfoGruppe';
-import useSøknadContext from '../../../context/SøknadContext';
 import { tomPersonInfo } from '../../../utils/person';
 import { useIntl } from 'react-intl';
+import { IBosituasjon } from '../../../models/bosituasjon';
 
 interface Props {
   tittel: string;
   ekteskapsLiknendeForhold: boolean;
+  settBosituasjon: (bositasjon: IBosituasjon) => void;
+  bosituasjon: IBosituasjon;
 }
 
-const OmSamboerenDin: FC<Props> = ({ tittel, ekteskapsLiknendeForhold }) => {
+const OmSamboerenDin: FC<Props> = ({
+  tittel,
+  ekteskapsLiknendeForhold,
+  settBosituasjon,
+  bosituasjon,
+}) => {
   const intl = useIntl();
-  const { søknad, settSøknad } = useSøknadContext();
-  const { bosituasjon } = søknad;
   const { samboerDetaljer } = bosituasjon;
 
   const settFødselsdato = (date: Date | null) => {
     date !== null &&
-      samboerDetaljer &&
-      settSøknad({
-        ...søknad,
-        bosituasjon: {
-          ...bosituasjon,
-          samboerDetaljer: { ...samboerDetaljer, fødselsdato: date },
-        },
+      settBosituasjon({
+        ...bosituasjon,
+        samboerDetaljer: { ...samboerDetaljer, fødselsdato: date },
       });
   };
 
@@ -36,40 +37,25 @@ const OmSamboerenDin: FC<Props> = ({ tittel, ekteskapsLiknendeForhold }) => {
     e: React.FormEvent<HTMLInputElement>,
     objektnøkkel: string
   ) => {
-    samboerDetaljer &&
-      settSøknad({
-        ...søknad,
-        bosituasjon: {
-          ...bosituasjon,
-          samboerDetaljer: {
-            ...samboerDetaljer,
-            [objektnøkkel]: e.currentTarget.value,
-          },
-        },
-      });
+    settBosituasjon({
+      ...bosituasjon,
+      samboerDetaljer: {
+        ...samboerDetaljer,
+        [objektnøkkel]: e.currentTarget.value,
+      },
+    });
   };
 
   const settDatoFlyttetSammen = (dato: Date | null) => {
     dato !== null &&
-      settSøknad({
-        ...søknad,
-        bosituasjon: {
-          ...bosituasjon,
-          datoFlyttetSammenMedSamboer: {
-            label: datovelgerTekst,
-            verdi: dato,
-          },
+      settBosituasjon({
+        ...bosituasjon,
+        datoFlyttetSammenMedSamboer: {
+          label: datovelgerTekst,
+          verdi: dato,
         },
       });
   };
-
-  useEffect(() => {
-    settSøknad({
-      ...søknad,
-      bosituasjon: { ...bosituasjon, samboerDetaljer: tomPersonInfo },
-    });
-    // eslint-disable-next-line
-  }, []);
 
   const datovelgerTekst = intl.formatMessage({
     id: 'bosituasjon.datovelger.nårFlyttetDereSammen',

--- a/src/søknad/steg/2-bosituasjon/SøkerSkalFlytteSammenEllerFåSamboer.tsx
+++ b/src/søknad/steg/2-bosituasjon/SøkerSkalFlytteSammenEllerFåSamboer.tsx
@@ -49,7 +49,6 @@ const SøkerSkalFlytteSammenEllerFåSamboer: FC<Props> = ({
     dato: Date | null,
     label: string
   ) => {
-    console.log('søkersklflyttesammen:', dato);
     dato !== null &&
       settBosituasjon({
         ...bosituasjon,
@@ -89,21 +88,27 @@ const SøkerSkalFlytteSammenEllerFåSamboer: FC<Props> = ({
               }
               tekstid={'datovelger.nårSkalDetteSkje'}
               datobegrensning={DatoBegrensning.FremtidigeDatoer}
-              settDato={(e) =>
-                settDatoSøkerSkalGifteSegEllerBliSamboer(e, datovelgerTekst)
-              }
+              settDato={(e) => {
+                settDatoSøkerSkalGifteSegEllerBliSamboer(e, datovelgerTekst);
+              }}
             />
           </KomponentGruppe>
-          <KomponentGruppe>
-            <OmSamboerenDin
-              tittel={'bosituasjon.tittel.hvemSkalSøkerGifteEllerBliSamboerMed'}
-              ekteskapsLiknendeForhold={false}
-            />
-          </KomponentGruppe>
+          {datoSkalGifteSegEllerBliSamboer && (
+            <KomponentGruppe>
+              <OmSamboerenDin
+                tittel={
+                  'bosituasjon.tittel.hvemSkalSøkerGifteEllerBliSamboerMed'
+                }
+                ekteskapsLiknendeForhold={false}
+                settBosituasjon={settBosituasjon}
+                bosituasjon={bosituasjon}
+              />
+            </KomponentGruppe>
+          )}
         </>
       ) : null}
     </>
   );
 };
 
-export default injectIntl(SøkerSkalFlytteSammenEllerFåSamboer);
+export default SøkerSkalFlytteSammenEllerFåSamboer;

--- a/src/søknad/steg/2-bosituasjon/SøkerSkalFlytteSammenEllerFåSamboer.tsx
+++ b/src/søknad/steg/2-bosituasjon/SøkerSkalFlytteSammenEllerFåSamboer.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
 import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
 import JaNeiSpørsmål from '../../../components/spørsmål/JaNeiSpørsmål';
 import { skalSøkerGifteSegMedSamboer } from './BosituasjonConfig';
@@ -7,20 +7,25 @@ import Datovelger, {
 } from '../../../components/dato/Datovelger';
 import { dagensDato } from '../../../utils/dato';
 import OmSamboerenDin from './OmSamboerenDin';
-import useSøknadContext from '../../../context/SøknadContext';
-import { injectIntl, IntlShape } from 'react-intl';
 import { ISpørsmål } from '../../../models/spørsmal';
+import { IBosituasjon } from '../../../models/bosituasjon';
+import { useIntl } from 'react-intl';
 
-const SøkerSkalFlytteSammenEllerFåSamboer: FC<{ intl: IntlShape }> = ({
-  intl,
+interface Props {
+  settBosituasjon: (bosituasjon: IBosituasjon) => void;
+  bosituasjon: IBosituasjon;
+}
+
+const SøkerSkalFlytteSammenEllerFåSamboer: FC<Props> = ({
+  settBosituasjon,
+  bosituasjon,
 }) => {
-  const { søknad, settSøknad } = useSøknadContext();
-  const { bosituasjon } = søknad;
+  const intl = useIntl();
+
   const {
     søkerDelerBoligMedAndreVoksne,
     søkerSkalGifteSegEllerBliSamboer,
     datoSkalGifteSegEllerBliSamboer,
-    samboerDetaljer,
   } = bosituasjon;
 
   const spørsmål: ISpørsmål = skalSøkerGifteSegMedSamboer;
@@ -29,16 +34,13 @@ const SøkerSkalFlytteSammenEllerFåSamboer: FC<{ intl: IntlShape }> = ({
     spørsmål: ISpørsmål,
     svar: boolean
   ) => {
-    settSøknad({
-      ...søknad,
-      bosituasjon: {
-        ...bosituasjon,
-        søkerSkalGifteSegEllerBliSamboer: {
-          label: intl.formatMessage({
-            id: spørsmål.tekstid,
-          }),
-          verdi: svar,
-        },
+    settBosituasjon({
+      søkerDelerBoligMedAndreVoksne: søkerDelerBoligMedAndreVoksne,
+      søkerSkalGifteSegEllerBliSamboer: {
+        label: intl.formatMessage({
+          id: spørsmål.tekstid,
+        }),
+        verdi: svar,
       },
     });
   };
@@ -47,40 +49,16 @@ const SøkerSkalFlytteSammenEllerFåSamboer: FC<{ intl: IntlShape }> = ({
     dato: Date | null,
     label: string
   ) => {
+    console.log('søkersklflyttesammen:', dato);
     dato !== null &&
-      settSøknad({
-        ...søknad,
-        bosituasjon: {
-          ...bosituasjon,
-          datoSkalGifteSegEllerBliSamboer: {
-            label: label,
-            verdi: dato,
-          },
+      settBosituasjon({
+        ...bosituasjon,
+        datoSkalGifteSegEllerBliSamboer: {
+          label: label,
+          verdi: dato,
         },
       });
   };
-
-  useEffect(() => {
-    const resetSamboerDetaljer = () => {
-      settSøknad({
-        ...søknad,
-        bosituasjon: {
-          søkerDelerBoligMedAndreVoksne: søkerDelerBoligMedAndreVoksne,
-          søkerSkalGifteSegEllerBliSamboer: søkerSkalGifteSegEllerBliSamboer,
-        },
-      });
-    };
-    søkerSkalGifteSegEllerBliSamboer &&
-      søkerSkalGifteSegEllerBliSamboer.verdi === false &&
-      samboerDetaljer &&
-      resetSamboerDetaljer();
-  }, [
-    søkerSkalGifteSegEllerBliSamboer,
-    samboerDetaljer,
-    settSøknad,
-    søknad,
-    søkerDelerBoligMedAndreVoksne,
-  ]);
 
   const datovelgerTekst = intl.formatMessage({
     id: 'datovelger.nårSkalDetteSkje',


### PR DESCRIPTION
**Denne PR-en er resultatet av en parprogrammeringsdag med Espen Hellerud som sitter på Digipost, og bruker React Context & Hooks daglig 😄** 
Var så heldig å få låne han en hel dag til å stille masse spørsmål, kvalitetsjekke koden vår og få input på forbedringer vi kunne gjøre 👩‍💻 👨‍💻  

**Inneholder:**
- En mer simpel context med kun useState
- Mindre nøstede funksjoner for å sette Bosituasjon inn i søknad vha av en lokal useState funksjon. 
- I stedet for å ha resette Bosituasjonsobjektet i en useEffect, så gjør vi det når bruker trykker på en knapp / et nytt svarsalternativ. And it feels so right ✨ 

Refaktorerte Bosituasjon fordi det ikke er et så stort steg, en tanken er vel å fortsette å kode/refaktorere de andre stegene i dette mønsteret.
Ta det litt etter hvert når vi får mulighet til det siden vi akkurat nå bare prøver å få på plass stegene til midten av mars :)
