### PR TITLE
Dok/vedlegg

### DIFF
--- a/src/components/filopplaster/Filopplaster.tsx
+++ b/src/components/filopplaster/Filopplaster.tsx
@@ -13,10 +13,11 @@ import { AlertStripeFeil } from 'nav-frontend-alertstriper';
 import Modal from 'nav-frontend-modal';
 import { IVedlegg } from '../../models/vedlegg';
 import Environment from '../../Environment';
-import { useSøknad } from '../../context/SøknadContext';
 
 interface Props {
   intl: IntlShape;
+  settVedlegg: (vedleggliste: IVedlegg[]) => void;
+  vedleggsliste: IVedlegg[];
   tittel: string;
   dokumentasjonsType: string;
   beskrivelsesListe?: string[];
@@ -26,13 +27,14 @@ interface Props {
 
 const Filopplaster: React.FC<Props> = ({
   intl,
+  settVedlegg,
+  vedleggsliste,
   tittel,
   dokumentasjonsType,
   beskrivelsesListe,
   tillatteFiltyper,
   maxFilstørrelse,
 }) => {
-  const { søknad, settSøknad } = useSøknad();
   const [filliste, settFilliste] = useState<any>([]);
   const [feilmeldinger, settFeilmeldinger] = useState<string[]>([]);
   const [åpenModal, settÅpenModal] = useState<boolean>(false);
@@ -92,12 +94,9 @@ const Filopplaster: React.FC<Props> = ({
               { filObjekt: fil, dokumentId: data.dokumentId },
               ...prevListe,
             ]);
-            const nyVedleggsliste = [...søknad.vedleggsliste, ...nyeVedlegg];
+            const nyVedleggsliste = [...vedleggsliste, ...nyeVedlegg];
 
-            settSøknad({
-              ...søknad,
-              vedleggsliste: nyVedleggsliste,
-            });
+            settVedlegg(nyVedleggsliste);
           })
           .catch((error) => {
             console.log('Feil', error);
@@ -108,7 +107,7 @@ const Filopplaster: React.FC<Props> = ({
       });
     },
     // eslint-disable-next-line
-    [søknad]
+    []
   );
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop });

--- a/src/søknad/SendSøknad.tsx
+++ b/src/søknad/SendSøknad.tsx
@@ -5,6 +5,7 @@ import { Normaltekst } from 'nav-frontend-typografi';
 import Filopplaster from '../components/filopplaster/Filopplaster';
 import tekster from '../language/tekster';
 import { useSøknad } from '../context/SøknadContext';
+import { IVedlegg } from '../models/vedlegg';
 
 interface IState {
   status: string;
@@ -38,6 +39,10 @@ const SendSøknad = () => {
       );
   };
 
+  const settVedlegg = (vedleggliste: IVedlegg[]) => {
+    return vedleggliste;
+  };
+
   return (
     <>
       {søknad.sivilstatus.begrunnelseForSøknad &&
@@ -46,6 +51,8 @@ const SendSøknad = () => {
         søknad.sivilstatus.begrunnelseForSøknad.verdi ===
           tekster.nb['sivilstatus.svar.samlivsbruddForeldre']) ? (
         <Filopplaster
+          settVedlegg={settVedlegg}
+          vedleggsliste={[]}
           tittel={'Erklæring om samlivsbrudd'}
           dokumentasjonsType={'samlivsbrudd'}
         />

--- a/src/søknad/steg/8-dokumentasjon/Dokumentasjonsbehov.tsx
+++ b/src/søknad/steg/8-dokumentasjon/Dokumentasjonsbehov.tsx
@@ -24,6 +24,7 @@ const Dokumentasjonsbehov: React.FC<Props> = ({ dokumentasjon }) => {
 
   useEffect(() => {
     settSøknad({ ...søknad, dokumentasjonsbehov: dokumentasjonsbehov });
+    // eslint-disable-next-line
   }, [dokumentasjonsbehov]);
 
   const settVedlegg = (vedleggliste: IVedlegg[]) => {

--- a/src/søknad/steg/8-dokumentasjon/Dokumentasjonsbehov.tsx
+++ b/src/søknad/steg/8-dokumentasjon/Dokumentasjonsbehov.tsx
@@ -40,8 +40,13 @@ const Dokumentasjonsbehov: React.FC<Props> = ({ dokumentasjon }) => {
   };
 
   const settHarSendtInnTidligere = (e: any) => {
-    const dokumentasjonEndret = dokumentasjonsbehov.map((dok) => {
+    const huketAv = e.target.checked;
+    const dokbehov = dokumentasjonsbehov;
+    const dokumentasjonEndret = dokbehov.map((dok) => {
       if (dok.id === dokumentasjon.id) {
+        if (huketAv && dok.opplastedeVedlegg) {
+          delete dok.opplastedeVedlegg;
+        }
         return {
           ...dok,
           harSendtInn: e.target.checked,

--- a/src/søknad/steg/8-dokumentasjon/Dokumentasjonsbehov.tsx
+++ b/src/søknad/steg/8-dokumentasjon/Dokumentasjonsbehov.tsx
@@ -70,14 +70,18 @@ const Dokumentasjonsbehov: React.FC<Props> = ({ dokumentasjon }) => {
           onChange={settHarSendtInnTidligere}
         />
       </FeltGruppe>
-      <Filopplaster
-        settVedlegg={settVedlegg}
-        vedleggsliste={
-          dokumentasjon.opplastedeVedlegg ? dokumentasjon.opplastedeVedlegg : []
-        }
-        tittel={hentTekst(dokumentasjon.tittel, intl)}
-        dokumentasjonsType={hentTekst(dokumentasjon.tittel, intl)}
-      />
+      {!dokumentasjon.harSendtInn && (
+        <Filopplaster
+          settVedlegg={settVedlegg}
+          vedleggsliste={
+            dokumentasjon.opplastedeVedlegg
+              ? dokumentasjon.opplastedeVedlegg
+              : []
+          }
+          tittel={hentTekst(dokumentasjon.tittel, intl)}
+          dokumentasjonsType={hentTekst(dokumentasjon.tittel, intl)}
+        />
+      )}
     </SeksjonGruppe>
   );
 };

--- a/src/søknad/steg/8-dokumentasjon/Dokumentasjonsbehov.tsx
+++ b/src/søknad/steg/8-dokumentasjon/Dokumentasjonsbehov.tsx
@@ -1,13 +1,15 @@
-import React from 'react';
-import { FormattedHTMLMessage, useIntl } from 'react-intl';
-import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
-import { Normaltekst, Undertittel } from 'nav-frontend-typografi';
+import React, { useEffect, useState } from 'react';
+import FeltGruppe from '../../../components/gruppe/FeltGruppe';
+import Filopplaster from '../../../components/filopplaster/Filopplaster';
+import LocaleTekst from '../../../language/LocaleTekst';
 import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
 import { Checkbox } from 'nav-frontend-skjema';
-import FeltGruppe from '../../../components/gruppe/FeltGruppe';
+import { FormattedHTMLMessage, useIntl } from 'react-intl';
 import { hentTekst } from '../../../utils/søknad';
 import { IDokumentasjon } from '../../../models/dokumentasjon';
-import LocaleTekst from '../../../language/LocaleTekst';
+import { IVedlegg } from '../../../models/vedlegg';
+import { Normaltekst, Undertittel } from 'nav-frontend-typografi';
+import { useSøknad } from '../../../context/SøknadContext';
 
 interface Props {
   dokumentasjon: IDokumentasjon;
@@ -15,6 +17,38 @@ interface Props {
 
 const Dokumentasjonsbehov: React.FC<Props> = ({ dokumentasjon }) => {
   const intl = useIntl();
+  const { søknad, settSøknad } = useSøknad();
+  const [dokumentasjonsbehov, settDokumentasjon] = useState<IDokumentasjon[]>(
+    søknad.dokumentasjonsbehov
+  );
+
+  useEffect(() => {
+    settSøknad({ ...søknad, dokumentasjonsbehov: dokumentasjonsbehov });
+  }, [dokumentasjonsbehov]);
+
+  const settVedlegg = (vedleggliste: IVedlegg[]) => {
+    const dokumentasjonMedVedlegg = dokumentasjonsbehov.map((dok) => {
+      if (dok.id === dokumentasjon.id) {
+        return {
+          ...dok,
+          opplastedeVedlegg: vedleggliste,
+        };
+      } else return dok;
+    });
+    settDokumentasjon(dokumentasjonMedVedlegg);
+  };
+
+  const settHarSendtInnTidligere = (e: any) => {
+    const dokumentasjonEndret = dokumentasjonsbehov.map((dok) => {
+      if (dok.id === dokumentasjon.id) {
+        return {
+          ...dok,
+          harSendtInn: e.target.checked,
+        };
+      } else return dok;
+    });
+    settDokumentasjon(dokumentasjonEndret);
+  };
 
   return (
     <SeksjonGruppe>
@@ -31,10 +65,18 @@ const Dokumentasjonsbehov: React.FC<Props> = ({ dokumentasjon }) => {
       <FeltGruppe>
         <Checkbox
           label={hentTekst('dokumentasjon.checkbox.sendtTidligere', intl)}
+          checked={dokumentasjon.harSendtInn}
+          onChange={settHarSendtInnTidligere}
         />
       </FeltGruppe>
-
-      <KomponentGruppe>Sett inn vedleggsopplaster her</KomponentGruppe>
+      <Filopplaster
+        settVedlegg={settVedlegg}
+        vedleggsliste={
+          dokumentasjon.opplastedeVedlegg ? dokumentasjon.opplastedeVedlegg : []
+        }
+        tittel={hentTekst(dokumentasjon.tittel, intl)}
+        dokumentasjonsType={hentTekst(dokumentasjon.tittel, intl)}
+      />
     </SeksjonGruppe>
   );
 };


### PR DESCRIPTION
Denne PR'en legger til vedleggsopplaster på dokumentasjonsbehov. Vha disse endringene:
- Filopplaster tar inn to nye props: `settVedlegg`og `vedleggsliste`
- Dokumentasjonsbehov sender inn `settVedlegg`-metoden som setter vedleggslista inn i dokumentasjonsbehovet den er knyttet til. 

```
export interface IDokumentasjon {
  id: string;
  spørsmålid: string;
  svarid: string;
  tittel: string;
  beskrivelse: string;
  harSendtInn: boolean;
  opplastedeVedlegg?: IVedlegg[];
}
```

NB! Er ikke ordentlig testet. Asbjørn skl ta over etter dette :) ✨ 👯 