### PR TITLE
Hent forside for arbeidssøker

### DIFF
--- a/src/arbeidssøker/Forside.tsx
+++ b/src/arbeidssøker/Forside.tsx
@@ -33,7 +33,7 @@ const Forside: React.FC<any> = ({ intl }) => {
   useEffect(() => {
     const fetchData = () => {
       client
-        .fetch('*[_type == $type][0]', { type: 'forside' })
+        .fetch('*[_type == $type][0]', { type: 'forside_arbeidssoker' })
         .then((res: any) => {
           settForside(res);
         })


### PR DESCRIPTION
Ny side for arbeidssøker-skjemaet.

Vi bruker arbeidssøker-branchen som "master" for det nye skjemaet, og brancher ut herfra når vi legger til nye features.