### PR TITLE
Endrer Spørsmålskomponenter for å bli mer konsistent

### DIFF
--- a/src/components/Hjelpetekst.tsx
+++ b/src/components/Hjelpetekst.tsx
@@ -4,6 +4,7 @@ import Lesmerpanel from 'nav-frontend-lesmerpanel';
 import styled from 'styled-components';
 import { useIntl } from 'react-intl';
 import LocaleTekst from '../language/LocaleTekst';
+import { hentTekst } from '../utils/søknad';
 
 const StyledHjelpetekst = styled.div`
   .lesMerPanel {
@@ -46,13 +47,12 @@ const Hjelpetekst: React.FC<Props> = ({
   innholdTekstid,
 }) => {
   const intl = useIntl();
-  const hentTekst = (id: string) => intl.formatMessage({ id: id });
 
   return (
     <StyledHjelpetekst>
       <Lesmerpanel
-        apneTekst={hentTekst(åpneTekstid)}
-        lukkTekst={lukkeTekstid ? hentTekst(lukkeTekstid) : undefined}
+        apneTekst={hentTekst(åpneTekstid, intl)}
+        lukkTekst={lukkeTekstid ? hentTekst(lukkeTekstid, intl) : undefined}
       >
         <Normaltekst>
           <LocaleTekst tekst={innholdTekstid} />

--- a/src/components/spørsmål/CheckboxSpørsmål.tsx
+++ b/src/components/spørsmål/CheckboxSpørsmål.tsx
@@ -20,7 +20,7 @@ const StyledCheckboxSpørsmål = styled.div`
 
 interface Props {
   spørsmål: ISpørsmål;
-  settValgteSvar: (spørsmål: string, svar: string[]) => void;
+  settValgteSvar: (spørsmål: ISpørsmål, svar: string[]) => void;
   valgteSvar: string[];
 }
 const CheckboxSpørsmål: React.FC<Props> = ({
@@ -35,17 +35,15 @@ const CheckboxSpørsmål: React.FC<Props> = ({
     checked: boolean,
     svarTekst: string
   ): void => {
-    const spørsmålTekst: string = intl.formatMessage({ id: spørsmål.tekstid });
-
     if (checked) {
       const avhukedeSvar: string[] = valgteSvar.filter((valgtSvar) => {
         return valgtSvar !== svarTekst;
       });
-      settValgteSvar(spørsmålTekst, avhukedeSvar);
+      settValgteSvar(spørsmål, avhukedeSvar);
     } else {
       const avhukedeSvar = valgteSvar;
       avhukedeSvar.push(svarTekst);
-      settValgteSvar(spørsmålTekst, avhukedeSvar);
+      settValgteSvar(spørsmål, avhukedeSvar);
     }
   };
 

--- a/src/components/spørsmål/MultiSvarSpørsmål.tsx
+++ b/src/components/spørsmål/MultiSvarSpørsmål.tsx
@@ -31,7 +31,7 @@ const StyledMultisvarSpørsmål = styled.div`
 interface Props {
   toKorteSvar?: boolean;
   spørsmål: ISpørsmål;
-  onChange: (spørsmål: string, svar: string) => void;
+  onChange: (spørsmål: ISpørsmål, svar: string) => void;
   valgtSvar: string | undefined;
 }
 
@@ -49,10 +49,7 @@ const MultiSvarSpørsmål: FC<Props> = ({
   ): void => {
     svar !== undefined &&
       onChange !== undefined &&
-      onChange(
-        intl.formatMessage({ id: spørsmål.tekstid }),
-        intl.formatMessage({ id: svar.svar_tekstid })
-      );
+      onChange(spørsmål, intl.formatMessage({ id: svar.svar_tekstid }));
   };
 
   return (

--- a/src/components/spørsmål/MultiSvarSpørsmål.tsx
+++ b/src/components/spørsmål/MultiSvarSpørsmål.tsx
@@ -31,14 +31,14 @@ const StyledMultisvarSpørsmål = styled.div`
 interface Props {
   toKorteSvar?: boolean;
   spørsmål: ISpørsmål;
-  onChange: (spørsmål: ISpørsmål, svar: string) => void;
+  settSpørsmålOgSvar: (spørsmål: ISpørsmål, svar: string) => void;
   valgtSvar: string | undefined;
 }
 
 const MultiSvarSpørsmål: FC<Props> = ({
   toKorteSvar,
   spørsmål,
-  onChange,
+  settSpørsmålOgSvar,
   valgtSvar,
 }) => {
   const intl = useIntl();
@@ -48,8 +48,11 @@ const MultiSvarSpørsmål: FC<Props> = ({
     svar: ISvar
   ): void => {
     svar !== undefined &&
-      onChange !== undefined &&
-      onChange(spørsmål, intl.formatMessage({ id: svar.svar_tekstid }));
+      settSpørsmålOgSvar !== undefined &&
+      settSpørsmålOgSvar(
+        spørsmål,
+        intl.formatMessage({ id: svar.svar_tekstid })
+      );
   };
 
   return (

--- a/src/søknad/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.tsx
@@ -10,20 +10,23 @@ import Utenlandsopphold from './Utenlandsopphold';
 import { dagensDato } from '../../../../utils/dato';
 import subDays from 'date-fns/subDays';
 import { IUtenlandsopphold } from '../../../../models/omDeg';
+import { hentTekst } from '../../../../utils/søknad';
 
 const PeriodeBoddIUtlandet: FC = () => {
   const { søknad, settSøknad } = useSøknadContext();
   const { perioderBoddIUtlandet } = søknad.medlemskap;
   const intl = useIntl();
-  const hentTekst = (id: string) => intl.formatMessage({ id: id });
 
   const nyPeriode = {
     periode: {
-      fra: { label: hentTekst('periode.fra'), verdi: subDays(dagensDato, 1) },
-      til: { label: hentTekst('periode.til'), verdi: dagensDato },
+      fra: {
+        label: hentTekst('periode.fra', intl),
+        verdi: subDays(dagensDato, 1),
+      },
+      til: { label: hentTekst('periode.til', intl), verdi: dagensDato },
     },
     begrunnelse: {
-      label: hentTekst('medlemskap.periodeBoddIUtlandet.begrunnelse'),
+      label: hentTekst('medlemskap.periodeBoddIUtlandet.begrunnelse', intl),
       verdi: '',
     },
   };

--- a/src/søknad/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
@@ -9,6 +9,7 @@ import { compareAsc } from 'date-fns';
 import { hentTittelMedNr } from '../../../../language/utils';
 import { IUtenlandsopphold } from '../../../../models/omDeg';
 import PeriodeDatovelgere from '../../../../components/dato/PeriodeDatovelger';
+import { hentTekst } from '../../../../utils/søknad';
 
 interface Props {
   utenlandsopphold: IUtenlandsopphold;
@@ -21,7 +22,6 @@ const Utenlandsopphold: FC<Props> = ({ oppholdsnr, utenlandsopphold }) => {
   const { periode, begrunnelse } = utenlandsopphold;
   const intl = useIntl();
   const [feilmelding, settFeilmelding] = useState('');
-  const hentTekst = (id: string) => intl.formatMessage({ id: id });
   const begrunnelseTekst = intl.formatMessage({
     id: 'medlemskap.periodeBoddIUtlandet.begrunnelse',
   });
@@ -89,7 +89,7 @@ const Utenlandsopphold: FC<Props> = ({ oppholdsnr, utenlandsopphold }) => {
             periode: {
               ...periode,
               [objektnøkkel]: {
-                label: hentTekst('periode.' + objektnøkkel),
+                label: hentTekst('periode.' + objektnøkkel, intl),
                 verdi: date !== null ? date : undefined,
               },
             },

--- a/src/søknad/steg/1-omdeg/sivilstatus/begrunnelse/SøknadsBegrunnelse.tsx
+++ b/src/søknad/steg/1-omdeg/sivilstatus/begrunnelse/SøknadsBegrunnelse.tsx
@@ -11,6 +11,7 @@ import { BegrunnelseSpørsmål } from '../SivilstatusConfig';
 import { Textarea } from 'nav-frontend-skjema';
 import { useIntl } from 'react-intl';
 import { ISpørsmål } from '../../../../../models/spørsmal';
+import { hentTekst } from '../../../../../utils/søknad';
 
 interface Props {
   settDato: (date: Date | null, objektnøkkel: string, tekstid: string) => void;
@@ -68,12 +69,13 @@ const Søknadsbegrunnelse: FC<Props> = ({ settDato }) => {
       });
   };
 
-  const settBegrunnelseForSøknad = (spørsmål: string, svar: string) => {
+  const settBegrunnelseForSøknad = (spørsmål: ISpørsmål, svar: string) => {
+    const spørsmålTekst: string = hentTekst(spørsmål.tekstid, intl);
     settSøknad({
       ...søknad,
       sivilstatus: {
         ...sivilstatus,
-        begrunnelseForSøknad: { label: spørsmål, verdi: svar },
+        begrunnelseForSøknad: { label: spørsmålTekst, verdi: svar },
       },
     });
   };

--- a/src/søknad/steg/1-omdeg/sivilstatus/begrunnelse/SøknadsBegrunnelse.tsx
+++ b/src/søknad/steg/1-omdeg/sivilstatus/begrunnelse/SøknadsBegrunnelse.tsx
@@ -112,7 +112,7 @@ const Søknadsbegrunnelse: FC<Props> = ({ settDato }) => {
           key={spørsmål.tekstid}
           spørsmål={spørsmål}
           valgtSvar={sivilstatus.begrunnelseForSøknad?.verdi}
-          onChange={settBegrunnelseForSøknad}
+          settSpørsmålOgSvar={settBegrunnelseForSøknad}
         />
       </KomponentGruppe>
 

--- a/src/søknad/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/søknad/steg/2-bosituasjon/Bosituasjon.tsx
@@ -81,7 +81,7 @@ const Bosituasjon: FC = () => {
           key={hovedSpørsmål.spørsmål_id}
           spørsmål={hovedSpørsmål}
           valgtSvar={bosituasjon.søkerDelerBoligMedAndreVoksne.verdi}
-          onChange={settBosituasjonFelt}
+          settSpørsmålOgSvar={settBosituasjonFelt}
         />
         {valgtSvar && valgtSvar.alert_tekstid ? (
           <AlertStripeAdvarsel className={'fjernBakgrunn'}>

--- a/src/søknad/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/søknad/steg/2-bosituasjon/Bosituasjon.tsx
@@ -8,7 +8,7 @@ import Side from '../../../components/side/Side';
 import SøkerSkalFlytteSammenEllerFåSamboer from './SøkerSkalFlytteSammenEllerFåSamboer';
 import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
 import { delerSøkerBoligMedAndreVoksne } from './BosituasjonConfig';
-import { erValgtSvarLiktSomSvar } from '../../../utils/søknad';
+import { erValgtSvarLiktSomSvar, hentTekst } from '../../../utils/søknad';
 import { ESøkerDelerBolig, IBosituasjon } from '../../../models/bosituasjon';
 import { ISpørsmål, ISvar } from '../../../models/spørsmal';
 import useSøknadContext from '../../../context/SøknadContext';
@@ -33,18 +33,20 @@ const Bosituasjon: FC = () => {
 
   const hovedSpørsmål: ISpørsmål = delerSøkerBoligMedAndreVoksne;
 
-  const settBosituasjonFelt = (spørsmål: string, svar: string) => {
+  const settBosituasjonFelt = (spørsmål: ISpørsmål, svar: string) => {
+    const spørsmålTekst: string = hentTekst(spørsmål.tekstid, intl);
+
     if (!bosituasjon.søkerDelerBoligMedAndreVoksne.verdi) {
       oppdaterBosituasjon({
         søkerDelerBoligMedAndreVoksne: {
-          label: spørsmål,
+          label: spørsmålTekst,
           verdi: svar,
         },
       });
     } else if (svar !== bosituasjon.søkerDelerBoligMedAndreVoksne.verdi) {
       settBosituasjon({
         søkerDelerBoligMedAndreVoksne: {
-          label: spørsmål,
+          label: spørsmålTekst,
           verdi: svar,
         },
       });

--- a/src/søknad/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnasBosted.tsx
@@ -49,7 +49,7 @@ const BarnasBosted: React.FC = () => {
                 key={borISammeHus.spørsmål_id}
                 spørsmål={borISammeHus}
                 valgtSvar={forelder.borISammeHus}
-                onChange={(_, svar) =>
+                settSpørsmålOgSvar={(_, svar) =>
                   settForelder({
                     ...forelder,
                     [borISammeHus.spørsmål_id]: svar,
@@ -91,7 +91,7 @@ const BarnasBosted: React.FC = () => {
                 key={hvorMyeSammen.spørsmål_id}
                 spørsmål={hvorMyeSammen}
                 valgtSvar={forelder.hvorMyeSammen}
-                onChange={(_, svar) =>
+                settSpørsmålOgSvar={(_, svar) =>
                   settForelder({
                     ...forelder,
                     [hvorMyeSammen.spørsmål_id]: svar,

--- a/src/søknad/steg/4-barnasbosted/BostedOgSamvær.tsx
+++ b/src/søknad/steg/4-barnasbosted/BostedOgSamvær.tsx
@@ -14,6 +14,7 @@ import {
 import HvordanPraktiseresSamværet from './HvordanPraktiseresSamværet';
 import LocaleTekst from '../../../language/LocaleTekst';
 import { AlertStripeInfo } from 'nav-frontend-alertstriper';
+import { ISpørsmål } from '../../../models/spørsmal';
 
 interface Props {
   settForelder: Function;
@@ -24,12 +25,12 @@ const BostedOgSamvær: React.FC<Props> = ({ settForelder, forelder }) => {
   const intl = useIntl();
 
   const settHarForelderSamværMedBarn = (
-    spørsmål: string,
+    spørsmål: ISpørsmål,
     valgtSvar: string
   ) => {
     const nyForelder = {
       ...forelder,
-      [harAnnenForelderSamværMedBarn.spørsmål_id]: valgtSvar,
+      [spørsmål.spørsmål_id]: valgtSvar,
     };
 
     if (
@@ -54,12 +55,12 @@ const BostedOgSamvær: React.FC<Props> = ({ settForelder, forelder }) => {
   };
 
   const settHarDereSkriftligSamværsavtale = (
-    spørsmål: string,
+    spørsmål: ISpørsmål,
     valgtSvar: string
   ) => {
     const nyForelder = {
       ...forelder,
-      [harDereSkriftligSamværsavtale.spørsmål_id]: valgtSvar,
+      [spørsmål.spørsmål_id]: valgtSvar,
     };
 
     if (

--- a/src/søknad/steg/4-barnasbosted/BostedOgSamvær.tsx
+++ b/src/søknad/steg/4-barnasbosted/BostedOgSamvær.tsx
@@ -115,7 +115,7 @@ const BostedOgSamvær: React.FC<Props> = ({ settForelder, forelder }) => {
           key={harAnnenForelderSamværMedBarn.spørsmål_id}
           spørsmål={harAnnenForelderSamværMedBarn}
           valgtSvar={forelder.harAnnenForelderSamværMedBarn}
-          onChange={(spørsmål, svar) =>
+          settSpørsmålOgSvar={(spørsmål, svar) =>
             settHarForelderSamværMedBarn(spørsmål, svar)
           }
         />
@@ -129,7 +129,7 @@ const BostedOgSamvær: React.FC<Props> = ({ settForelder, forelder }) => {
             key={harDereSkriftligSamværsavtale.spørsmål_id}
             spørsmål={harDereSkriftligSamværsavtale}
             valgtSvar={forelder.harDereSkriftligSamværsavtale}
-            onChange={(spørsmål, svar) =>
+            settSpørsmålOgSvar={(spørsmål, svar) =>
               settHarDereSkriftligSamværsavtale(spørsmål, svar)
             }
           />

--- a/src/søknad/steg/5-arbeidssituasjon/Arbeidssituasjon.tsx
+++ b/src/søknad/steg/5-arbeidssituasjon/Arbeidssituasjon.tsx
@@ -13,6 +13,8 @@ import {
   IArbeidssituasjon,
   nyttTekstListeFelt,
 } from '../../../models/arbeidssituasjon';
+import { ISpørsmål } from '../../../models/spørsmal';
+import { hentTekst } from '../../../utils/søknad';
 
 const Arbeidssituasjon: React.FC = () => {
   const intl = useIntl();
@@ -31,10 +33,10 @@ const Arbeidssituasjon: React.FC = () => {
     settArbeidssituasjon({ ...arbeidssituasjon, ...nyArbeidssituasjon });
   };
 
-  const settArbeidssituasjonFelt = (spørsmål: string, svar: string[]) => {
+  const settArbeidssituasjonFelt = (spørsmål: ISpørsmål, svar: string[]) => {
     oppdaterArbeidssituasjon({
       ...arbeidssituasjon,
-      situasjon: { label: spørsmål, verdi: svar },
+      situasjon: { label: hentTekst(spørsmål.tekstid, intl), verdi: svar },
     });
   };
 

--- a/src/søknad/steg/5-arbeidssituasjon/arbeidsforhold/Arbeidsgiver.tsx
+++ b/src/søknad/steg/5-arbeidssituasjon/arbeidsforhold/Arbeidsgiver.tsx
@@ -18,6 +18,7 @@ import HarSøkerSluttdato from './HarSøkerSluttdato';
 import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
 import InputLabelGruppe from '../../../../components/gruppe/InputLabelGruppe';
 import { hentTekst } from '../../../../utils/søknad';
+import { ISpørsmål } from '../../../../models/spørsmal';
 
 const StyledArbeidsgiver = styled.div`
   display: flex;
@@ -136,8 +137,12 @@ const Arbeidsgiver: React.FC<Props> = ({
         <MultiSvarSpørsmål
           toKorteSvar={true}
           spørsmål={hvaSlagsStilling}
-          onChange={(spørsmål: string, svar: string) =>
-            oppdaterArbeidsgiver(EArbeidsgiver.fastStilling, spørsmål, svar)
+          onChange={(spørsmål: ISpørsmål, svar: string) =>
+            oppdaterArbeidsgiver(
+              EArbeidsgiver.fastStilling,
+              spørsmål.tekstid,
+              svar
+            )
           }
           valgtSvar={arbeidsgiver.fastStilling?.verdi}
         />

--- a/src/søknad/steg/5-arbeidssituasjon/arbeidsforhold/Arbeidsgiver.tsx
+++ b/src/søknad/steg/5-arbeidssituasjon/arbeidsforhold/Arbeidsgiver.tsx
@@ -17,6 +17,7 @@ import MultiSvarSpørsmål from '../../../../components/spørsmål/MultiSvarSpø
 import HarSøkerSluttdato from './HarSøkerSluttdato';
 import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
 import InputLabelGruppe from '../../../../components/gruppe/InputLabelGruppe';
+import { hentTekst } from '../../../../utils/søknad';
 
 const StyledArbeidsgiver = styled.div`
   display: flex;
@@ -83,17 +84,15 @@ const Arbeidsgiver: React.FC<Props> = ({
     oppdaterArbeidsgiver(nøkkel, label, e.currentTarget.value);
   };
 
-  const hentFeltTekstid = (feltid: EArbeidsgiver) => {
-    return intl.formatMessage({ id: 'arbeidsforhold.label.' + feltid }).trim();
-  };
   const arbeidsgiverTittel = hentTittelMedNr(
     arbeidsforhold!,
     arbeidsgivernummer,
     intl.formatMessage({ id: 'arbeidsforhold.tittel.arbeidsgiver' })
   );
-  const navnLabel: string = hentFeltTekstid(EArbeidsgiver.navn);
-  const arbeidsmengdeLabel: string = hentFeltTekstid(
-    EArbeidsgiver.arbeidsmengde
+  const navnLabel: string = hentTekst('arbeidsforhold.label.navn', intl);
+  const arbeidsmengdeLabel: string = hentTekst(
+    'arbeidsforhold.label.arbeidsmengde',
+    intl
   );
 
   return (

--- a/src/søknad/steg/5-arbeidssituasjon/arbeidsforhold/Arbeidsgiver.tsx
+++ b/src/søknad/steg/5-arbeidssituasjon/arbeidsforhold/Arbeidsgiver.tsx
@@ -137,7 +137,7 @@ const Arbeidsgiver: React.FC<Props> = ({
         <MultiSvarSpørsmål
           toKorteSvar={true}
           spørsmål={hvaSlagsStilling}
-          onChange={(spørsmål: ISpørsmål, svar: string) =>
+          settSpørsmålOgSvar={(spørsmål: ISpørsmål, svar: string) =>
             oppdaterArbeidsgiver(
               EArbeidsgiver.fastStilling,
               spørsmål.tekstid,

--- a/src/utils/søknad.ts
+++ b/src/utils/søknad.ts
@@ -47,3 +47,6 @@ export const erValgtSvarLiktSomSvar = (
 ) => {
   return valgtSvar === intl.formatMessage({ id: annetSvarTekstid });
 };
+
+export const hentTekst = (id: string, intl: IntlShape) =>
+  intl.formatMessage({ id: id });


### PR DESCRIPTION
- CheckboxSpørsmål og MultiSvarSpørsmål er tar nå en onChange-metode med spørsmål av type ISpørsmål i stedet for kun string. 
- metodenavn er endret fra onChange til settSpørsmålOgSvar
++

_______________
**Diskusjon:**
 
Skal vi endre I..Felt-ene til å lagre tekstid-er til spørsmål/label og svar (for de som er strenger) også? 
Så fra 
```
ITekstFelt {
 label: string;
 verdi: string;
}
```

til 
```
ITekstFelt {
 nøkkel: string; 
 label_tekstid: string;
 verdi_tekstid: string;
 label: string;  (klar tekst, oversatt med intl.formatMsg allerede)
 verdi: string; (klar tekst, oversatt med intl.formatMsg allerede)
}
```
slik at vi slipper å oversette med intl.formatMsg når vi skl prøve å sammenlikne svarsalternativ med svaret som er lagret i søknaden?
Kanskje i en egen branch igjen tho. 🤷‍♀  🤔 
