### PR TITLE
Validering/datovelger

### DIFF
--- a/src/components/dato/Datovelger.tsx
+++ b/src/components/dato/Datovelger.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { addDays, subDays } from 'date-fns';
-import { dagensDato } from '../../utils/dato';
 import { Normaltekst } from 'nav-frontend-typografi';
 import { registerLocale, setDefaultLocale } from 'react-datepicker';
 import { useSpråkContext } from '../../context/SpråkContext';

--- a/src/components/dato/Datovelger.tsx
+++ b/src/components/dato/Datovelger.tsx
@@ -43,7 +43,6 @@ const Datovelger: React.FC<Props> = ({
   };
 
   useEffect(() => {
-    settDato(valgtDato ? valgtDato : dagensDato);
     setDefaultLocale('nb');
     // eslint-disable-next-line
   }, []);
@@ -62,7 +61,8 @@ const Datovelger: React.FC<Props> = ({
               <DatePicker
                 className={'datovelger__input'}
                 onChange={(e) => settDato(e)}
-                selected={valgtDato !== undefined ? valgtDato : dagensDato}
+                placeholderText={'DD.MM.YYYY'}
+                selected={valgtDato !== undefined ? valgtDato : null}
                 dateFormat={'dd.MM.yyyy'}
                 locale={locale}
                 maxDate={addDays(new Date(), 0)}
@@ -71,7 +71,8 @@ const Datovelger: React.FC<Props> = ({
               <DatePicker
                 className={'datovelger__input'}
                 onChange={(e) => settDato(e)}
-                selected={valgtDato !== undefined ? valgtDato : dagensDato}
+                placeholderText={'DD.MM.YYYY'}
+                selected={valgtDato !== undefined ? valgtDato : null}
                 dateFormat={'dd.MM.yyyy'}
                 minDate={subDays(new Date(), 0)}
                 locale={locale}
@@ -80,7 +81,8 @@ const Datovelger: React.FC<Props> = ({
               <DatePicker
                 className={'datovelger__input'}
                 onChange={(e) => settDato(e)}
-                selected={valgtDato !== undefined ? valgtDato : dagensDato}
+                placeholderText={'DD.MM.YYYY'}
+                selected={valgtDato !== undefined ? valgtDato : null}
                 dateFormat={'dd.MM.yyyy'}
                 locale={locale}
               />

--- a/src/helpers/omdeg.ts
+++ b/src/helpers/omdeg.ts
@@ -40,7 +40,7 @@ export const harSøkerTlfnr = (søker: IPerson): boolean => {
   return telefonnr !== '';
 };
 
-export const erSøknadsBegrunnelseUtfylt = (sivilstatus: ISivilstatus) => {
+export const erSøknadsBegrunnelseBesvart = (sivilstatus: ISivilstatus) => {
   const {
     datoForSamlivsbrudd,
     datoFlyttetFraHverandre,

--- a/src/helpers/omdeg.ts
+++ b/src/helpers/omdeg.ts
@@ -1,4 +1,5 @@
 import { IPerson } from '../models/person';
+import { EBegrunnelse, ISivilstatus } from '../models/steg/omDeg/sivilstatus';
 
 export const hentSivilstatus = (statuskode: string) => {
   switch (statuskode) {
@@ -37,4 +38,31 @@ export const hentSøkersTlfnr = (søker: IPerson): string => {
 export const harSøkerTlfnr = (søker: IPerson): boolean => {
   const telefonnr = hentSøkersTlfnr(søker).trim();
   return telefonnr !== '';
+};
+
+export const erSøknadsBegrunnelseUtfylt = (sivilstatus: ISivilstatus) => {
+  const {
+    datoForSamlivsbrudd,
+    datoFlyttetFraHverandre,
+    datoEndretSamvær,
+    begrunnelseAnnet,
+    begrunnelseForSøknad,
+  } = sivilstatus;
+
+  const valgtBegrunnelse = begrunnelseForSøknad?.svarid;
+
+  switch (valgtBegrunnelse) {
+    case EBegrunnelse.samlivsbruddForeldre:
+      return datoForSamlivsbrudd?.verdi !== undefined;
+    case EBegrunnelse.samlivsbruddAndre:
+      return datoFlyttetFraHverandre?.verdi !== undefined;
+    case EBegrunnelse.endringISamværsordning:
+      return datoEndretSamvær?.verdi !== undefined;
+    case EBegrunnelse.aleneFraFødsel:
+      return true;
+    case EBegrunnelse.dødsfall:
+      return true;
+    case EBegrunnelse.annet:
+      return begrunnelseAnnet?.verdi !== undefined;
+  }
 };

--- a/src/søknad/steg/1-omdeg/OmDeg.tsx
+++ b/src/søknad/steg/1-omdeg/OmDeg.tsx
@@ -8,7 +8,10 @@ import { useSøknad } from '../../../context/SøknadContext';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Hovedknapp } from 'nav-frontend-knapper';
 import { hentTekst } from '../../../utils/søknad';
-import { harSøkerTlfnr } from '../../../helpers/omdeg';
+import {
+  erSøknadsBegrunnelseUtfylt,
+  harSøkerTlfnr,
+} from '../../../helpers/omdeg';
 import { EBegrunnelse } from '../../../models/steg/omDeg/sivilstatus';
 
 const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
@@ -30,17 +33,7 @@ const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
 
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
 
-  const erBegrunnelseBesvart: boolean =
-    (begrunnelseForSøknad?.svarid === EBegrunnelse.samlivsbruddForeldre &&
-      datoForSamlivsbrudd?.verdi !== undefined) ||
-    (begrunnelseForSøknad?.svarid === EBegrunnelse.samlivsbruddAndre &&
-      datoFlyttetFraHverandre?.verdi !== undefined) ||
-    (begrunnelseForSøknad?.svarid === EBegrunnelse.endringISamværsordning &&
-      datoEndretSamvær?.verdi !== undefined) ||
-    begrunnelseForSøknad?.svarid === EBegrunnelse.aleneFraFødsel ||
-    begrunnelseForSøknad?.svarid === EBegrunnelse.dødsfall ||
-    (begrunnelseForSøknad?.svarid === EBegrunnelse.annet &&
-      begrunnelseAnnet?.verdi !== undefined);
+  const erBegrunnelseBesvart = erSøknadsBegrunnelseUtfylt(søknad.sivilstatus);
 
   const søkerFyltUtAlleFelterOgSpørsmål = () => {
     if (søkerBosattINorgeSisteTreÅr?.verdi === false) {

--- a/src/søknad/steg/1-omdeg/OmDeg.tsx
+++ b/src/søknad/steg/1-omdeg/OmDeg.tsx
@@ -9,7 +9,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { Hovedknapp } from 'nav-frontend-knapper';
 import { hentTekst } from '../../../utils/søknad';
 import {
-  erSøknadsBegrunnelseUtfylt,
+  erSøknadsBegrunnelseBesvart,
   harSøkerTlfnr,
 } from '../../../helpers/omdeg';
 
@@ -24,8 +24,6 @@ const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
   const history = useHistory();
 
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
-
-  const erBegrunnelseBesvart = erSøknadsBegrunnelseUtfylt(søknad.sivilstatus);
 
   const søkerFyltUtAlleFelterOgSpørsmål = () => {
     if (søkerBosattINorgeSisteTreÅr?.verdi === false) {
@@ -55,7 +53,7 @@ const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
 
             {harSøktSeparasjon ||
             harSøktSeparasjon === false ||
-            erBegrunnelseBesvart ? (
+            erSøknadsBegrunnelseBesvart(søknad.sivilstatus) ? (
               <Medlemskap />
             ) : null}
           </>

--- a/src/søknad/steg/1-omdeg/OmDeg.tsx
+++ b/src/søknad/steg/1-omdeg/OmDeg.tsx
@@ -12,18 +12,10 @@ import {
   erSøknadsBegrunnelseUtfylt,
   harSøkerTlfnr,
 } from '../../../helpers/omdeg';
-import { EBegrunnelse } from '../../../models/steg/omDeg/sivilstatus';
 
 const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
   const { søknad } = useSøknad();
-  const {
-    begrunnelseForSøknad,
-    harSøktSeparasjon,
-    datoForSamlivsbrudd,
-    datoFlyttetFraHverandre,
-    datoEndretSamvær,
-    begrunnelseAnnet,
-  } = søknad.sivilstatus;
+  const { harSøktSeparasjon } = søknad.sivilstatus;
   const {
     søkerBosattINorgeSisteTreÅr,
     perioderBoddIUtlandet,

--- a/src/søknad/steg/1-omdeg/OmDeg.tsx
+++ b/src/søknad/steg/1-omdeg/OmDeg.tsx
@@ -54,7 +54,6 @@ const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
     else return false;
   };
 
-  console.log(erBegrunnelseBesvart);
   return (
     <Side
       tittel={intl.formatMessage({ id: 'stegtittel.omDeg' })}

--- a/src/søknad/steg/1-omdeg/OmDeg.tsx
+++ b/src/søknad/steg/1-omdeg/OmDeg.tsx
@@ -9,10 +9,18 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { Hovedknapp } from 'nav-frontend-knapper';
 import { hentTekst } from '../../../utils/søknad';
 import { harSøkerTlfnr } from '../../../helpers/omdeg';
+import { EBegrunnelse } from '../../../models/steg/omDeg/sivilstatus';
 
 const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
   const { søknad } = useSøknad();
-  const { begrunnelseForSøknad, harSøktSeparasjon } = søknad.sivilstatus;
+  const {
+    begrunnelseForSøknad,
+    harSøktSeparasjon,
+    datoForSamlivsbrudd,
+    datoFlyttetFraHverandre,
+    datoEndretSamvær,
+    begrunnelseAnnet,
+  } = søknad.sivilstatus;
   const {
     søkerBosattINorgeSisteTreÅr,
     perioderBoddIUtlandet,
@@ -21,6 +29,18 @@ const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
   const history = useHistory();
 
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
+
+  const erBegrunnelseBesvart: boolean =
+    (begrunnelseForSøknad?.svarid === EBegrunnelse.samlivsbruddForeldre &&
+      datoForSamlivsbrudd?.verdi !== undefined) ||
+    (begrunnelseForSøknad?.svarid === EBegrunnelse.samlivsbruddAndre &&
+      datoFlyttetFraHverandre?.verdi !== undefined) ||
+    (begrunnelseForSøknad?.svarid === EBegrunnelse.endringISamværsordning &&
+      datoEndretSamvær?.verdi !== undefined) ||
+    begrunnelseForSøknad?.svarid === EBegrunnelse.aleneFraFødsel ||
+    begrunnelseForSøknad?.svarid === EBegrunnelse.dødsfall ||
+    (begrunnelseForSøknad?.svarid === EBegrunnelse.annet &&
+      begrunnelseAnnet?.verdi !== undefined);
 
   const søkerFyltUtAlleFelterOgSpørsmål = () => {
     if (søkerBosattINorgeSisteTreÅr?.verdi === false) {
@@ -34,6 +54,7 @@ const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
     else return false;
   };
 
+  console.log(erBegrunnelseBesvart);
   return (
     <Side
       tittel={intl.formatMessage({ id: 'stegtittel.omDeg' })}
@@ -50,7 +71,7 @@ const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
 
             {harSøktSeparasjon ||
             harSøktSeparasjon === false ||
-            begrunnelseForSøknad ? (
+            erBegrunnelseBesvart ? (
               <Medlemskap />
             ) : null}
           </>

--- a/src/søknad/steg/1-omdeg/sivilstatus/begrunnelse/SøknadsBegrunnelse.tsx
+++ b/src/søknad/steg/1-omdeg/sivilstatus/begrunnelse/SøknadsBegrunnelse.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
 
 import DatoForSamlivsbrudd from './DatoForSamlivsbrudd';
 import EndringISamvær from './EndringISamvær';
@@ -51,10 +51,14 @@ const Søknadsbegrunnelse: FC<Props> = ({
   const samlivsbruddMedForelder = erBegrunnelse(
     EBegrunnelse.samlivsbruddForeldre
   );
-  const samlivsbruddAndre = erBegrunnelse(EBegrunnelse.samlivsbruddAndre);
-  const endretSamvær = erBegrunnelse(EBegrunnelse.endringISamværsordning);
-  const dødsfall = erBegrunnelse(EBegrunnelse.dødsfall);
-  const annet = erBegrunnelse(EBegrunnelse.annet);
+  const samlivsbruddAndre: boolean = erBegrunnelse(
+    EBegrunnelse.samlivsbruddAndre
+  );
+  const endretSamvær: boolean = erBegrunnelse(
+    EBegrunnelse.endringISamværsordning
+  );
+  const dødsfall: boolean = erBegrunnelse(EBegrunnelse.dødsfall);
+  const annet: boolean = erBegrunnelse(EBegrunnelse.annet);
 
   const settTekstfeltBegrunnelseAnnet = (
     e: React.ChangeEvent<HTMLTextAreaElement>
@@ -72,8 +76,11 @@ const Søknadsbegrunnelse: FC<Props> = ({
 
   const settBegrunnelseForSøknad = (spørsmål: ISpørsmål, svar: ISvar) => {
     const spørsmålTekst: string = hentTekst(spørsmål.tekstid, intl);
+
+    const nyttSivilstatusObjekt = fjernIrrelevanteSøknadsfelter(svar);
+
     settSivilstatus({
-      ...sivilstatus,
+      ...nyttSivilstatusObjekt,
       begrunnelseForSøknad: {
         spørsmålid: spørsmål.søknadid,
         svarid: svar.id,
@@ -84,30 +91,20 @@ const Søknadsbegrunnelse: FC<Props> = ({
     settDokumentasjonsbehov(spørsmål, svar);
   };
 
-  const fjernIrrelevanteSøknadsfelter = () => {
-    if (!samlivsbruddMedForelder && datoForSamlivsbrudd) {
-      const { datoForSamlivsbrudd, ...nySivilstatusObjekt } = sivilstatus;
-      settSivilstatus(nySivilstatusObjekt);
+  const fjernIrrelevanteSøknadsfelter = (svar: ISvar): ISivilstatus => {
+    const nySivilStatusObjekt = sivilstatus;
+    if (svar.id !== EBegrunnelse.samlivsbruddForeldre && datoForSamlivsbrudd) {
+      delete nySivilStatusObjekt.datoForSamlivsbrudd;
+    }
+    if (svar.id !== EBegrunnelse.samlivsbruddAndre && datoFlyttetFraHverandre) {
+      delete nySivilStatusObjekt.datoFlyttetFraHverandre;
     }
 
-    if (
-      !samlivsbruddAndre &&
-      datoFlyttetFraHverandre &&
-      !samlivsbruddMedForelder
-    ) {
-      const { datoFlyttetFraHverandre, ...nySivilstatusObjekt } = sivilstatus;
-      settSivilstatus(nySivilstatusObjekt);
+    if (svar.id !== EBegrunnelse.endringISamværsordning && datoEndretSamvær) {
+      delete nySivilStatusObjekt.datoEndretSamvær;
     }
-
-    if (!endretSamvær && datoEndretSamvær) {
-      const { datoEndretSamvær, ...nySivilstatusObjekt } = sivilstatus;
-      settSivilstatus(nySivilstatusObjekt);
-    }
+    return nySivilStatusObjekt;
   };
-
-  useEffect(() => {
-    fjernIrrelevanteSøknadsfelter();
-  });
 
   const alertTekstForDødsfall = hentSvarAlertFraSpørsmål(
     EBegrunnelse.dødsfall,


### PR DESCRIPTION
- **Endret Datovelger**: Viser nå placeholder tekst i stedet for `dagensDato` 
- **Validering/steg 1:** Må velge dato før neste bolk med spm/felter vises

_(Se GIF)_

![May-12-2020 16-12-24](https://user-images.githubusercontent.com/8249453/81703124-78a9e380-946c-11ea-8d66-338d4d0790a9.gif)

**NB!** `<PeriodeDatovelger/>` (der vi har to datovelgere og viser feilmeldinger avhengig av datoene) må også oppdateres. Her vil det fremdeles vises en default dato for periode når en `<PeriodeDatovelger/>` først loades. _(Se bilde)_.   
**Eksempel under:** Utenlandsopphold når man velger _"Nei"_ på siste spørsmål _"Har du bodd i Norge de 3 siste årene?"_ på steg 1. 

![Skjermbilde 2020-05-12 kl  16 16 40](https://user-images.githubusercontent.com/8249453/81703212-8eb7a400-946c-11ea-9060-ac491f893159.png)

Det blir litt krøll når jeg prøver å benytte placeholder tekst i stedet for `dagensDato`, så tenker å ta dette i en egen branch siden det mest sannsynligvis må finnes en bedre løsning på å legge til perioder (Utenlandsopphold, TidligereUtdanninger) enn slik det er satt opp i dag. Har vært litt knotete tidligere, så hvis noen har tid og lyst, så kunne vi gjerne sett på dette sammen 😁 
