### PR TITLE
Endrer fra ISkjema til IArbeidssøker++

### DIFF
--- a/src/arbeidssøkerskjema/SkjemaApp.tsx
+++ b/src/arbeidssøkerskjema/SkjemaApp.tsx
@@ -12,9 +12,9 @@ import {
   verifiserAtBrukerErAutentisert,
 } from '../utils/autentisering';
 import Forside from './Forside';
-import Spørsmål from './Spørsmål';
-import Oppsummering from './Oppsummering';
-import Kvittering from './Kvittering';
+import Spørsmål from './steg/1-Spørsmål';
+import Oppsummering from './steg/2-Oppsummering';
+import Kvittering from './steg/3-Kvittering';
 import { SkjemaProvider } from './SkjemaContext';
 
 const App = () => {

--- a/src/arbeidssøkerskjema/SkjemaContext.tsx
+++ b/src/arbeidssøkerskjema/SkjemaContext.tsx
@@ -1,14 +1,9 @@
 import createUseContext from 'constate';
 import React from 'react';
-import { ISkjema } from './typer/skjema';
-
-const initialState: ISkjema = {
-  fødselsnummer: '',
-  arbeidssøker: {},
-};
+import { IArbeidssøker } from '../models/steg/aktivitet/arbeidssøker';
 
 const [SkjemaProvider, useSkjema] = createUseContext(() => {
-  const [skjema, settSkjema] = React.useState<ISkjema>(initialState);
+  const [skjema, settSkjema] = React.useState<IArbeidssøker>({});
 
   return { skjema, settSkjema };
 });

--- a/src/arbeidssøkerskjema/side/Side.tsx
+++ b/src/arbeidssøkerskjema/side/Side.tsx
@@ -5,18 +5,18 @@ import KnappBase from 'nav-frontend-knapper';
 import LocaleTekst from '../../language/LocaleTekst';
 import Stegindikator from 'nav-frontend-stegindikator';
 import { hentForrigeRoute, hentNesteRoute } from '../routes/Routes';
-import { ISkjema } from '../typer/skjema';
 import { Panel } from 'nav-frontend-paneler';
 import { Routes } from '../routes/Routes';
 import { Systemtittel } from 'nav-frontend-typografi';
 import { useLocation, useHistory } from 'react-router-dom';
 import { useSkjema } from '../SkjemaContext';
+import { IArbeidssøker } from '../../models/steg/aktivitet/arbeidssøker';
 
 interface ISide {
   tittel: string;
   visNesteKnapp: boolean;
   kommerFraOppsummering?: boolean;
-  sendSkjema?: (skjema: ISkjema) => void;
+  sendSkjema?: (skjema: IArbeidssøker) => void;
 }
 
 const Side: React.FC<ISide> = ({

--- a/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
+++ b/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
@@ -1,11 +1,11 @@
 import React, { FC } from 'react';
-import Side from './side/Side';
+import Side from '../side/Side';
 import { useIntl } from 'react-intl';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Hovedknapp } from 'nav-frontend-knapper';
-import { hentSvarAlertFraSpørsmål, hentTekst } from '../utils/søknad';
-import SeksjonGruppe from '../components/gruppe/SeksjonGruppe';
-import JaNeiSpørsmål from '../components/spørsmål/JaNeiSpørsmål';
+import { hentSvarAlertFraSpørsmål, hentTekst } from '../../utils/søknad';
+import SeksjonGruppe from '../../components/gruppe/SeksjonGruppe';
+import JaNeiSpørsmål from '../../components/spørsmål/JaNeiSpørsmål';
 import {
   erSøkerArbeidssøker,
   erVilligTilÅTaImotTilbud,
@@ -13,21 +13,21 @@ import {
   kanSkaffeBarnepassInnenEnUke,
   ønskerHalvStillig,
   ønsketArbeidssted,
-} from '../søknad/steg/5-aktivitet/arbeidssøker/ArbeidssøkerConfig';
+} from '../../søknad/steg/5-aktivitet/arbeidssøker/ArbeidssøkerConfig';
 import AlertStripe from 'nav-frontend-alertstriper';
-import LocaleTekst from '../language/LocaleTekst';
-import KomponentGruppe from '../components/gruppe/KomponentGruppe';
-import { ESvar, ISpørsmål, ISvar } from '../models/spørsmålogsvar';
-import { hentBooleanFraValgtSvar } from '../utils/spørsmålogsvar';
-import { useSkjema } from './SkjemaContext';
-import MultiSvarSpørsmål from '../components/spørsmål/MultiSvarSpørsmål';
+import LocaleTekst from '../../language/LocaleTekst';
+import KomponentGruppe from '../../components/gruppe/KomponentGruppe';
+import { ESvar, ISpørsmål, ISvar } from '../../models/spørsmålogsvar';
+import { hentBooleanFraValgtSvar } from '../../utils/spørsmålogsvar';
+import { useSkjema } from '../SkjemaContext';
+import MultiSvarSpørsmål from '../../components/spørsmål/MultiSvarSpørsmål';
 
 const Spørsmål: FC = () => {
   const location = useLocation();
   const history = useHistory();
   const intl = useIntl();
   const { skjema, settSkjema } = useSkjema();
-  const [arbeidssøker, settArbeidssøker] = React.useState(skjema.arbeidssøker);
+  const [arbeidssøker, settArbeidssøker] = React.useState(skjema);
 
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
   const registrertSomArbeidssøkerAlert = hentSvarAlertFraSpørsmål(
@@ -36,7 +36,7 @@ const Spørsmål: FC = () => {
   );
 
   React.useEffect(() => {
-    settSkjema({ ...skjema, arbeidssøker: arbeidssøker });
+    settSkjema(arbeidssøker);
     // eslint-disable-next-line
   }, [arbeidssøker]);
 

--- a/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
+++ b/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
@@ -1,13 +1,14 @@
 import React, { FC } from 'react';
-import Side from './side/Side';
-import { IntlShape, injectIntl } from 'react-intl';
+import Side from '../side/Side';
+import { useIntl } from 'react-intl';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Hovedknapp } from 'nav-frontend-knapper';
-import { hentTekst } from '../utils/søknad';
+import { hentTekst } from '../../utils/søknad';
 
-const Oppsummering: FC<{ intl: IntlShape }> = ({ intl }) => {
+const Oppsummering: FC = () => {
   const location = useLocation();
   const history = useHistory();
+  const intl = useIntl();
 
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
 
@@ -36,4 +37,4 @@ const Oppsummering: FC<{ intl: IntlShape }> = ({ intl }) => {
   );
 };
 
-export default injectIntl(Oppsummering);
+export default Oppsummering;

--- a/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
+++ b/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import Side from '../side/Side';
 import { useIntl } from 'react-intl';
-import endre from '../assets/endre.svg';
+import endre from '../../assets/endre.svg';
 import { hentPath, Routes, RouteEnum, hentNesteRoute } from '../routes/Routes';
 import { mapDataTilLabelOgVerdiTyper } from '../utils/innsending';
 import { Undertittel } from 'nav-frontend-typografi';

--- a/src/arbeidssøkerskjema/steg/3-Kvittering.tsx
+++ b/src/arbeidssøkerskjema/steg/3-Kvittering.tsx
@@ -1,13 +1,14 @@
 import React, { FC } from 'react';
-import Side from './side/Side';
-import { IntlShape, injectIntl } from 'react-intl';
+import Side from '../side/Side';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Hovedknapp } from 'nav-frontend-knapper';
-import { hentTekst } from '../utils/søknad';
+import { hentTekst } from '../../utils/søknad';
+import { useIntl } from 'react-intl';
 
-const Kvittering: FC<{ intl: IntlShape }> = ({ intl }) => {
+const Kvittering: FC = () => {
   const location = useLocation();
   const history = useHistory();
+  const intl = useIntl();
 
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
 
@@ -36,4 +37,4 @@ const Kvittering: FC<{ intl: IntlShape }> = ({ intl }) => {
   );
 };
 
-export default injectIntl(Kvittering);
+export default Kvittering;

--- a/src/arbeidssøkerskjema/typer/skjema.ts
+++ b/src/arbeidssøkerskjema/typer/skjema.ts
@@ -1,6 +1,0 @@
-import { IArbeidssøker } from '../../models/steg/aktivitet/arbeidssøker';
-
-export interface ISkjema {
-  fødselsnummer: string;
-  arbeidssøker: IArbeidssøker;
-}


### PR DESCRIPTION
- Siden vi skal hente fnr direkte fra innlogget bruker, så fjerner vi fødselsnr feltet i skjemaobjektet.  Da trenger vi ikke en ISkjema datamodell. Bruker IArbeidssøker direkte. 
- Skifter til å bruke useIntl hook

✨ 🐈 
