### PR TITLE
Nullstilling av tilstand i søknadsdialogen

### DIFF
--- a/src/components/gruppe/PersonInfoGruppe.tsx
+++ b/src/components/gruppe/PersonInfoGruppe.tsx
@@ -42,6 +42,7 @@ const PersonInfoGruppe: FC<Props> = ({
           type="text"
           bredde={'L'}
           onChange={(e) => settPersonInfo(e, 'navn')}
+          value={valgtPersonInfo.navn?.verdi}
         />
       </FeltGruppe>
       <FeltGruppe classname={'datoOgPersonnummer'}>
@@ -58,6 +59,7 @@ const PersonInfoGruppe: FC<Props> = ({
               label={intl.formatMessage({ id: 'person.nr' }).trim()}
               type="text"
               bredde={'S'}
+              value={valgtPersonInfo.fødselsnummer?.verdi}
               onChange={(e) => settPersonInfo(e, 'fødselsnummer')}
             />
           </>

--- a/src/søknad/steg/6-meromsituasjon/FåttJobbTilbud.tsx
+++ b/src/søknad/steg/6-meromsituasjon/FåttJobbTilbud.tsx
@@ -49,7 +49,7 @@ const FåttJobbTilbud: React.FC<Props> = ({
         </Normaltekst>
       </AlertStripe>
       <Datovelger
-        valgtDato={dinSituasjon.datoOppstartUtdanning?.verdi}
+        valgtDato={dinSituasjon.datoOppstartJobb?.verdi}
         tekstid={'dinSituasjon.datovelger.jobb'}
         datobegrensning={DatoBegrensning.FremtidigeDatoer}
         settDato={settDato}

--- a/src/søknad/steg/6-meromsituasjon/MerOmDinSituasjon.tsx
+++ b/src/søknad/steg/6-meromsituasjon/MerOmDinSituasjon.tsx
@@ -11,7 +11,6 @@ import SyktBarn from './SyktBarn';
 import SøkerErSyk from './SøkerErSyk';
 import SøkerSkalTaUtdanning from './SøkerSkalTaUtdanning';
 import SøktBarnepassOgVenterPåSvar from './SøktBarnepassOgVenterPåSvar';
-import { dagensDatoStreng } from '../../../utils/dato';
 import { gjelderNoeAvDetteDeg } from './SituasjonConfig';
 import { hentTekst } from '../../../utils/søknad';
 import { ISpørsmål, ISvar } from '../../../models/spørsmålogsvar';

--- a/src/søknad/steg/6-meromsituasjon/MerOmDinSituasjon.tsx
+++ b/src/søknad/steg/6-meromsituasjon/MerOmDinSituasjon.tsx
@@ -39,10 +39,9 @@ const MerOmDinSituasjon: React.FC = () => {
   } = useSøknad();
   const history = useHistory();
   const location = useLocation();
-  const [dinSituasjon, settDinSituasjon] = useState<IDinSituasjon>({
-    gjelderDetteDeg: søknad.merOmDinSituasjon.gjelderDetteDeg,
-    søknadsdato: { label: '', verdi: dagensDatoStreng },
-  });
+  const [dinSituasjon, settDinSituasjon] = useState<IDinSituasjon>(
+    søknad.merOmDinSituasjon
+  );
   const {
     gjelderDetteDeg,
     datoOppstartJobb,


### PR DESCRIPTION
**Inneholder de fleste fiksene i [dette Favro-kortet](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-1289) :**

- [X] Steg 2: "Hvem skal du gifte deg med eller bli samboer med?" Navn på person du skal gifte deg med 
- [X] Steg 2: Personnummer til den du skal gifte deg med
- [ ] Steg 5: Fra og til-dato på hvilken utdanning du skal ta blir nullstilt
- [ ] Steg 5: Historisk utdanning: Linje, Fra-dato og Til-dato blir nullstilt
- [X] Steg 6: Huke av for jobb og utdanning så må disse datoene være identiske...
- [X] Steg 6: Dato for jobb/utdanning nullstilles  
- [X] Steg 6: Bestemt måned for stønad: Ja/Nei - denne nullstilles. Dato som følger er også nullstilt. 

NB! Mangler å fikse der det brukes `<PeriodeDatovelger/>`. Denne bør fikses i en egen PR. 🤓 

