### PR TITLE
Intro sanity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2686,6 +2686,33 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@sanity/block-content-to-hyperscript": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@sanity/block-content-to-hyperscript/-/block-content-to-hyperscript-2.0.10.tgz",
+      "integrity": "sha512-xT3iEmZkK0fvO5PDFpn9GMWGfvOopvbrRCBU48XxpFoTxRrfsHhxbRy8J0eND1HGXHUENkIKv5jbohtGd1MiVg==",
+      "requires": {
+        "@sanity/generate-help-url": "^0.140.0",
+        "@sanity/image-url": "^0.140.15",
+        "hyperscript": "^2.0.2",
+        "object-assign": "^4.1.1"
+      },
+      "dependencies": {
+        "@sanity/generate-help-url": {
+          "version": "0.140.0",
+          "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-0.140.0.tgz",
+          "integrity": "sha512-H/G/WA9S22TXcXST52CIiTsHx3S2hH0gvK7LnI5w76vfKS0obnDPh8jrPg4xeNRYGPuV9MHYRlyERGpRGoo4Qw=="
+        }
+      }
+    },
+    "@sanity/block-content-to-react": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@sanity/block-content-to-react/-/block-content-to-react-2.0.7.tgz",
+      "integrity": "sha512-oSriTf/3Ihnxp6AjEGiVjNPA2Iq/IFaWg4Frn5msGq5GT8N1kwLwxduig1OSn87UA15LNwiai9LAJwBR2k9lIg==",
+      "requires": {
+        "@sanity/block-content-to-hyperscript": "^2.0.10",
+        "prop-types": "^15.6.2"
+      }
+    },
     "@sanity/client": {
       "version": "0.142.6",
       "resolved": "https://registry.npmjs.org/@sanity/client/-/client-0.142.6.tgz",
@@ -2713,6 +2740,53 @@
       "version": "0.142.0",
       "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-0.142.0.tgz",
       "integrity": "sha512-dHNGG1J8QvJh/Itce0lBDmGEdbzpVHOnZz5QDO/K6uWMCCFsj3/ePseidOJpgKSf4Xg2qfgAVGQEad3o0B6dhQ=="
+    },
+    "@sanity/image-url": {
+      "version": "0.140.18",
+      "resolved": "https://registry.npmjs.org/@sanity/image-url/-/image-url-0.140.18.tgz",
+      "integrity": "sha512-xdO4ET2N4YtUwsG1Il1mdleIjlxbQSeeFD2RUD5abysWs5LHDFQx8mGV8DADgiGchwViYH7WCg6qi5Npmv6XBw==",
+      "requires": {
+        "@sanity/client": "^1.149.7"
+      },
+      "dependencies": {
+        "@sanity/client": {
+          "version": "1.149.7",
+          "resolved": "https://registry.npmjs.org/@sanity/client/-/client-1.149.7.tgz",
+          "integrity": "sha512-sSCWkHVBZTxLClNC//vWQWbYeTH42VMEJaqJbEVVU0hEAuwLt0jzi6EZNcYkp+2Nm5NEW1XtjGMnIeQJI/BPhg==",
+          "requires": {
+            "@sanity/eventsource": "1.149.0",
+            "@sanity/generate-help-url": "1.149.0",
+            "@sanity/observable": "1.149.0",
+            "deep-assign": "^2.0.0",
+            "get-it": "^5.0.0",
+            "make-error": "^1.3.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "@sanity/eventsource": {
+          "version": "1.149.0",
+          "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-1.149.0.tgz",
+          "integrity": "sha512-Ve7jwxXwYqLXuqB2ZqcsglWp7TqMHmzIsj2FCfcywnGu6DXpP5vbmnRCL6eDi6S3fKlr/9uWdTC3tmzWSh0G5w==",
+          "requires": {
+            "eventsource": "^1.0.6",
+            "eventsource-polyfill": "^0.9.6"
+          }
+        },
+        "@sanity/generate-help-url": {
+          "version": "1.149.0",
+          "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-1.149.0.tgz",
+          "integrity": "sha512-8KKryNJGP/AKQOvziu6hdah7s9analAsQ1YZCHYyybdRRxDoaZ8QoBZ/If2vyQFBIl2+EXK9Z+x4qVmNa17umQ=="
+        },
+        "@sanity/observable": {
+          "version": "1.149.0",
+          "resolved": "https://registry.npmjs.org/@sanity/observable/-/observable-1.149.0.tgz",
+          "integrity": "sha512-Qh5q4DkgV5X3Yub+Nr3akKkjXGGtUPw9UtAwlPBa7jDBrKPBIzqD/vb7dDlNs+7JhfFKPwzaDqV36I7kbzPL0w==",
+          "requires": {
+            "object-assign": "^4.1.1",
+            "rxjs": "^6.5.3"
+          }
+        }
+      }
     },
     "@sanity/observable": {
       "version": "0.142.6",
@@ -4434,6 +4508,11 @@
         }
       }
     },
+    "browser-split": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.0.tgz",
+      "integrity": "sha1-QUGcrvdpdVkp3VGJZ9PuwKYmJ3E="
+    },
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -4780,6 +4859,14 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "class-list": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/class-list/-/class-list-0.1.1.tgz",
+      "integrity": "sha1-m5dFGSxBebXaCg12M2WOPHDXlss=",
+      "requires": {
+        "indexof": "0.0.1"
       }
     },
     "class-utils": {
@@ -7889,6 +7976,14 @@
       "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
       "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
     },
+    "html-element": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/html-element/-/html-element-2.3.1.tgz",
+      "integrity": "sha512-xnFt2ZkbFcjc+JoAtg3Hl89VeEZDjododu4VCPkRvFmBTHHA9U1Nt6hLUWfW2O+6Sl/rT1hHK/PivleX3PdBJQ==",
+      "requires": {
+        "class-list": "~0.1.1"
+      }
+    },
     "html-encoding-sniffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -8243,6 +8338,16 @@
         }
       }
     },
+    "hyperscript": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hyperscript/-/hyperscript-2.0.2.tgz",
+      "integrity": "sha1-ODnLpFVUvf4nu4HCFC0WhPgTWvU=",
+      "requires": {
+        "browser-split": "0.0.0",
+        "class-list": "~0.1.0",
+        "html-element": "^2.0.0"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -8359,6 +8464,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "infer-owner": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@craco/craco": "^5.5.0",
     "@navikt/fnrvalidator": "^1.1.0",
+    "@sanity/block-content-to-react": "^2.0.7",
     "@sanity/client": "^0.142.6",
     "@types/body-parser": "^1.17.1",
     "@types/classnames": "^2.2.9",

--- a/src/søknad/forside/Forside.less
+++ b/src/søknad/forside/Forside.less
@@ -56,6 +56,24 @@
     @media @mobile {
       width: 100%;
     }
+
+    .seksjon  {
+      .typo-element {
+        font-size: 20px;
+      }
+
+      .alertstripe__ikon {
+        display: none;
+      }
+    }
+
+    .bekreftCheckboksPanel {
+      background-color: #ffe9cc;
+    }
+
+    .alertstripe__tekst {
+      padding-left: 1rem;
+    }
   }
   .forside__panel {
     padding: 2rem;

--- a/src/søknad/forside/Forside.tsx
+++ b/src/søknad/forside/Forside.tsx
@@ -1,16 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { Panel } from 'nav-frontend-paneler';
 import FeltGruppe from '../../components/gruppe/FeltGruppe';
-import Språkvelger from '../../components/språkvelger/Språkvelger';
-import { ReactComponent as Veilederkvinne } from '../../assets/VeilederKvinne.svg';
-import Veileder from 'nav-frontend-veileder';
 import { BekreftCheckboksPanel } from 'nav-frontend-skjema';
-import { Element, Normaltekst, Sidetittel } from 'nav-frontend-typografi';
+import { Element, Sidetittel } from 'nav-frontend-typografi';
 import { usePersonContext } from '../../context/PersonContext';
+import { useSpråkContext } from '../../context/SpråkContext';
 import { Routes } from '../../routing/Routes';
 import useSøknadContext from '../../context/SøknadContext';
 import { hentBeskjedMedNavn } from '../../utils/språk';
-import { FormattedHTMLMessage, injectIntl } from 'react-intl';
+import { injectIntl } from 'react-intl';
 import { hentNesteRoute } from '../../routing/utils';
 import { useLocation, useHistory } from 'react-router-dom';
 import KnappBase from 'nav-frontend-knapper';
@@ -24,10 +22,13 @@ const Forside: React.FC<any> = ({ intl }) => {
   const { person } = usePersonContext();
   const { søknad, settSøknad } = useSøknadContext();
   const location = useLocation();
+  const [locale] = useSpråkContext();
   const history = useHistory();
   const nestePath = hentNesteRoute(Routes, location.pathname);
   const [forside, settForside] = useState<any>({});
+  // eslint-disable-next-line
   const [error, settError] = useState<boolean>(false);
+  // eslint-disable-next-line
   const [fetching, settFetching] = useState<boolean>(false);
 
   useEffect(() => {
@@ -44,6 +45,8 @@ const Forside: React.FC<any> = ({ intl }) => {
     };
     fetchData();
   }, []);
+
+  console.log(forside);
 
   const onChange = () => {
     settSøknad({ ...søknad, bekreftet: !søknad.bekreftet });
@@ -69,17 +72,20 @@ const Forside: React.FC<any> = ({ intl }) => {
     return BlockContent.defaultSerializers.types.block(props);
   };
 
+  const disclaimer = forside['disclaimer_' + locale];
+  const seksjon = forside['seksjon_' + locale];
+
   return (
     <div className={'forside'}>
       <main className={'forside__innhold'}>
         <Panel className={'forside__panel'}>
           <Sidetittel>Søknad om overgangsstønad</Sidetittel>
 
-          {forside.seksjon &&
-            forside.seksjon.map((seksjon: any) => {
+          {seksjon &&
+            seksjon.map((blokk: any) => {
               return (
                 <div className="seksjon">
-                  {seksjon.tittel && <Element>{seksjon.tittel}</Element>}
+                  {blokk.tittel && <Element>{blokk.tittel}</Element>}
                   <BlockContent
                     className="typo-normal"
                     blocks={seksjon.innhold}
@@ -89,13 +95,13 @@ const Forside: React.FC<any> = ({ intl }) => {
               );
             })}
 
-          {forside.disclaimer && (
+          {disclaimer && (
             <div className="seksjon">
               <AlertStripeAdvarsel>
                 {' '}
                 <BlockContent
                   className="typo-normal"
-                  blocks={forside.disclaimer}
+                  blocks={disclaimer}
                   serializers={{ types: { block: BlockRenderer } }}
                 />
                 <BekreftCheckboksPanel

--- a/src/søknad/forside/Forside.tsx
+++ b/src/søknad/forside/Forside.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Panel } from 'nav-frontend-paneler';
 import FeltGruppe from '../../components/gruppe/FeltGruppe';
 import Språkvelger from '../../components/språkvelger/Språkvelger';
@@ -14,7 +14,11 @@ import { FormattedHTMLMessage, injectIntl } from 'react-intl';
 import { hentNesteRoute } from '../../routing/utils';
 import { useLocation, useHistory } from 'react-router-dom';
 import KnappBase from 'nav-frontend-knapper';
+import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
 import LocaleTekst from '../../language/LocaleTekst';
+import { client } from '../../utils/sanity';
+
+const BlockContent = require('@sanity/block-content-to-react');
 
 const Forside: React.FC<any> = ({ intl }) => {
   const { person } = usePersonContext();
@@ -22,51 +26,89 @@ const Forside: React.FC<any> = ({ intl }) => {
   const location = useLocation();
   const history = useHistory();
   const nestePath = hentNesteRoute(Routes, location.pathname);
+  const [forside, settForside] = useState<any>({});
+  const [error, settError] = useState<boolean>(false);
+  const [fetching, settFetching] = useState<boolean>(false);
+
+  useEffect(() => {
+    const fetchData = () => {
+      client
+        .fetch('*[_type == $type][0]', { type: 'forside' })
+        .then((res: any) => {
+          settForside(res);
+        })
+        .catch((err: any) => {
+          settError(true);
+        });
+      settFetching(false);
+    };
+    fetchData();
+  }, []);
 
   const onChange = () => {
     settSøknad({ ...søknad, bekreftet: !søknad.bekreftet });
   };
 
+  const BlockRenderer = (props: any) => {
+    const { style = 'normal' } = props.node;
+
+    if (/^h\d/.test(style)) {
+      const level = style.replace(/[^\d]/g, '');
+      return React.createElement(
+        style,
+        { className: `heading-${level}` },
+        props.children
+      );
+    }
+
+    if (style === 'blockquote') {
+      return <blockquote>- {props.children}</blockquote>;
+    }
+
+    // Fall back to default handling
+    return BlockContent.defaultSerializers.types.block(props);
+  };
+
   return (
     <div className={'forside'}>
-      <div className={'header'}>
-        <div className={'banner'}></div>
-
-        <Veileder
-          storrelse={'M'}
-          posisjon={'topp'}
-          tekst={
-            <span>
-              <Element>Hei, {person.søker.forkortetNavn}!</Element>{' '}
-              <Normaltekst>Velkommen til søknad om overgangsstønad</Normaltekst>
-            </span>
-          }
-        >
-          <Veilederkvinne />
-        </Veileder>
-      </div>
-      <Sidetittel>Søknad om overgangsstønad</Sidetittel>
-      <Språkvelger />
       <main className={'forside__innhold'}>
         <Panel className={'forside__panel'}>
-          <FeltGruppe>
-            <Normaltekst>
-              <FormattedHTMLMessage id={'side.info.overgangsstønad'} />
-            </Normaltekst>
-          </FeltGruppe>
-          <FeltGruppe>
-            <Element>Vi stoler på deg</Element>
-          </FeltGruppe>
-          <FeltGruppe>
-            <BekreftCheckboksPanel
-              onChange={(e) => onChange()}
-              checked={søknad.bekreftet ? true : false}
-              label={hentBeskjedMedNavn(
-                person.søker.forkortetNavn,
-                intl.formatMessage({ id: 'side.bekreftelse' })
-              )}
-            />
-          </FeltGruppe>
+          <Sidetittel>Søknad om overgangsstønad</Sidetittel>
+
+          {forside.seksjon &&
+            forside.seksjon.map((seksjon: any) => {
+              return (
+                <div className="seksjon">
+                  {seksjon.tittel && <Element>{seksjon.tittel}</Element>}
+                  <BlockContent
+                    className="typo-normal"
+                    blocks={seksjon.innhold}
+                    serializers={{ types: { block: BlockRenderer } }}
+                  />
+                </div>
+              );
+            })}
+
+          {forside.disclaimer && (
+            <div className="seksjon">
+              <AlertStripeAdvarsel>
+                {' '}
+                <BlockContent
+                  className="typo-normal"
+                  blocks={forside.disclaimer}
+                  serializers={{ types: { block: BlockRenderer } }}
+                />
+                <BekreftCheckboksPanel
+                  onChange={(e) => onChange()}
+                  checked={søknad.bekreftet ? true : false}
+                  label={hentBeskjedMedNavn(
+                    person.søker.forkortetNavn,
+                    intl.formatMessage({ id: 'side.bekreftelse' })
+                  )}
+                />
+              </AlertStripeAdvarsel>
+            </div>
+          )}
 
           {søknad.bekreftet ? (
             <FeltGruppe classname={'sentrert'}>

--- a/src/søknad/steg/3-barnadine/BarnaDine.tsx
+++ b/src/søknad/steg/3-barnadine/BarnaDine.tsx
@@ -7,7 +7,6 @@ import { AlertStripeInfo } from 'nav-frontend-alertstriper';
 import { useIntl } from 'react-intl';
 import Modal from 'nav-frontend-modal';
 import LeggTilBarn from './LeggTilBarn';
-import Hjelpetekst from '../../../components/Hjelpetekst';
 import { Knapp, Hovedknapp } from 'nav-frontend-knapper';
 import { hentTekst } from '../../../utils/søknad';
 import { useHistory, useLocation } from 'react-router-dom';


### PR DESCRIPTION
Henter forsideinformasjonen fra Sanity. Planen først var å la hele siden være ett tekstelement, der man kunne legge inn overskrifter, lenker, bullet-points og alt man trenger under ett felt, men jeg fikk ikke riktig spacing mellom seksjonene på denne måten, så ble det også litt uryddig slik.

Sideelementene er derfor organisert på denne måten (disse endringene er gjort i `family-soknad-sanity`): ![Screen Shot 2020-04-17 at 12 18 54 PM](https://user-images.githubusercontent.com/1413265/79569063-3f719400-80b7-11ea-8f1a-a38ed2825f78.png), der hver seksjon inneholder en valgfri tittel + innhold, slik: 

![Screen Shot 2020-04-17 at 12 19 18 PM](https://user-images.githubusercontent.com/1413265/79569139-629c4380-80b7-11ea-9ea9-33277a1602ee.png)

Støtter ikke internasjonalisering nå, usikker på hvordan vi skal løse det. Kan jo kjøre tre felter for tittel og tre for innhold, men følte det ble litt uryddig her. Kanskje det er eneste måten å løse det på, tho.