### PR TITLE
Gå videre til neste steg fra Forside

### DIFF
--- a/src/arbeidssøker/ArbeidssøkerApp.tsx
+++ b/src/arbeidssøker/ArbeidssøkerApp.tsx
@@ -12,6 +12,7 @@ import {
   verifiserAtBrukerErAutentisert,
 } from '../utils/autentisering';
 import Forside from './Forside';
+import Spørsmål from './Spørsmål';
 
 const App = () => {
   const [toggles, settToggles] = useState<Toggles>({});
@@ -53,8 +54,11 @@ const App = () => {
         <>
           <TestsideInformasjon />
           <Switch>
-            <Route path={'/arbeidssøker'}>
+            <Route exact path={'/arbeidssøker'}>
               <Forside />
+            </Route>
+            <Route path={'/arbeidssøker/spørsmål'}>
+              <Spørsmål />
             </Route>
           </Switch>
         </>

--- a/src/arbeidssøker/Forside.tsx
+++ b/src/arbeidssøker/Forside.tsx
@@ -116,7 +116,7 @@ const Forside: React.FC<any> = ({ intl }) => {
           {bekreftet ? (
             <FeltGruppe classname={'sentrert'}>
               <KnappBase
-                onClick={() => history.push(nestePath.path)}
+                onClick={() => history.push('/arbeidssøker/spørsmål')}
                 type={'hoved'}
               >
                 <LocaleTekst tekst={'knapp.start'} />

--- a/src/arbeidssøker/Spørsmål.tsx
+++ b/src/arbeidssøker/Spørsmål.tsx
@@ -1,0 +1,35 @@
+import React, { FC } from 'react';
+import Side from '../components/side/Side';
+import { IntlShape, injectIntl } from 'react-intl';
+import { useHistory, useLocation } from 'react-router-dom';
+import { Hovedknapp } from 'nav-frontend-knapper';
+import { hentTekst } from '../utils/søknad';
+
+const Spørsmål: FC<{ intl: IntlShape }> = ({ intl }) => {
+  const location = useLocation();
+  const history = useHistory();
+
+  const kommerFraOppsummering = location.state?.kommerFraOppsummering;
+
+  return (
+    <Side tittel={'Spørsmål'} kommerFraOppsummering={kommerFraOppsummering}>
+      <h1>Halla</h1>
+      {kommerFraOppsummering ? (
+        <div className={'side'}>
+          <Hovedknapp
+            className="tilbake-til-oppsummering"
+            onClick={() =>
+              history.push({
+                pathname: '/oppsummering',
+              })
+            }
+          >
+            {hentTekst('oppsummering.tilbake', intl)}
+          </Hovedknapp>
+        </div>
+      ) : null}
+    </Side>
+  );
+};
+
+export default injectIntl(Spørsmål);


### PR DESCRIPTION
La til mulighet for å gå til spørsmålssiden fra forsiden. Hardkodet pathen til spørsmålssiden slik: `onClick={() => history.push('/arbeidssøker/spørsmål')}`, men kanskje vi må legge til en Routes-fil her også for at det skal bli riktig i Side-komponenten, da den legger til forrige og neste-knapper.