### PR TITLE
Fiks variabelnavn

### DIFF
--- a/src/language/tekster.ts
+++ b/src/language/tekster.ts
@@ -331,7 +331,8 @@ export default {
 
     'barnasbosted.spm.borAnnenForelderISammeHus':
       'Bor du og den andre forelderen til [0] i samme hus, blokk, gårdstun, kvartal eller vei/gate?',
-    'barnasbosted.spm.hvordanBorDere': 'Hvordan bor dere nærme hverandre?',
+    'barnasbosted.spm.borAnnenForelderISammeHusBeskrivelse':
+      'Hvordan bor dere nærme hverandre?',
     'barnasbosted.spm.vetikke': 'Jeg vet ikke hvor den andre forelderen bor',
     'barnasbosted.hjelpetekst.borAnnenForelderISammeHus.apne':
       'Hvorfor spør vi om dere bor nærme hverandre?',

--- a/src/language/tekster.ts
+++ b/src/language/tekster.ts
@@ -329,13 +329,13 @@ export default {
     'barnasbosted.normaltekst.nårreiserbarnet':
       'når barnet reiser til og fra den andre forelderen',
 
-    'barnasbosted.spm.borISammeHus':
+    'barnasbosted.spm.borAnnenForelderISammeHus':
       'Bor du og den andre forelderen til [0] i samme hus, blokk, gårdstun, kvartal eller vei/gate?',
     'barnasbosted.spm.hvordanBorDere': 'Hvordan bor dere nærme hverandre?',
     'barnasbosted.spm.vetikke': 'Jeg vet ikke hvor den andre forelderen bor',
-    'barnasbosted.hjelpetekst.borisammehus.apne':
+    'barnasbosted.hjelpetekst.borAnnenForelderISammeHus.apne':
       'Hvorfor spør vi om dere bor nærme hverandre?',
-    'barnasbosted.hjelpetekst.borisammehus.innhold':
+    'barnasbosted.hjelpetekst.borAnnenForelderISammeHus.innhold':
       'Når du bor svært nær den andre forelderen, regnes du ikke for å være alene om omsorgen for barn.',
 
     'barnasbosted.spm.boddsammenfør':
@@ -773,16 +773,17 @@ export default {
       'Ja, men den inneholder ikke konkrete tidspunkter som samvær',
     'barnasbosted.spm.boddsammenfør':
       'Har du bodd sammen med den andre forelderen til Mina før?',
-    'barnasbosted.spm.borISammeHus':
+    'barnasbosted.spm.borAnnenForelderISammeHus':
       'Bor du og den andre forelderen til [0] i samme hus, blokk, gårdstun, kvartal eller vei/gate?',
     'barnasbosted.spm.vetikke': 'Jeg vet ikke hvor den andre forelderen bor',
     'barnasbosted.hjelpetekst.bosted.apne': 'Hva er avtale om delt bosted?',
     'barnasbosted.hjelpetekst.bosted.innhold': 'lorem ipsum jepsi pepsi',
     'barnasbosted.hjelpetekst.samvær.apne': 'Hva er vanlig samværsrett?',
     'barnasbosted.hjelpetekst.samvær.innhold': 'lorem ipsum jepsi pepsi',
-    'barnasbosted.hjelpetekst.borisammehus.apne':
+    'barnasbosted.hjelpetekst.borAnnenForelderISammeHus.apne':
       'Hvorfor spør vi om dere bor nærme hverandre?',
-    'barnasbosted.hjelpetekst.borisammehus.innhold': 'lorem bipsum bepp hepp',
+    'barnasbosted.hjelpetekst.borAnnenForelderISammeHus.innhold':
+      'lorem bipsum bepp hepp',
     'barnasbosted.spm.møtesIkke': 'Vi møtes ikke',
     'barnasbosted.spm.kunNårLeveres':
       'Vi møtes kun når barnet skal hentes eller leveres',
@@ -872,16 +873,17 @@ export default {
       'Ja, men den inneholder ikke konkrete tidspunkter som samvær',
     'barnasbosted.spm.boddsammenfør':
       'Har du bodd sammen med den andre forelderen til Mina før?',
-    'barnasbosted.spm.borISammeHus':
+    'barnasbosted.spm.borAnnenForelderISammeHus':
       'Bor du og den andre forelderen til [0] i samme hus, blokk, gårdstun, kvartal eller vei/gate?',
     'barnasbosted.spm.vetikke': 'Jeg vet ikke hvor den andre forelderen bor',
     'barnasbosted.hjelpetekst.bosted.apne': 'Hva er avtale om delt bosted?',
     'barnasbosted.hjelpetekst.bosted.innhold': 'lorem ipsum jepsi pepsi',
     'barnasbosted.hjelpetekst.samvær.apne': 'Hva er vanlig samværsrett?',
     'barnasbosted.hjelpetekst.samvær.innhold': 'lorem ipsum jepsi pepsi',
-    'barnasbosted.hjelpetekst.borisammehus.apne':
+    'barnasbosted.hjelpetekst.borAnnenForelderISammeHus.apne':
       'Hvorfor spør vi om dere bor nærme hverandre?',
-    'barnasbosted.hjelpetekst.borisammehus.innhold': 'lorem bipsum bepp hepp',
+    'barnasbosted.hjelpetekst.borAnnenForelderISammeHus.innhold':
+      'lorem bipsum bepp hepp',
     'barnasbosted.spm.møtesIkke': 'Vi møtes ikke',
     'barnasbosted.spm.kunNårLeveres':
       'Vi møtes kun når barnet skal hentes eller leveres',

--- a/src/models/forelder.ts
+++ b/src/models/forelder.ts
@@ -20,7 +20,7 @@ export interface IForelder {
   harAnnenForelderSamværMedBarn?: ISpørsmålFelt;
   harDereSkriftligSamværsavtale?: ISpørsmålFelt;
   hvordanPraktiseresSamværet?: ITekstFelt;
-  borISammeHus?: ISpørsmålFelt;
+  borAnnenForelderISammeHus?: ISpørsmålFelt;
   hvordanBorDere?: ISpørsmålFelt;
   boddSammenFør?: ISpørsmålBooleanFelt;
   flyttetFra?: IDatoFelt;
@@ -37,7 +37,7 @@ export enum EForelder {
   harAnnenForelderSamværMedBarn = 'harAnnenForelderSamværMedBarn',
   harDereSkriftligSamværsavtale = 'harDereSkriftligSamværsavtale',
   hvordanPraktiseresSamværet = 'hvordanPraktiseresSamværet',
-  borISammeHus = 'borISammeHus',
+  borAnnenForelderISammeHus = 'borAnnenForelderISammeHus',
   hvordanBorDere = 'hvordanBorDere',
   boddSammenFør = 'boddSammenFør',
   flyttetFra = 'flyttetFra',

--- a/src/models/forelder.ts
+++ b/src/models/forelder.ts
@@ -21,7 +21,7 @@ export interface IForelder {
   harDereSkriftligSamværsavtale?: ISpørsmålFelt;
   hvordanPraktiseresSamværet?: ITekstFelt;
   borAnnenForelderISammeHus?: ISpørsmålFelt;
-  hvordanBorDere?: ISpørsmålFelt;
+  borAnnenForelderISammeHusBeskrivelse?: ISpørsmålFelt;
   boddSammenFør?: ISpørsmålBooleanFelt;
   flyttetFra?: IDatoFelt;
   hvorMyeSammen?: ISpørsmålFelt;
@@ -38,7 +38,7 @@ export enum EForelder {
   harDereSkriftligSamværsavtale = 'harDereSkriftligSamværsavtale',
   hvordanPraktiseresSamværet = 'hvordanPraktiseresSamværet',
   borAnnenForelderISammeHus = 'borAnnenForelderISammeHus',
-  hvordanBorDere = 'hvordanBorDere',
+  borAnnenForelderISammeHusBeskrivelse = 'borAnnenForelderISammeHusBeskrivelse',
   boddSammenFør = 'boddSammenFør',
   flyttetFra = 'flyttetFra',
   hvorMyeSammen = 'hvorMyeSammen',

--- a/src/models/steg/barnasbosted.ts
+++ b/src/models/steg/barnasbosted.ts
@@ -10,7 +10,7 @@ export enum EHarSkriftligSamværsavtale {
   nei = 'nei',
 }
 
-export enum EBorISammeHus {
+export enum EBorAnnenForelderISammeHus {
   ja = 'ja',
   nei = 'nei',
   vetikke = 'vetikke',

--- a/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
+++ b/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
@@ -43,7 +43,7 @@ const AnnenForelderKnapper: React.FC<Props> = ({
       borINorge: denAndreForelderen?.borINorge,
       hvordanPraktiseresSamværet:
         denAndreForelderen?.hvordanPraktiseresSamværet,
-      borISammeHus: denAndreForelderen?.borISammeHus,
+      borAnnenForelderISammeHus: denAndreForelderen?.borAnnenForelderISammeHus,
       boddSammenFør: denAndreForelderen?.boddSammenFør,
       flyttetFra: denAndreForelderen?.flyttetFra,
       hvorMyeSammen: denAndreForelderen?.hvorMyeSammen,

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -194,7 +194,9 @@ const BarnetsBostedEndre: React.FC<Props> = ({
               {((harValgtSvar(borAnnenForelderISammeHus?.verdi) &&
                 borAnnenForelderISammeHus?.svarid !==
                   EBorAnnenForelderISammeHus.ja) ||
-                harValgtSvar(forelder.hvordanBorDere?.verdi)) && (
+                harValgtSvar(
+                  forelder.borAnnenForelderISammeHusBeskrivelse?.verdi
+                )) && (
                 <BoddSammenFør
                   forelder={forelder}
                   settForelder={settForelder}

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -25,10 +25,10 @@ import {
 import BorForelderINorge from './bostedOgSamvær/BorForelderINorge';
 import { ESvar, ISpørsmål, ISvar } from '../../../models/spørsmålogsvar';
 import { isValid } from 'date-fns';
-import BorISammeHus from './ikkesammeforelder/BorISammeHus';
+import BorAnnenForelderISammeHus from './ikkesammeforelder/BorAnnenForelderISammeHus';
 import BoddSammenFør from './ikkesammeforelder/BoddSammenFør';
 import HvorMyeSammen from './ikkesammeforelder/HvorMyeSammen';
-import { EBorISammeHus } from '../../../models/steg/barnasbosted';
+import { EBorAnnenForelderISammeHus } from '../../../models/steg/barnasbosted';
 
 interface Props {
   barn: IBarn;
@@ -52,7 +52,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   const [barnHarSammeForelder, settBarnHarSammeForelder] = useState<
     boolean | undefined
   >(undefined);
-  const { borISammeHus, boddSammenFør, flyttetFra } = forelder;
+  const { borAnnenForelderISammeHus, boddSammenFør, flyttetFra } = forelder;
 
   const intl = useIntl();
 
@@ -186,10 +186,14 @@ const BarnetsBostedEndre: React.FC<Props> = ({
 
           {!barnHarSammeForelder && visSpørsmålHvisIkkeSammeForelder(forelder) && (
             <>
-              <BorISammeHus forelder={forelder} settForelder={settForelder} />
+              <BorAnnenForelderISammeHus
+                forelder={forelder}
+                settForelder={settForelder}
+              />
 
-              {((harValgtSvar(borISammeHus?.verdi) &&
-                borISammeHus?.svarid !== EBorISammeHus.ja) ||
+              {((harValgtSvar(borAnnenForelderISammeHus?.verdi) &&
+                borAnnenForelderISammeHus?.svarid !==
+                  EBorAnnenForelderISammeHus.ja) ||
                 harValgtSvar(forelder.hvordanBorDere?.verdi)) && (
                 <BoddSammenFør
                   forelder={forelder}

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedLagtTil.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedLagtTil.tsx
@@ -145,17 +145,19 @@ const BarnetsBostedLagtTil: React.FC<Props> = ({
             <Normaltekst>{forelder.beskrivSamværUtenBarn.verdi}</Normaltekst>
           </div>
         )}
-        {forelder.borISammeHus ? (
+        {forelder.borAnnenForelderISammeHus ? (
           <div className="spørsmål-og-svar">
             <Element>
               {hentBeskjedMedNavn(
                 barn.navn.verdi,
                 intl.formatMessage({
-                  id: 'barnasbosted.spm.borISammeHus',
+                  id: 'barnasbosted.spm.borAnnenForelderISammeHus',
                 })
               )}
             </Element>
-            <Normaltekst>{forelder.borISammeHus.verdi}</Normaltekst>
+            <Normaltekst>
+              {forelder.borAnnenForelderISammeHus.verdi}
+            </Normaltekst>
           </div>
         ) : null}
         <LenkeMedIkon

--- a/src/søknad/steg/4-barnasbosted/ForeldreConfig.tsx
+++ b/src/søknad/steg/4-barnasbosted/ForeldreConfig.tsx
@@ -2,7 +2,7 @@ import { ESvar, ESvarTekstid, ISpørsmål } from '../../../models/spørsmålogsv
 import {
   EHarSamværMedBarn,
   EHarSkriftligSamværsavtale,
-  EBorISammeHus,
+  EBorAnnenForelderISammeHus,
   EHvorMyeSammen,
   ESkalBarnetBoHosSøker,
   EHvorforIkkeOppgi,
@@ -156,26 +156,27 @@ export const harDereSkriftligSamværsavtale: ISpørsmål = {
   ],
 };
 
-export const borISammeHus: ISpørsmål = {
-  søknadid: 'borISammeHus',
-  tekstid: 'barnasbosted.spm.borISammeHus',
+export const borAnnenForelderISammeHus: ISpørsmål = {
+  søknadid: 'borAnnenForelderISammeHus',
+  tekstid: 'barnasbosted.spm.borAnnenForelderISammeHus',
   lesmer: {
-    åpneTekstid: 'barnasbosted.hjelpetekst.borisammehus.apne',
+    åpneTekstid: 'barnasbosted.hjelpetekst.borAnnenForelderISammeHus.apne',
     lukkeTekstid: '',
-    innholdTekstid: 'barnasbosted.hjelpetekst.borisammehus.innhold',
+    innholdTekstid:
+      'barnasbosted.hjelpetekst.borAnnenForelderISammeHus.innhold',
   },
   flersvar: false,
   svaralternativer: [
     {
-      id: EBorISammeHus.ja,
+      id: EBorAnnenForelderISammeHus.ja,
       svar_tekstid: 'barnasbosted.spm.ja',
     },
     {
-      id: EBorISammeHus.nei,
+      id: EBorAnnenForelderISammeHus.nei,
       svar_tekstid: 'barnasbosted.spm.nei',
     },
     {
-      id: EBorISammeHus.vetikke,
+      id: EBorAnnenForelderISammeHus.vetikke,
       svar_tekstid: 'barnasbosted.spm.vetikke',
     },
   ],

--- a/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
+++ b/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
@@ -79,6 +79,8 @@ const OmAndreForelder: React.FC<Props> = ({ settForelder, forelder, barn }) => {
         verdi: forelder.kanIkkeOppgiAnnenForelderFar || false,
       },
     });
+
+    //eslint-disable-next-line
   }, []);
 
   const hukAvKanIkkeOppgiAnnenForelder = (e: any) => {

--- a/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
+++ b/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import FeltGruppe from '../../../components/gruppe/FeltGruppe';
 import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
 import MultiSvarSpørsmål from '../../../components/spørsmål/MultiSvarSpørsmål';
@@ -66,6 +66,20 @@ const OmAndreForelder: React.FC<Props> = ({ settForelder, forelder, barn }) => {
   const intl = useIntl();
   const [begyntÅSkrive, settBegyntÅSkrive] = useState<boolean>(false);
   const hvorforIkkeOppgiLabel = hentTekst(hvorforIkkeOppgi.tekstid, intl);
+  const jegKanIkkeOppgiLabel = hentTekst(
+    'barnasbosted.kanikkeoppgiforelder',
+    intl
+  );
+
+  useEffect(() => {
+    settForelder({
+      ...forelder,
+      kanIkkeOppgiAnnenForelderFar: {
+        label: jegKanIkkeOppgiLabel,
+        verdi: forelder.kanIkkeOppgiAnnenForelderFar || false,
+      },
+    });
+  }, []);
 
   const hukAvKanIkkeOppgiAnnenForelder = (e: any) => {
     const nyForelder = { ...forelder };
@@ -86,7 +100,7 @@ const OmAndreForelder: React.FC<Props> = ({ settForelder, forelder, barn }) => {
     settForelder({
       ...nyForelder,
       kanIkkeOppgiAnnenForelderFar: {
-        label: hvorforIkkeOppgiLabel,
+        label: jegKanIkkeOppgiLabel,
         verdi: !forelder.kanIkkeOppgiAnnenForelderFar?.verdi,
       },
     });

--- a/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
+++ b/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
@@ -76,7 +76,7 @@ const OmAndreForelder: React.FC<Props> = ({ settForelder, forelder, barn }) => {
       ...forelder,
       kanIkkeOppgiAnnenForelderFar: {
         label: jegKanIkkeOppgiLabel,
-        verdi: forelder.kanIkkeOppgiAnnenForelderFar || false,
+        verdi: forelder.kanIkkeOppgiAnnenForelderFar?.verdi || false,
       },
     });
 

--- a/src/søknad/steg/4-barnasbosted/ikkesammeforelder/BorAnnenForelderISammeHus.tsx
+++ b/src/søknad/steg/4-barnasbosted/ikkesammeforelder/BorAnnenForelderISammeHus.tsx
@@ -2,8 +2,8 @@ import React, { FC } from 'react';
 import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
 import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
 import MultiSvarSpørsmål from '../../../../components/spørsmål/MultiSvarSpørsmål';
-import { borISammeHus } from '../ForeldreConfig';
-import { EBorISammeHus } from '../../../../models/steg/barnasbosted';
+import { borAnnenForelderISammeHus } from '../ForeldreConfig';
+import { EBorAnnenForelderISammeHus } from '../../../../models/steg/barnasbosted';
 import { hentTekst } from '../../../../utils/søknad';
 import { IForelder } from '../../../../models/forelder';
 import { ISpørsmål, ISvar } from '../../../../models/spørsmålogsvar';
@@ -15,23 +15,26 @@ interface Props {
   forelder: IForelder;
   settForelder: Function;
 }
-const BorISammeHus: FC<Props> = ({ forelder, settForelder }) => {
+const BorAnnenForelderISammeHus: FC<Props> = ({ forelder, settForelder }) => {
   const intl = useIntl();
 
-  const settBorISammeHus = (spørsmål: ISpørsmål, valgtSvar: ISvar) => {
+  const settBorAnnenForelderISammeHus = (
+    spørsmål: ISpørsmål,
+    valgtSvar: ISvar
+  ) => {
     const nyForelder = {
       ...forelder,
-      [borISammeHus.søknadid]: {
+      [borAnnenForelderISammeHus.søknadid]: {
         spørsmålid: spørsmål.søknadid,
         svarid: valgtSvar.id,
-        label: hentTekst('barnasbosted.spm.borISammeHus', intl),
+        label: hentTekst('barnasbosted.spm.borAnnenForelderISammeHus', intl),
         verdi: hentTekst(valgtSvar.svar_tekstid, intl),
       },
     };
 
     if (
-      valgtSvar.id === EBorISammeHus.nei ||
-      valgtSvar.id === EBorISammeHus.vetikke
+      valgtSvar.id === EBorAnnenForelderISammeHus.nei ||
+      valgtSvar.id === EBorAnnenForelderISammeHus.vetikke
     ) {
       delete nyForelder.hvordanBorDere;
     }
@@ -53,15 +56,16 @@ const BorISammeHus: FC<Props> = ({ forelder, settForelder }) => {
     <>
       <KomponentGruppe>
         <MultiSvarSpørsmål
-          key={borISammeHus.søknadid}
-          spørsmål={borISammeHus}
-          valgtSvar={forelder.borISammeHus?.verdi}
+          key={borAnnenForelderISammeHus.søknadid}
+          spørsmål={borAnnenForelderISammeHus}
+          valgtSvar={forelder.borAnnenForelderISammeHus?.verdi}
           settSpørsmålOgSvar={(spørsmål, svar) =>
-            settBorISammeHus(spørsmål, svar)
+            settBorAnnenForelderISammeHus(spørsmål, svar)
           }
         />
       </KomponentGruppe>
-      {forelder.borISammeHus?.svarid === EBorISammeHus.ja && (
+      {forelder.borAnnenForelderISammeHus?.svarid ===
+        EBorAnnenForelderISammeHus.ja && (
         <>
           <div className="margin-bottom-05">
             <Normaltekst>
@@ -87,4 +91,4 @@ const BorISammeHus: FC<Props> = ({ forelder, settForelder }) => {
   );
 };
 
-export default BorISammeHus;
+export default BorAnnenForelderISammeHus;

--- a/src/søknad/steg/4-barnasbosted/ikkesammeforelder/BorAnnenForelderISammeHus.tsx
+++ b/src/søknad/steg/4-barnasbosted/ikkesammeforelder/BorAnnenForelderISammeHus.tsx
@@ -36,17 +36,20 @@ const BorAnnenForelderISammeHus: FC<Props> = ({ forelder, settForelder }) => {
       valgtSvar.id === EBorAnnenForelderISammeHus.nei ||
       valgtSvar.id === EBorAnnenForelderISammeHus.vetikke
     ) {
-      delete nyForelder.hvordanBorDere;
+      delete nyForelder.borAnnenForelderISammeHusBeskrivelse;
     }
 
     settForelder(nyForelder);
   };
 
-  const settBeskrivHvordanBorDere = (e: any) => {
+  const settBorAnnenForelderISammeHusBeskrivelse = (e: any) => {
     settForelder({
       ...forelder,
-      hvordanBorDere: {
-        label: hentTekst('barnasbosted.spm.hvordanBorDere', intl),
+      borAnnenForelderISammeHusBeskrivelse: {
+        label: hentTekst(
+          'barnasbosted.spm.borAnnenForelderISammeHusBeskrivelse',
+          intl
+        ),
         verdi: e.target.value,
       },
     });
@@ -70,18 +73,19 @@ const BorAnnenForelderISammeHus: FC<Props> = ({ forelder, settForelder }) => {
           <div className="margin-bottom-05">
             <Normaltekst>
               {intl.formatMessage({
-                id: 'barnasbosted.spm.hvordanBorDere',
+                id: 'barnasbosted.spm.borAnnenForelderISammeHusBeskrivelse',
               })}
             </Normaltekst>
           </div>
           <FeltGruppe>
             <Textarea
               value={
-                forelder.hvordanBorDere && forelder.hvordanBorDere.verdi
-                  ? forelder.hvordanBorDere.verdi
+                forelder.borAnnenForelderISammeHusBeskrivelse &&
+                forelder.borAnnenForelderISammeHusBeskrivelse.verdi
+                  ? forelder.borAnnenForelderISammeHusBeskrivelse.verdi
                   : ''
               }
-              onChange={settBeskrivHvordanBorDere}
+              onChange={settBorAnnenForelderISammeHusBeskrivelse}
               label=""
             />
           </FeltGruppe>


### PR DESCRIPTION
Setter defaultverdien til `kanIkkeOppgiAnnenForelderFar` til false, og gjør følgende variabelnavnendringer:

borISammeHus -> borAnnenForelderISammeHus
hvordanBorDere -> borAnnenForelderISammeHusBeskrivelse