### PR TITLE
Neste fremfor tilbake til oppsummering

### DIFF
--- a/src/søknad/steg/3-barnadine/BarnaDine.tsx
+++ b/src/søknad/steg/3-barnadine/BarnaDine.tsx
@@ -16,7 +16,7 @@ const BarnaDine: React.FC = () => {
   const { søknad, mellomlagreOvergangsstønad } = useSøknad();
   const history = useHistory();
   const location = useLocation();
-  const kommerFraOppsummering = location.state?.kommerFraOppsummering;
+  const kommerFraOppsummering = location.state?.kommerFraOppsummering && false;
 
   const [åpenModal, settÅpenModal] = useState(false);
 
@@ -26,7 +26,7 @@ const BarnaDine: React.FC = () => {
     <>
       <Side
         tittel={hentTekst('barnadine.sidetittel', intl)}
-        skalViseKnapper={!kommerFraOppsummering}
+        skalViseKnapper={true}
         erSpørsmålBesvart={true}
         mellomlagreOvergangsstønad={mellomlagreOvergangsstønad}
       >
@@ -82,7 +82,7 @@ const BarnaDine: React.FC = () => {
             </div>
           </Modal>
         </div>
-        {location.state?.kommerFraOppsummering ? (
+        {kommerFraOppsummering ? (
           <div className={'side'}>
             <Hovedknapp
               className="tilbake-til-oppsummering"

--- a/src/søknad/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnasBosted.tsx
@@ -27,8 +27,6 @@ const BarnasBosted: React.FC = () => {
     (barn) => barn.forelder === undefined
   );
 
-  console.log(hentIndexFørsteBarnSomIkkeErUtfylt);
-
   const [aktivIndex, settAktivIndex] = useState<number>(
     hentIndexFørsteBarnSomIkkeErUtfylt
   );

--- a/src/søknad/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnasBosted.tsx
@@ -22,7 +22,9 @@ const BarnasBosted: React.FC = () => {
   const [aktivIndex, settAktivIndex] = useState<number>(0);
   const [sisteBarnUtfylt, settSisteBarnUtfylt] = useState<boolean>(false);
   const barna = søknad.person.barn;
-  const kommerFraOppsummering = location.state?.kommerFraOppsummering;
+  const kommerFraOppsummering = location.state?.kommerFraOppsummering && false;
+
+  console.log('kommerFRaOppsummering:', kommerFraOppsummering);
 
   const lagtTilBarn = useRef(null);
 
@@ -35,7 +37,7 @@ const BarnasBosted: React.FC = () => {
   return (
     <Side
       tittel={hentTekst('barnasbosted.sidetittel', intl)}
-      skalViseKnapper={!kommerFraOppsummering}
+      skalViseKnapper={true}
       erSpørsmålBesvart={sisteBarnUtfylt}
       mellomlagreOvergangsstønad={mellomlagreOvergangsstønad}
     >

--- a/src/søknad/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnasBosted.tsx
@@ -22,9 +22,7 @@ const BarnasBosted: React.FC = () => {
   const [aktivIndex, settAktivIndex] = useState<number>(0);
   const [sisteBarnUtfylt, settSisteBarnUtfylt] = useState<boolean>(false);
   const barna = søknad.person.barn;
-  const kommerFraOppsummering = location.state?.kommerFraOppsummering && false;
-
-  console.log('kommerFRaOppsummering:', kommerFraOppsummering);
+  const kommerFraOppsummering = location.state?.kommerFraOppsummering;
 
   const lagtTilBarn = useRef(null);
 
@@ -37,7 +35,7 @@ const BarnasBosted: React.FC = () => {
   return (
     <Side
       tittel={hentTekst('barnasbosted.sidetittel', intl)}
-      skalViseKnapper={true}
+      skalViseKnapper={!kommerFraOppsummering}
       erSpørsmålBesvart={sisteBarnUtfylt}
       mellomlagreOvergangsstønad={mellomlagreOvergangsstønad}
     >

--- a/src/søknad/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnasBosted.tsx
@@ -19,10 +19,19 @@ const BarnasBosted: React.FC = () => {
   const history = useHistory();
   const location = useLocation();
   const { søknad, mellomlagreOvergangsstønad } = useSøknad();
-  const [aktivIndex, settAktivIndex] = useState<number>(0);
-  const [sisteBarnUtfylt, settSisteBarnUtfylt] = useState<boolean>(false);
   const barna = søknad.person.barn;
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
+  const [sisteBarnUtfylt, settSisteBarnUtfylt] = useState<boolean>(false);
+
+  const hentIndexFørsteBarnSomIkkeErUtfylt: number = barna.findIndex(
+    (barn) => barn.forelder === undefined
+  );
+
+  console.log(hentIndexFørsteBarnSomIkkeErUtfylt);
+
+  const [aktivIndex, settAktivIndex] = useState<number>(
+    hentIndexFørsteBarnSomIkkeErUtfylt
+  );
 
   const lagtTilBarn = useRef(null);
 


### PR DESCRIPTION
- Hvis man går tilbake for å endre informasjon om barna sine, vil man få en "neste"-knapp i stedet for "tilbake til oppsummering" siden de da må fylle ut informasjon om den nye forelderen hvis man skulle legge til et nytt barn. 
- Løser at man slipper å fylle ut "første" barn i lista på nytt (hvis forelder allerede eksisterer), men at man heller må fylle ut info til den nye forelderen som er lagt til. 
