### PR TITLE
Legg til label på samboerDetaljer

### DIFF
--- a/src/søknad/steg/2-bosituasjon/OmSamboerenDin.tsx
+++ b/src/søknad/steg/2-bosituasjon/OmSamboerenDin.tsx
@@ -47,7 +47,10 @@ const OmSamboerenDin: FC<Props> = ({
       ...bosituasjon,
       samboerDetaljer: {
         ...samboerDetaljer,
-        [objektnøkkel]: e.currentTarget.value,
+        [objektnøkkel]: {
+          label: objektnøkkel,
+          verdi: e.currentTarget.value,
+        },
       },
     });
   };


### PR DESCRIPTION
Navn og personnummer manglet label på samboerDetaljer (verdien lå rett på rot). Denne fikser dette.