### PR TITLE
Utvider søknadsfelter for barnesteg (3 og 4)

### DIFF
--- a/src/helpers/barn.ts
+++ b/src/helpers/barn.ts
@@ -1,0 +1,46 @@
+import { IntlShape } from 'react-intl';
+import { hentFeltObjekt, hentTekst } from '../utils/søknad';
+import { differenceInYears } from 'date-fns';
+import { dagensDato, formatDate } from '../utils/dato';
+import { hentUid } from '../utils/uuid';
+import { EBarn, IBarn } from '../models/barn';
+import { ESvar } from '../models/spørsmalogsvar';
+
+export const hentNyttBarn = (
+  fødselsnummer: string,
+  personnummer: string,
+  barnDato: Date,
+  navn: string,
+  boHosDeg: string,
+  født: boolean,
+  intl: IntlShape
+): IBarn => {
+  return {
+    fnr: hentFeltObjekt('person.fnr', fødselsnummer, intl),
+    personnummer: hentFeltObjekt('barnadine.personnummer', personnummer, intl),
+    alder: hentFeltObjekt(
+      'person.alder',
+      differenceInYears(dagensDato, barnDato),
+      intl
+    ),
+    navn: hentFeltObjekt('person.navn', navn, intl),
+    fødselsdato: hentFeltObjekt(
+      'person.fødselsdato',
+      formatDate(barnDato),
+      intl
+    ),
+    harSammeAdresse: hentFeltObjekt(
+      'barnekort.spm.født',
+      boHosDeg === 'ja',
+      intl
+    ),
+    født: {
+      spørsmålid: EBarn.født,
+      svarid: født ? ESvar.JA : ESvar.NEI,
+      label: hentTekst('barnekort.spm.født', intl),
+      verdi: født,
+    },
+    lagtTil: true,
+    id: hentUid(),
+  };
+};

--- a/src/language/tekster.ts
+++ b/src/language/tekster.ts
@@ -329,7 +329,7 @@ export default {
     'barnasbosted.spm.jaIkkeKonkreteTidspunkt':
       'Ja, men den inneholder ikke konkrete tidspunkter som samvær',
     'barnasbosted.spm.boddsammenfør':
-      'Har du bodd sammen med den andre forelderen til Mina før?',
+      'Har du bodd sammen med den andre forelderen til [0] før?',
     'barnasbosted.spm.borISammeHus':
       'Bor du og den andre forelderen til [0] i samme hus, blokk, gårdstun, kvartal eller vei/gate?',
     'barnasbosted.spm.vetikke': 'Jeg vet ikke hvor den andre forelderen bor',

--- a/src/language/tekster.ts
+++ b/src/language/tekster.ts
@@ -42,16 +42,18 @@ export default {
 
     'person.navn': 'Navn',
     'person.nr': 'Personnummer 5 siffer. Kun hvis du vet',
+    'person.fnr': 'Fødselsnummer',
+    'person.telefonnr': 'Telefonnummer',
+    'person.statsborgerskap': 'Statsborgerskap',
+    'person.adresse': 'Adresse',
+    'person.alder': 'Alder',
+    'person.fødselsdato': 'Fødselsdato',
 
     'personopplysninger.alert.infohentet':
       'Hvis opplysningene vi har om deg ikke stemmer, må du endre disse hos Folkeregisteret.',
-    'personopplysninger.adresse': 'Adresse',
     'personopplysninger.spm.riktigAdresse': 'Bor du på denne adressen?',
     'personopplysninger.alert.riktigAdresse':
       'Du må oppdatere Folkeregisteret med riktig adresse for å søke digitalt. Hvis du ikke skal endre Folkeregistrert adresse, kan du søke på papir med bostedsadressen din.',
-    'personopplysninger.fnr': 'Fødselsnr',
-    'personopplysninger.telefonnr': 'Telefonnummer',
-    'personopplysninger.statsborgerskap': 'Statsborgerskap',
 
     'sivilstatus.tittel': 'Sivilstatus',
     'sivilstatus.somgift':
@@ -297,7 +299,8 @@ export default {
     'barnekort.normaltekst.barn': 'Barn',
     'barnekort.adresse.registrert': 'Registrert på adressen din',
     'barnekort.adresse.uregistrert': 'Ikke registrert på adressen din',
-    'barnekort.født': 'Er barnet født?',
+    'barnekort.spm.født': 'Er barnet født?',
+    'barnekort.spm.sammeAdresse': 'Har barnet samme adresse som deg?',
 
     'barnadine.sidetittel': 'Barna dine',
     'barnasbosted.sidetittel': 'Barnas bosted og foreldrenes samværsordning',
@@ -380,8 +383,6 @@ export default {
       'Hvis du har studert i utlandet med støtte fra Lånekassen i denne perioden, regnes du som bosatt i Norge.',
     'medlemskap.spm.flyktning': 'Er du registrert som flyktning i UDI?',
     'medlemskap.spm.opphold': 'Oppholder du deg i Norge?',
-    'personopplysninger.adresse': 'Adresse',
-    'personopplysninger.fnr': 'Fødselsnr',
     'personopplysninger.infohentet':
       'Informasjonen er hentet fra Folkeregisteret og NAVS register',
     'personopplysninger.telefonnr': 'Telefonnummer',

--- a/src/mock/person.json
+++ b/src/mock/person.json
@@ -12,11 +12,11 @@
     "innvandretDato": "1991-12-28",
     "utvandretDato": "",
     "oppholdstillatelse": "",
-    "sivilstand": "UGIF",
+    "sivilstand": "SKIL",
     "språk": "NB",
     "statsborgerskap": "NOR",
     "privattelefon": "",
-    "mobiltelefon": "983289398",
+    "mobiltelefon": " ",
     "jobbtelefon": "",
     "bankkontonummer": ""
   },

--- a/src/models/barn.ts
+++ b/src/models/barn.ts
@@ -1,0 +1,32 @@
+import {
+  IBooleanFelt,
+  ISpørsmålBooleanFelt,
+  ITekstFelt,
+} from './søknadsfelter';
+import { IForelder } from './forelder';
+
+export interface IBarn {
+  id?: string;
+  alder: ITekstFelt;
+  fnr: ITekstFelt;
+  fødselsdato: ITekstFelt;
+  personnummer?: ITekstFelt;
+  harSammeAdresse: IBooleanFelt;
+  navn: ITekstFelt;
+  født?: ISpørsmålBooleanFelt;
+  lagtTil?: boolean;
+  skalBarnBoHosDeg?: IBooleanFelt;
+  forelder?: IForelder;
+}
+
+export enum EBarn {
+  alder = 'alder',
+  fnr = 'fnr',
+  fødselsdato = 'fødselsdato',
+  personnummer = 'personnummer',
+  harSammeAdresse = 'harSammeAdresse',
+  navn = 'navn',
+  født = 'født',
+  skalBarnBoHosDeg = 'skalBarnBoHosDeg',
+  forelder = 'forelder',
+}

--- a/src/models/forelder.ts
+++ b/src/models/forelder.ts
@@ -1,0 +1,17 @@
+import { IBooleanFelt, IDatoFelt, ITekstFelt } from './søknadsfelter';
+
+export interface IForelder {
+  navn?: string;
+  skalBarnBoHosDeg?: ITekstFelt;
+  fødselsdato?: Date | null;
+  personnr?: string;
+  borINorge?: IBooleanFelt;
+  avtaleOmDeltBosted?: IBooleanFelt;
+  harAnnenForelderSamværMedBarn?: ITekstFelt;
+  harDereSkriftligSamværsavtale?: ITekstFelt;
+  hvordanPraktiseresSamværet?: ITekstFelt;
+  borISammeHus?: ITekstFelt;
+  boddSammenFør?: IBooleanFelt;
+  flyttetFra?: IDatoFelt;
+  hvorMyeSammen?: ITekstFelt;
+}

--- a/src/models/forelder.ts
+++ b/src/models/forelder.ts
@@ -1,4 +1,10 @@
-import { IBooleanFelt, IDatoFelt, ITekstFelt } from './søknadsfelter';
+import {
+  IBooleanFelt,
+  IDatoFelt,
+  ISpørsmålBooleanFelt,
+  ISpørsmålFelt,
+  ITekstFelt,
+} from './søknadsfelter';
 
 export interface IForelder {
   navn?: string;
@@ -8,10 +14,10 @@ export interface IForelder {
   borINorge?: IBooleanFelt;
   avtaleOmDeltBosted?: IBooleanFelt;
   harAnnenForelderSamværMedBarn?: ITekstFelt;
-  harDereSkriftligSamværsavtale?: ITekstFelt;
+  harDereSkriftligSamværsavtale?: ISpørsmålFelt;
   hvordanPraktiseresSamværet?: ITekstFelt;
   borISammeHus?: ITekstFelt;
-  boddSammenFør?: IBooleanFelt;
+  boddSammenFør?: ISpørsmålBooleanFelt;
   flyttetFra?: IDatoFelt;
   hvorMyeSammen?: ITekstFelt;
 }

--- a/src/models/person.ts
+++ b/src/models/person.ts
@@ -1,4 +1,4 @@
-import { ITekstFelt, IBooleanFelt, IDatoFelt } from './søknadsfelter';
+import { IBarn } from './barn';
 
 export interface IPerson {
   søker: ISøker;
@@ -29,38 +29,8 @@ export interface IAdresse {
   postnummer: string;
 }
 
-export interface IBarn {
-  id?: string;
-  alder: ITekstFelt;
-  fnr: ITekstFelt;
-  fødselsdato: ITekstFelt;
-  personnummer?: ITekstFelt;
-  harSammeAdresse: IBooleanFelt;
-  navn: ITekstFelt;
-  født?: IBooleanFelt;
-  lagtTil?: boolean;
-  skalBarnBoHosDeg?: IBooleanFelt;
-  forelder?: IForelder;
-}
-
 export interface IPersonDetaljer {
   navn?: string;
   fødselsdato?: Date;
   fødselsnummer?: string;
-}
-
-export interface IForelder {
-  navn?: string;
-  skalBarnBoHosDeg?: ITekstFelt;
-  fødselsdato?: Date | null;
-  personnr?: string;
-  borINorge?: IBooleanFelt;
-  avtaleOmDeltBosted?: IBooleanFelt;
-  harAnnenForelderSamværMedBarn?: ITekstFelt;
-  harDereSkriftligSamværsavtale?: ITekstFelt;
-  hvordanPraktiseresSamværet?: ITekstFelt;
-  borISammeHus?: ITekstFelt;
-  boddSammenFør?: IBooleanFelt;
-  flyttetFra?: IDatoFelt;
-  hvorMyeSammen?: ITekstFelt;
 }

--- a/src/søknad/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
+++ b/src/søknad/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
@@ -80,21 +80,21 @@ const Personopplysninger: React.FC = () => {
 
         <FeltGruppe>
           <Element>
-            <LocaleTekst tekst={'personopplysninger.fnr'} />
+            <LocaleTekst tekst={'person.fnr'} />
           </Element>
           <Normaltekst>{søker.fnr}</Normaltekst>
         </FeltGruppe>
 
         <FeltGruppe>
           <Element>
-            <LocaleTekst tekst={'personopplysninger.statsborgerskap'} />
+            <LocaleTekst tekst={'person.statsborgerskap'} />
           </Element>
           <Normaltekst>{søker.statsborgerskap}</Normaltekst>
         </FeltGruppe>
 
         <FeltGruppe>
           <Element>
-            <LocaleTekst tekst={'personopplysninger.adresse'} />
+            <LocaleTekst tekst={'person.adresse'} />
           </Element>
           <Normaltekst>{søker.adresse.adresse}</Normaltekst>
         </FeltGruppe>
@@ -146,9 +146,7 @@ const Personopplysninger: React.FC = () => {
       {telefonnr === '' ? (
         <Input
           key={'tlf'}
-          label={intl
-            .formatMessage({ id: 'personopplysninger.telefonnr' })
-            .trim()}
+          label={intl.formatMessage({ id: 'person.telefonnr' }).trim()}
           type="tel"
           bredde={'M'}
           onChange={(e) => settTelefonnummer(e)}
@@ -161,7 +159,7 @@ const Personopplysninger: React.FC = () => {
       ) : (
         <FeltGruppe>
           <Element>
-            <LocaleTekst tekst={'personopplysninger.telefonnr'} />
+            <LocaleTekst tekst={'person.telefonnr'} />
           </Element>
           <Normaltekst>{telefonnr}</Normaltekst>
         </FeltGruppe>

--- a/src/søknad/steg/3-barnadine/BarnaDine.tsx
+++ b/src/søknad/steg/3-barnadine/BarnaDine.tsx
@@ -52,7 +52,7 @@ const BarnaDine: React.FC = () => {
                   barn.født
                     ? barn.født
                     : {
-                        label: hentTekst('barnekort.født', intl),
+                        label: hentTekst('barnekort.spm.født', intl),
                         verdi: false,
                       }
                 }

--- a/src/søknad/steg/3-barnadine/BarneConfig.tsx
+++ b/src/søknad/steg/3-barnadine/BarneConfig.tsx
@@ -3,6 +3,6 @@ import { JaNeiSvar } from '../../../helpers/svar';
 
 export const barnetFødt: ISpørsmål = {
   søknadid: 'barnetFødt',
-  tekstid: 'barnekort.født',
+  tekstid: 'barnekort.spm.født',
   svaralternativer: JaNeiSvar,
 };

--- a/src/søknad/steg/3-barnadine/LeggTilBarn.tsx
+++ b/src/søknad/steg/3-barnadine/LeggTilBarn.tsx
@@ -10,9 +10,9 @@ import LeggTilBarnUfødt from './LeggTilBarnUfødt';
 import Seksjonsgruppe from '../../../components/gruppe/SeksjonGruppe';
 import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
 import { ESvar } from '../../../models/spørsmalogsvar';
-import { useIntl } from 'react-intl';
 import { IBarn } from '../../../models/barn';
 import { hentNyttBarn } from '../../../helpers/barn';
+import { useIntl } from 'react-intl';
 
 interface Props {
   settÅpenModal: Function;

--- a/src/søknad/steg/3-barnadine/LeggTilBarn.tsx
+++ b/src/søknad/steg/3-barnadine/LeggTilBarn.tsx
@@ -2,22 +2,17 @@ import React, { useState, useEffect } from 'react';
 import { Hovedknapp } from 'nav-frontend-knapper';
 import { Undertittel } from 'nav-frontend-typografi';
 import useSøknadContext from '../../../context/SøknadContext';
-import { differenceInYears } from 'date-fns';
 import JaNeiSpørsmål from '../../../components/spørsmål/JaNeiSpørsmål';
-import {
-  formatDate,
-  formatDateFnr,
-  dagensDato,
-  parseDate,
-} from '../../../utils/dato';
+import { formatDateFnr, dagensDato, parseDate } from '../../../utils/dato';
 import { barnetFødt } from './BarneConfig';
 import LeggTilBarnFødt from './LeggTilBarnFødt';
 import LeggTilBarnUfødt from './LeggTilBarnUfødt';
 import Seksjonsgruppe from '../../../components/gruppe/SeksjonGruppe';
 import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
-import { hentUid } from '../../../utils/uuid';
-import { standardLabelsBarn } from '../../../helpers/labels';
-import { settLabelOgVerdi } from '../../../utils/søknad';
+import { ESvar } from '../../../models/spørsmalogsvar';
+import { useIntl } from 'react-intl';
+import { IBarn } from '../../../models/barn';
+import { hentNyttBarn } from '../../../helpers/barn';
 
 interface Props {
   settÅpenModal: Function;
@@ -25,9 +20,10 @@ interface Props {
 }
 
 const LeggTilBarn: React.FC<Props> = ({ settÅpenModal, id }) => {
+  const intl = useIntl();
   const { søknad, settSøknad } = useSøknadContext();
   const [barnDato, settBarnDato] = useState<Date>(dagensDato);
-  const [født, settBarnFødt] = useState();
+  const [født, settBarnFødt] = useState<boolean>();
   const [navn, settNavn] = useState('');
   const [personnummer, settPersonnummer] = useState('');
   const [boHosDeg, settBoHosDeg] = useState('');
@@ -70,28 +66,29 @@ const LeggTilBarn: React.FC<Props> = ({ settÅpenModal, id }) => {
     const fødselsnummer =
       barnDato && personnummer ? formatDateFnr(barnDato) + personnummer : '';
 
-    const barn = {
-      fnr: fødselsnummer,
-      personnummer: personnummer,
-      alder: differenceInYears(dagensDato, barnDato),
-      navn: navn,
-      fødselsdato: formatDate(barnDato),
-      harSammeAdresse: boHosDeg === 'ja',
-      født: født,
-      lagtTil: true,
-      id: hentUid(),
-    };
+    if (født) {
+      const nyttBarn: IBarn = hentNyttBarn(
+        fødselsnummer,
+        personnummer,
+        barnDato,
+        navn,
+        boHosDeg,
+        født,
+        intl
+      );
 
-    const nyttBarn = settLabelOgVerdi(barn, standardLabelsBarn);
+      const nyBarneListe = [
+        ...søknad.person.barn.filter((b) => b.id !== id),
+        nyttBarn,
+      ];
 
-    const nyBarneListe = [
-      ...søknad.person.barn.filter((b) => b.id !== id),
-      nyttBarn,
-    ];
+      settSøknad({
+        ...søknad,
+        person: { ...søknad.person, barn: nyBarneListe },
+      });
 
-    settSøknad({ ...søknad, person: { ...søknad.person, barn: nyBarneListe } });
-
-    settÅpenModal(false);
+      settÅpenModal(false);
+    }
   };
 
   return (
@@ -104,7 +101,7 @@ const LeggTilBarn: React.FC<Props> = ({ settÅpenModal, id }) => {
             spørsmål={barnetFødt}
             onChange={(_, svar) => {
               tilbakestillFelt();
-              settBarnFødt(svar);
+              settBarnFødt(svar.id === ESvar.JA);
             }}
             valgtSvar={født}
           />

--- a/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
+++ b/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
@@ -2,7 +2,8 @@ import React, { useState, SyntheticEvent } from 'react';
 import { Element } from 'nav-frontend-typografi';
 import { useIntl } from 'react-intl';
 import { RadioPanel } from 'nav-frontend-skjema';
-import { IBarn, IForelder } from '../../../models/person';
+import { IBarn } from '../../../models/barn';
+import { IForelder } from '../../../models/forelder';
 
 interface Props {
   barn: IBarn;

--- a/src/søknad/steg/4-barnasbosted/BarnasBostedHeader.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnasBostedHeader.tsx
@@ -3,7 +3,7 @@ import { Element } from 'nav-frontend-typografi';
 import barn1 from '../../../assets/barn1.svg';
 import ufødtIkon from '../../../assets/ufodt.svg';
 import styled from 'styled-components';
-import { IBarn } from '../../../models/person';
+import { IBarn } from '../../../models/barn';
 
 const StyledBarnasBostedHeader = styled.div`
     .barnas-bosted-header {

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -19,6 +19,7 @@ import { Knapp } from 'nav-frontend-knapper';
 import { useIntl } from 'react-intl';
 import { IBarn } from '../../../models/barn';
 import { IForelder } from '../../../models/forelder';
+import { hentTekst } from '../../../utils/søknad';
 
 interface Props {
   barn: IBarn;
@@ -131,7 +132,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
                         label: intl.formatMessage({
                           id: 'barnasbosted.spm.borISammeHus',
                         }),
-                        verdi: svar,
+                        verdi: hentTekst(svar.svar_tekstid, intl),
                       },
                     })
                   }
@@ -183,7 +184,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
                         label: intl.formatMessage({
                           id: 'barnasbosted.spm.hvorMyeSammen',
                         }),
-                        verdi: svar,
+                        verdi: hentTekst(svar.svar_tekstid, intl),
                       },
                     })
                   }

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -53,7 +53,9 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     const nyForelder = {
       ...forelder,
       [boddSammenFør.søknadid]: {
-        label: intl.formatMessage({ id: 'barnasbosted.spm.boddsammenfør' }),
+        spørsmålid: spørsmål.søknadid,
+        svarid: valgtSvar.id,
+        label: hentTekst(spørsmål.tekstid, intl),
         verdi: hentBooleanFraValgtSvar(valgtSvar),
       },
     };

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -14,10 +14,11 @@ import SkalBarnBoHosDeg from './SkalBarnBoHosDeg';
 import useSøknadContext from '../../../context/SøknadContext';
 import { boddSammenFør, borISammeHus, hvorMyeSammen } from './ForeldreConfig';
 import { hentBooleanFraValgtSvar } from '../../../utils/spørsmålogsvar';
-import { IForelder, IBarn } from '../../../models/person';
 import { ESvar, ISpørsmål, ISvar } from '../../../models/spørsmalogsvar';
 import { Knapp } from 'nav-frontend-knapper';
 import { useIntl } from 'react-intl';
+import { IBarn } from '../../../models/barn';
+import { IForelder } from '../../../models/forelder';
 
 interface Props {
   barn: IBarn;

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedLagtTil.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedLagtTil.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Normaltekst, Element } from 'nav-frontend-typografi';
 import { useIntl } from 'react-intl';
-import { IBarn } from '../../../models/person';
 import BarnasBostedHeader from './BarnasBostedHeader';
 import { formatDate } from '../../../utils/dato';
 import endre from '../../../assets/endre.svg';
 import LenkeMedIkon from './LenkeMedIkon';
 import { hentBeskjedMedNavn } from '../../../utils/språk';
+import { IBarn } from '../../../models/barn';
 
 interface Props {
   barn: IBarn;

--- a/src/søknad/steg/4-barnasbosted/BostedOgSamvær.tsx
+++ b/src/søknad/steg/4-barnasbosted/BostedOgSamvær.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
 import { useIntl } from 'react-intl';
-import { IForelder } from '../../../models/person';
 import JaNeiSpørsmål from '../../../components/spørsmål/JaNeiSpørsmål';
 import FeltGruppe from '../../../components/gruppe/FeltGruppe';
 import MultiSvarSpørsmål from '../../../components/spørsmål/MultiSvarSpørsmål';
@@ -16,6 +15,7 @@ import LocaleTekst from '../../../language/LocaleTekst';
 import AlertStripe from 'nav-frontend-alertstriper';
 import { ISpørsmål, ISvar } from '../../../models/spørsmalogsvar';
 import { hentTekst } from '../../../utils/søknad';
+import { IForelder } from '../../../models/forelder';
 
 interface Props {
   settForelder: Function;

--- a/src/søknad/steg/4-barnasbosted/BostedOgSamvær.tsx
+++ b/src/søknad/steg/4-barnasbosted/BostedOgSamvær.tsx
@@ -16,6 +16,7 @@ import AlertStripe from 'nav-frontend-alertstriper';
 import { ISpørsmål, ISvar } from '../../../models/spørsmalogsvar';
 import { hentTekst } from '../../../utils/søknad';
 import { IForelder } from '../../../models/forelder';
+import { hentBooleanFraValgtSvar } from '../../../utils/spørsmålogsvar';
 
 interface Props {
   settForelder: Function;
@@ -113,7 +114,7 @@ const BostedOgSamvær: React.FC<Props> = ({
                 ...forelder,
                 [borINorge.søknadid]: {
                   label: intl.formatMessage({ id: 'barnasbosted.borinorge' }),
-                  verdi: svar,
+                  verdi: hentBooleanFraValgtSvar(svar),
                 },
               })
             }
@@ -129,7 +130,7 @@ const BostedOgSamvær: React.FC<Props> = ({
               ...forelder,
               [avtaleOmDeltBosted.søknadid]: {
                 label: intl.formatMessage({ id: 'barnasbosted.avtale' }),
-                verdi: svar,
+                verdi: hentBooleanFraValgtSvar(svar),
               },
             })
           }

--- a/src/søknad/steg/4-barnasbosted/BostedOgSamvær.tsx
+++ b/src/søknad/steg/4-barnasbosted/BostedOgSamvær.tsx
@@ -72,6 +72,8 @@ const BostedOgSamvær: React.FC<Props> = ({
     const nyForelder = {
       ...forelder,
       [spørsmål.søknadid]: {
+        spørsmålid: spørsmål.søknadid,
+        svarid: svar.id,
         label: intl.formatMessage({
           id: 'barnasbosted.spm.harDereSkriftligSamværsavtale',
         }),

--- a/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
+++ b/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
 import FeltGruppe from '../../../components/gruppe/FeltGruppe';
-import { IForelder, IBarn } from '../../../models/person';
 import { Input } from 'nav-frontend-skjema';
 import { Checkbox } from 'nav-frontend-skjema';
 import Datovelger, {
   DatoBegrensning,
 } from '../../../components/dato/Datovelger';
+import { IBarn } from '../../../models/barn';
+import { IForelder } from '../../../models/forelder';
 
 interface Props {
   barn: IBarn;

--- a/src/søknad/steg/4-barnasbosted/SkalBarnBoHosDeg.tsx
+++ b/src/søknad/steg/4-barnasbosted/SkalBarnBoHosDeg.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
 import { useIntl } from 'react-intl';
-import { IBarn } from '../../../models/person';
 import { skalBarnBoHosDeg } from './ForeldreConfig';
 import FeltGruppe from '../../../components/gruppe/FeltGruppe';
 import AlertStripe from 'nav-frontend-alertstriper';
 import MultiSvarSpørsmål from '../../../components/spørsmål/MultiSvarSpørsmål';
 import { Normaltekst } from 'nav-frontend-typografi';
 import LocaleTekst from '../../../language/LocaleTekst';
+import { IBarn } from '../../../models/barn';
 
 interface Props {
   barn: IBarn;

--- a/src/utils/søknad.ts
+++ b/src/utils/søknad.ts
@@ -65,3 +65,11 @@ export const settLabelOgVerdi = (objekt: any, variabelTilLabel: any) => {
 
   return nyttObjekt;
 };
+
+export const hentFeltObjekt = (
+  tekstid: string,
+  verdi: any,
+  intl: IntlShape
+) => {
+  return { label: hentTekst(tekstid, intl), verdi: verdi };
+};


### PR DESCRIPTION
- [Utvider søknadsfelter for barnesteg ](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-852)med `{spørsmålid og svarid}` der spørsmål med svar som senere skal trigge et dokumentasjonsbehov. 
- Inneholder noen småfixes der svar ikke blir ordentlig satt pga. endringer til spørsmålskomponenter
- Har flyttet IForelder og IBarn til egne ts-filer :)
![bilde](https://user-images.githubusercontent.com/8249453/78213631-8ce4e300-74b3-11ea-87b0-732c2a1b9d80.png)
