### PR TITLE
Bugfix/riktig rekkefolge oppsummering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13610,11 +13610,6 @@
           "resolved": false,
           "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
         },
-        "is-obj": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-        },
         "is-path-inside": {
           "version": "1.0.1",
           "resolved": false,

--- a/src/arbeidssøkerskjema/side/Side.tsx
+++ b/src/arbeidssøkerskjema/side/Side.tsx
@@ -10,6 +10,7 @@ import { RoutesArbeidssokerskjema } from '../routes/routesArbeidssokerskjema';
 import { Systemtittel } from 'nav-frontend-typografi';
 import { useLocation, useHistory } from 'react-router-dom';
 import { hentForrigeRoute, hentNesteRoute } from '../../utils/routing';
+import { LocationStateSøknad } from '../../models/søknad/søknad';
 
 interface ISide {
   tittel: string;
@@ -23,7 +24,7 @@ const Side: React.FC<ISide> = ({
   skalViseKnapper,
   erSpørsmålBesvart,
 }) => {
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const history = useHistory();
 
   const routes = Object.values(RoutesArbeidssokerskjema);

--- a/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
+++ b/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
@@ -28,9 +28,10 @@ import {
   RoutesArbeidssokerskjema,
 } from '../routes/routesArbeidssokerskjema';
 import { hentPath } from '../../utils/routing';
+import { LocationStateSøknad } from '../../models/søknad/søknad';
 
 const Spørsmål: FC = () => {
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const { person } = usePersonContext();
   const history = useHistory();
   const intl = useIntl();

--- a/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
+++ b/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
@@ -28,6 +28,7 @@ import {
   hentNesteRoute,
   hentPath,
 } from '../../utils/routing';
+import { LocationStateSøknad } from '../../models/søknad/søknad';
 
 interface Innsending {
   status: IStatus;
@@ -36,7 +37,7 @@ interface Innsending {
 }
 
 const Oppsummering: React.FC = () => {
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const history = useHistory();
   const intl = useIntl();
   const { skjema, settSkjema } = useSkjema();

--- a/src/barnetilsyn/steg/1-omdeg/OmDeg.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/OmDeg.tsx
@@ -18,10 +18,11 @@ import Side, { ESide } from '../../../components/side/Side';
 import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
 import { hentPathBarnetilsynOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
-  const location = useLocation();
-  const kommerFraOppsummering: string = location.state?.kommerFraOppsummering;
+  const location = useLocation<LocationStateSøknad>();
+  const kommerFraOppsummering = location.state?.kommerFraOppsummering;
   const skalViseKnapper = !kommerFraOppsummering
     ? ESide.visTilbakeNesteAvbrytKnapp
     : ESide.visTilbakeTilOppsummeringKnapp;

--- a/src/barnetilsyn/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/barnetilsyn/steg/2-bosituasjon/Bosituasjon.tsx
@@ -9,6 +9,7 @@ import Side, { ESide } from '../../../components/side/Side';
 import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
 import { hentPathBarnetilsynOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const Bosituasjon: FC = () => {
   const intl = useIntl();
@@ -19,7 +20,7 @@ const Bosituasjon: FC = () => {
     mellomlagreBarnetilsyn,
   } = useBarnetilsynSøknad();
   const bosituasjon = søknad.bosituasjon;
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
   const skalViseKnapper = !kommerFraOppsummering
     ? ESide.visTilbakeNesteAvbrytKnapp

--- a/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
+++ b/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
@@ -17,6 +17,7 @@ import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
 import { hentPathBarnetilsynOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const BarnaDine: React.FC = () => {
   const intl = useIntl();
@@ -27,7 +28,7 @@ const BarnaDine: React.FC = () => {
     settDokumentasjonsbehovForBarn,
   } = useBarnetilsynSøknad();
   const history = useHistory();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const kommerFraOppsummering = location.state?.kommerFraOppsummering && false;
   const skalViseKnapper = !kommerFraOppsummering
     ? ESide.visTilbakeNesteAvbrytKnapp

--- a/src/barnetilsyn/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/BarnasBosted.tsx
@@ -10,6 +10,7 @@ import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
 import { hentPathBarnetilsynOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
   if (!ref || !ref.current) return;
@@ -18,7 +19,7 @@ const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
 
 const BarnasBosted: React.FC = () => {
   const intl = useIntl();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const {
     søknad,
     mellomlagreBarnetilsyn,

--- a/src/barnetilsyn/steg/5-aktivitet/Aktivitet.tsx
+++ b/src/barnetilsyn/steg/5-aktivitet/Aktivitet.tsx
@@ -29,6 +29,7 @@ import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
 import { hentPathBarnetilsynOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const Aktivitet: React.FC = () => {
   const intl = useIntl();
@@ -38,7 +39,7 @@ const Aktivitet: React.FC = () => {
     settDokumentasjonsbehov,
     mellomlagreBarnetilsyn,
   } = useBarnetilsynSøknad();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const [arbeidssituasjon, settArbeidssituasjon] = useState<IAktivitet>(
     søknad?.aktivitet
   );

--- a/src/barnetilsyn/steg/6-barnepass/Barnepass.tsx
+++ b/src/barnetilsyn/steg/6-barnepass/Barnepass.tsx
@@ -25,11 +25,12 @@ import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
 import { hentPathBarnetilsynOppsummering } from '../../utils';
 import { useLocation } from 'react-router';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 interface Props {}
 const Barnepass: FC<Props> = () => {
   const intl = useIntl();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
   const skalViseKnapper = !kommerFraOppsummering
     ? ESide.visTilbakeNesteAvbrytKnapp

--- a/src/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -17,6 +17,7 @@ import { useIntl } from 'react-intl';
 import { hentPath } from '../../../utils/routing';
 import Side, { ESide } from '../../../components/side/Side';
 import { hentTekst } from '../../../utils/søknad';
+import { Stønadstype } from '../../../models/søknad/stønadstyper';
 
 const Oppsummering: React.FC = () => {
   const intl = useIntl();
@@ -57,6 +58,7 @@ const Oppsummering: React.FC = () => {
             />
             <OppsummeringBarnaDine
               barn={søknad.person.barn}
+              stønadstype={Stønadstype.barnetilsyn}
               endreInformasjonPath={hentPath(
                 RoutesBarnetilsyn,
                 ERouteBarnetilsyn.BarnaDine

--- a/src/barnetilsyn/steg/8-dokumentasjon/Dokumentasjon.tsx
+++ b/src/barnetilsyn/steg/8-dokumentasjon/Dokumentasjon.tsx
@@ -12,11 +12,12 @@ import Side, { ESide } from '../../../components/side/Side';
 import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
 import { IVedlegg } from '../../../models/steg/vedlegg';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const Dokumentasjon: React.FC = () => {
   const intl = useIntl();
   const { søknad, settSøknad, mellomlagreBarnetilsyn } = useBarnetilsynSøknad();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const { dokumentasjonsbehov } = søknad;
   const sidetittel: string = hentTekst('dokumentasjon.tittel', intl);
   const forrigeDokumentasjonsbehov = usePrevious(søknad.dokumentasjonsbehov);

--- a/src/barnetilsyn/steg/8-dokumentasjon/SendBarnetilsynSøknad.tsx
+++ b/src/barnetilsyn/steg/8-dokumentasjon/SendBarnetilsynSøknad.tsx
@@ -19,6 +19,7 @@ import { ISøknad } from '../../models/søknad';
 import { IBarn } from '../../../models/steg/barn';
 import { hentForrigeRoute, hentNesteRoute } from '../../../utils/routing';
 import { unikeDokumentasjonsbehov } from '../../../utils/søknad';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 interface Innsending {
   status: string;
@@ -28,7 +29,7 @@ interface Innsending {
 
 const SendSøknadKnapper: FC = () => {
   const { søknad, settSøknad } = useBarnetilsynSøknad();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const history = useHistory();
   const nesteRoute = hentNesteRoute(RoutesBarnetilsyn, location.pathname);
   const forrigeRoute = hentForrigeRoute(RoutesBarnetilsyn, location.pathname);

--- a/src/components/gruppe/LabelVerdiGruppe.tsx
+++ b/src/components/gruppe/LabelVerdiGruppe.tsx
@@ -1,0 +1,33 @@
+import React, { FC } from 'react';
+import styled from 'styled-components/macro';
+
+const StyledLabelVerdiGruppe = styled.div`
+  display: grid;
+  grid-template-rows: auto;
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    'label'
+    'verdi';
+
+  .typo-element {
+    grid-area: label;
+    padding-bottom: 15px;
+  }
+  .typo-normal,
+  .verdi {
+    grid-area: verdi;
+    padding-bottom: 15px;
+  }
+`;
+
+const LabelVerdiGruppe: FC<{ className?: string }> = ({
+  className,
+  children,
+}) => {
+  return (
+    <StyledLabelVerdiGruppe className={className}>
+      {children}
+    </StyledLabelVerdiGruppe>
+  );
+};
+export default LabelVerdiGruppe;

--- a/src/components/knapper/TilbakeNesteAvbrytKnapper.tsx
+++ b/src/components/knapper/TilbakeNesteAvbrytKnapper.tsx
@@ -5,6 +5,7 @@ import { hentForrigeRoute, hentNesteRoute } from '../../utils/routing';
 import { IRoute } from '../../models/routes';
 import { useHistory, useLocation } from 'react-router';
 import styled from 'styled-components';
+import { LocationStateSøknad } from '../../models/søknad/søknad';
 
 const StyledNavigeringsKnapper = styled.div`
   padding: 2rem;
@@ -73,7 +74,7 @@ const TilbakeNesteAvbrytKnapper: FC<Props> = ({
   erSpørsmålBesvart,
   mellomlagreStønad,
 }) => {
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const history = useHistory();
   const nesteRoute = hentNesteRoute(routesStønad, location.pathname);
   const forrigeRoute = hentForrigeRoute(routesStønad, location.pathname);

--- a/src/components/side/Side.tsx
+++ b/src/components/side/Side.tsx
@@ -12,6 +12,7 @@ import TilbakeNesteAvbrytKnapper from '../../components/knapper/TilbakeNesteAvbr
 import { IRoute } from '../../models/routes';
 import { Stønadstype } from '../../models/søknad/stønadstyper';
 import { hentBannertittel } from '../../utils/stønadstype';
+import { LocationStateSøknad } from '../../models/søknad/søknad';
 
 export enum ESide {
   visTilbakeNesteAvbrytKnapp = 'visTilbakeNesteAvbrytKnapp',
@@ -40,7 +41,7 @@ const Side: React.FC<ISide> = ({
   tilbakeTilOppsummeringPath,
 }) => {
   const intl = useIntl();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const history = useHistory();
 
   const routes = Object.values(routesStønad);

--- a/src/components/side/Side.tsx
+++ b/src/components/side/Side.tsx
@@ -82,11 +82,14 @@ const Side: React.FC<ISide> = ({
           erSpørsmålBesvart && (
             <Hovedknapp
               className="tilbake-til-oppsummering"
-              onClick={() =>
+              onClick={() => {
+                if (mellomlagreStønad) {
+                  mellomlagreStønad(location.pathname);
+                }
                 history.push({
                   pathname: tilbakeTilOppsummeringPath,
-                })
-              }
+                });
+              }}
             >
               {hentTekst('oppsummering.tilbake', intl)}
             </Hovedknapp>

--- a/src/language/tekster.ts
+++ b/src/language/tekster.ts
@@ -267,7 +267,7 @@ export default {
     'barnadine.hjelpetekst.åpne': 'Hvilke barn kan du få stønad for?',
     'barnadine.hjelpetekst.innhold': 'Lorem ipsum hjelpetekst jadda',
     'barnadine.leggtil': 'Legg til barn',
-    'barnadine.label.skalHaBarnepass': 'Med i søknaden',
+    'barnadine.label.skalHaBarnepass': 'Skal barnet ha barnepass?',
     'barnadine.knapp.fjern': 'Fjern fra søknad',
     'barnadine.knapp.søkBarnetilsyn':
       'Søk om stønad til barnetilsyn for barnet',

--- a/src/models/søknad/søknad.ts
+++ b/src/models/søknad/søknad.ts
@@ -23,3 +23,7 @@ export interface ISøknad {
 export enum ESøknad {
   søkerBorPåRegistrertAdresse = 'søkerBorPåRegistrertAdresse',
 }
+
+export interface LocationStateSøknad {
+  kommerFraOppsummering?: boolean;
+}

--- a/src/overgangsstønad/steg/1-omdeg/OmDeg.tsx
+++ b/src/overgangsstønad/steg/1-omdeg/OmDeg.tsx
@@ -18,10 +18,11 @@ import { RoutesOvergangsstonad } from '../../routing/routesOvergangsstonad';
 import { hentPathOvergangsstønadOppsummering } from '../../utils';
 import { useIntl } from 'react-intl';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const OmDeg: FC = () => {
   const intl = useIntl();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
   const skalViseKnapper = !kommerFraOppsummering
     ? ESide.visTilbakeNesteAvbrytKnapp

--- a/src/overgangsstønad/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/overgangsstønad/steg/2-bosituasjon/Bosituasjon.tsx
@@ -9,6 +9,7 @@ import { RoutesOvergangsstonad } from '../../routing/routesOvergangsstonad';
 import { hentPathOvergangsstønadOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const Bosituasjon: FC = () => {
   const intl = useIntl();
@@ -19,7 +20,7 @@ const Bosituasjon: FC = () => {
     mellomlagreOvergangsstønad,
   } = useSøknad();
   const bosituasjon = søknad.bosituasjon;
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
   const skalViseKnapper = !kommerFraOppsummering
     ? ESide.visTilbakeNesteAvbrytKnapp

--- a/src/overgangsstønad/steg/3-barnadine/BarnaDine.tsx
+++ b/src/overgangsstønad/steg/3-barnadine/BarnaDine.tsx
@@ -14,6 +14,7 @@ import Side, { ESide } from '../../../components/side/Side';
 import { RoutesOvergangsstonad } from '../../routing/routesOvergangsstonad';
 import { hentPathOvergangsstønadOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const BarnaDine: React.FC = () => {
   const intl = useIntl();
@@ -23,7 +24,7 @@ const BarnaDine: React.FC = () => {
     settSøknad,
     settDokumentasjonsbehovForBarn,
   } = useSøknad();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const kommerFraOppsummering = location.state?.kommerFraOppsummering && false;
   const skalViseKnapper = !kommerFraOppsummering
     ? ESide.visTilbakeNesteAvbrytKnapp

--- a/src/overgangsstønad/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/overgangsstønad/steg/4-barnasbosted/BarnasBosted.tsx
@@ -11,6 +11,7 @@ import Side, { ESide } from '../../../components/side/Side';
 import { RoutesOvergangsstonad } from '../../routing/routesOvergangsstonad';
 import { hentPathOvergangsstønadOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
   if (!ref || !ref.current) return;
@@ -19,7 +20,7 @@ const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
 
 const BarnasBosted: React.FC = () => {
   const intl = useIntl();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const {
     søknad,
     mellomlagreOvergangsstønad,

--- a/src/overgangsstønad/steg/5-aktivitet/Aktivitet.tsx
+++ b/src/overgangsstønad/steg/5-aktivitet/Aktivitet.tsx
@@ -19,6 +19,7 @@ import Side, { ESide } from '../../../components/side/Side';
 import { RoutesOvergangsstonad } from '../../routing/routesOvergangsstonad';
 import { hentPathOvergangsstønadOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const Aktivitet: React.FC = () => {
   const intl = useIntl();
@@ -28,7 +29,7 @@ const Aktivitet: React.FC = () => {
     settDokumentasjonsbehov,
     mellomlagreOvergangsstønad,
   } = useSøknad();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
   const skalViseKnapper = !kommerFraOppsummering
     ? ESide.visTilbakeNesteAvbrytKnapp

--- a/src/overgangsstønad/steg/6-meromsituasjon/MerOmDinSituasjon.tsx
+++ b/src/overgangsstønad/steg/6-meromsituasjon/MerOmDinSituasjon.tsx
@@ -29,6 +29,7 @@ import Side, { ESide } from '../../../components/side/Side';
 import { RoutesOvergangsstonad } from '../../routing/routesOvergangsstonad';
 import { hentPathOvergangsstønadOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const MerOmDinSituasjon: React.FC = () => {
   const intl = useIntl();
@@ -38,7 +39,7 @@ const MerOmDinSituasjon: React.FC = () => {
     settDokumentasjonsbehov,
     mellomlagreOvergangsstønad,
   } = useSøknad();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
   const skalViseKnapper = !kommerFraOppsummering
     ? ESide.visTilbakeNesteAvbrytKnapp

--- a/src/overgangsstønad/steg/7-oppsummering/Oppsummering.less
+++ b/src/overgangsstønad/steg/7-oppsummering/Oppsummering.less
@@ -1,11 +1,7 @@
 .oppsummering {
-  .listeelement {
-    hr {
-      margin-top: 2rem;
-      margin-bottom: 2rem;
-    }
+  .typo-ingress {
+    padding-bottom: 45px;
   }
-
   .disclaimer {
     margin-top: 3rem;
     margin-bottom: 3rem;

--- a/src/overgangsstønad/steg/7-oppsummering/Oppsummering.less
+++ b/src/overgangsstønad/steg/7-oppsummering/Oppsummering.less
@@ -20,18 +20,6 @@
     margin-top: 1rem;
     margin-bottom: 1rem;
   }
-
-  .oppsummering-barn {
-    hr {
-      margin-top: 2rem;
-    }
-
-    .typo-element {
-      margin-top: 2rem;
-      margin-bottom: 1rem;
-    }
-  }
-
   .oppsummering-bosituasjon {
     .seksjon-samboer {
       margin-top: 2rem;

--- a/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
@@ -16,6 +16,7 @@ import {
 import { hentPath } from '../../../utils/routing';
 import Side, { ESide } from '../../../components/side/Side';
 import { hentTekst } from '../../../utils/søknad';
+import { Stønadstype } from '../../../models/søknad/stønadstyper';
 
 const Oppsummering: React.FC = () => {
   const intl = useIntl();
@@ -53,6 +54,7 @@ const Oppsummering: React.FC = () => {
             />
             <OppsummeringBarnaDine
               barn={søknad.person.barn}
+              stønadstype={Stønadstype.overgangsstønad}
               endreInformasjonPath={hentPath(
                 RoutesOvergangsstonad,
                 ERouteOvergangsstønad.Barn

--- a/src/overgangsstønad/steg/8-dokumentasjon/Dokumentasjon.tsx
+++ b/src/overgangsstønad/steg/8-dokumentasjon/Dokumentasjon.tsx
@@ -15,11 +15,12 @@ import Side, { ESide } from '../../../components/side/Side';
 import { RoutesOvergangsstonad } from '../../routing/routesOvergangsstonad';
 import { IVedlegg } from '../../../models/steg/vedlegg';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const Dokumentasjon: React.FC = () => {
   const intl = useIntl();
   const { søknad, settSøknad, mellomlagreOvergangsstønad } = useSøknad();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const { dokumentasjonsbehov } = søknad;
   const sidetittel: string = hentTekst('dokumentasjon.tittel', intl);
   const forrigeDokumentasjonsbehov = usePrevious(søknad.dokumentasjonsbehov);

--- a/src/overgangsstønad/steg/8-dokumentasjon/SendSøknad.tsx
+++ b/src/overgangsstønad/steg/8-dokumentasjon/SendSøknad.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import KnappBase from 'nav-frontend-knapper';
 import LocaleTekst from '../../../language/LocaleTekst';
 import { IStatus } from '../../../arbeidssøkerskjema/innsending/typer';
-import { ISøknad } from '../../../models/søknad/søknad';
+import { ISøknad, LocationStateSøknad } from '../../../models/søknad/søknad';
 import { parseISO } from 'date-fns';
 import { useSøknad } from '../../../context/SøknadContext';
 import { useHistory, useLocation } from 'react-router';
@@ -28,7 +28,7 @@ interface Innsending {
 
 const SendSøknadKnapper: FC = () => {
   const { søknad, settSøknad } = useSøknad();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const history = useHistory();
   const nesteRoute = hentNesteRoute(RoutesOvergangsstonad, location.pathname);
   const forrigeRoute = hentForrigeRoute(

--- a/src/skolepenger/steg/1-omdeg/OmDeg.tsx
+++ b/src/skolepenger/steg/1-omdeg/OmDeg.tsx
@@ -18,9 +18,10 @@ import Side, { ESide } from '../../../components/side/Side';
 import { RoutesSkolepenger } from '../../routing/routes';
 import { hentPathSkolepengerOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
   const skalViseKnapper = !kommerFraOppsummering
     ? ESide.visTilbakeNesteAvbrytKnapp

--- a/src/skolepenger/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/skolepenger/steg/2-bosituasjon/Bosituasjon.tsx
@@ -9,6 +9,7 @@ import Side, { ESide } from '../../../components/side/Side';
 import { RoutesSkolepenger } from '../../routing/routes';
 import { hentPathSkolepengerOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const Bosituasjon: FC = () => {
   const intl = useIntl();
@@ -19,7 +20,7 @@ const Bosituasjon: FC = () => {
     mellomlagreSkolepenger,
   } = useSkolepengerSøknad();
   const bosituasjon = søknad.bosituasjon;
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
   const skalViseKnapper = !kommerFraOppsummering
     ? ESide.visTilbakeNesteAvbrytKnapp

--- a/src/skolepenger/steg/3-barnadine/BarnaDine.tsx
+++ b/src/skolepenger/steg/3-barnadine/BarnaDine.tsx
@@ -14,6 +14,7 @@ import { RoutesSkolepenger } from '../../routing/routes';
 import { hentPathSkolepengerOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const BarnaDine: React.FC = () => {
   const intl = useIntl();
@@ -23,7 +24,7 @@ const BarnaDine: React.FC = () => {
     mellomlagreSkolepenger,
     settDokumentasjonsbehovForBarn,
   } = useSkolepengerSøknad();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const kommerFraOppsummering = location.state?.kommerFraOppsummering && false;
   const skalViseKnapper = !kommerFraOppsummering
     ? ESide.visTilbakeNesteAvbrytKnapp

--- a/src/skolepenger/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/skolepenger/steg/4-barnasbosted/BarnasBosted.tsx
@@ -11,6 +11,7 @@ import { RoutesSkolepenger } from '../../routing/routes';
 import { hentPathSkolepengerOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
   if (!ref || !ref.current) return;
@@ -19,7 +20,7 @@ const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
 
 const BarnasBosted: React.FC = () => {
   const intl = useIntl();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
   const skalViseKnapper = !kommerFraOppsummering
     ? ESide.visTilbakeNesteAvbrytKnapp

--- a/src/skolepenger/steg/5-aktivitet/UtdanningSituasjon.tsx
+++ b/src/skolepenger/steg/5-aktivitet/UtdanningSituasjon.tsx
@@ -9,11 +9,12 @@ import { IDetaljertUtdanning } from '../../models/detaljertUtdanning';
 import { useSkolepengerSøknad } from '../../SkolepengerContext';
 import UnderUtdanning from '../../../søknad/steg/5-aktivitet/underUtdanning/UnderUtdanning';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 const UtdanningSituasjon: React.FC = () => {
   const intl = useIntl();
   const { søknad, settSøknad, mellomlagreSkolepenger } = useSkolepengerSøknad();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
   const skalViseKnapper = !kommerFraOppsummering
     ? ESide.visTilbakeNesteAvbrytKnapp
@@ -31,7 +32,8 @@ const UtdanningSituasjon: React.FC = () => {
 
   return (
     <Side
-      tittel={intl.formatMessage({ id: 'stegtittel.utdanning' })}
+      stønadstype={Stønadstype.skolepenger}
+      stegtittel={intl.formatMessage({ id: 'stegtittel.utdanning' })}
       skalViseKnapper={skalViseKnapper}
       erSpørsmålBesvart={erSisteSpørsmålBesvartOgMinstEttAlternativValgt}
       mellomlagreStønad={mellomlagreSkolepenger}

--- a/src/skolepenger/steg/6-oppsummering/Oppsummering.tsx
+++ b/src/skolepenger/steg/6-oppsummering/Oppsummering.tsx
@@ -12,6 +12,7 @@ import Side, { ESide } from '../../../components/side/Side';
 import { hentTekst } from '../../../utils/søknad';
 import { useSkolepengerSøknad } from '../../SkolepengerContext';
 import OppsummeringDetaljertUtdanning from '../../../søknad/steg/7-oppsummering/OppsummeringDetaljertUtdanning';
+import { Stønadstype } from '../../../models/søknad/stønadstyper';
 
 const Oppsummering: React.FC = () => {
   const intl = useIntl();
@@ -19,7 +20,8 @@ const Oppsummering: React.FC = () => {
   return (
     <>
       <Side
-        tittel={intl.formatMessage({ id: 'oppsummering.sidetittel' })}
+        stønadstype={Stønadstype.skolepenger}
+        stegtittel={intl.formatMessage({ id: 'oppsummering.sidetittel' })}
         skalViseKnapper={ESide.visTilbakeNesteAvbrytKnapp}
         erSpørsmålBesvart={true}
         mellomlagreStønad={mellomlagreSkolepenger}
@@ -48,6 +50,7 @@ const Oppsummering: React.FC = () => {
               )}
             />
             <OppsummeringBarnaDine
+              stønadstype={Stønadstype.skolepenger}
               barn={søknad.person.barn}
               endreInformasjonPath={hentPath(
                 RoutesSkolepenger,

--- a/src/skolepenger/steg/7-dokumentasjon/Dokumentasjon.tsx
+++ b/src/skolepenger/steg/7-dokumentasjon/Dokumentasjon.tsx
@@ -14,11 +14,13 @@ import Side, { ESide } from '../../../components/side/Side';
 import { RoutesSkolepenger } from '../../routing/routes';
 import { IVedlegg } from '../../../models/steg/vedlegg';
 import { useSkolepengerSøknad } from '../../SkolepengerContext';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
+import { Stønadstype } from '../../../models/søknad/stønadstyper';
 
 const Dokumentasjon: React.FC = () => {
   const intl = useIntl();
   const { søknad, settSøknad, mellomlagreSkolepenger } = useSkolepengerSøknad();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const { dokumentasjonsbehov } = søknad;
   const sidetittel: string = hentTekst('dokumentasjon.tittel', intl);
   const forrigeDokumentasjonsbehov = usePrevious(søknad.dokumentasjonsbehov);
@@ -77,7 +79,8 @@ const Dokumentasjon: React.FC = () => {
   const harDokumentasjonsbehov = søknad.dokumentasjonsbehov.length > 0;
   return (
     <Side
-      tittel={sidetittel}
+      stønadstype={Stønadstype.skolepenger}
+      stegtittel={sidetittel}
       skalViseKnapper={ESide.skjulKnapper}
       erSpørsmålBesvart={false}
       mellomlagreStønad={mellomlagreSkolepenger}

--- a/src/skolepenger/steg/7-dokumentasjon/SendSkolepengerSøknad.tsx
+++ b/src/skolepenger/steg/7-dokumentasjon/SendSkolepengerSøknad.tsx
@@ -19,6 +19,7 @@ import { hentForrigeRoute, hentNesteRoute } from '../../../utils/routing';
 import { unikeDokumentasjonsbehov } from '../../../utils/søknad';
 import { ISøknad } from '../../models/søknad';
 import { useSkolepengerSøknad } from '../../SkolepengerContext';
+import { LocationStateSøknad } from '../../../models/søknad/søknad';
 
 interface Innsending {
   status: string;
@@ -28,7 +29,7 @@ interface Innsending {
 
 const SendSøknadKnapper: FC = () => {
   const { søknad, settSøknad } = useSkolepengerSøknad();
-  const location = useLocation();
+  const location = useLocation<LocationStateSøknad>();
   const history = useHistory();
   const nesteRoute = hentNesteRoute(RoutesSkolepenger, location.pathname);
   const forrigeRoute = hentForrigeRoute(RoutesSkolepenger, location.pathname);

--- a/src/skolepenger/steg/8-kvittering/Kvittering.tsx
+++ b/src/skolepenger/steg/8-kvittering/Kvittering.tsx
@@ -31,7 +31,8 @@ const Kvittering: React.FC = () => {
 
   return søknad.innsendingsdato ? (
     <Side
-      tittel={intl.formatMessage({ id: 'kvittering.takk' })}
+      stønadstype={Stønadstype.skolepenger}
+      stegtittel={intl.formatMessage({ id: 'kvittering.takk' })}
       skalViseKnapper={ESide.skjulKnapper}
       routesStønad={RoutesSkolepenger}
     >

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -168,7 +168,9 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   return (
     <>
       <div className="barnas-bosted">
-        <BarneHeader barn={barn} />
+        <SeksjonGruppe>
+          <BarneHeader barn={barn} />
+        </SeksjonGruppe>
         <div className="barnas-bosted__innhold">
           {!barn.harSammeAdresse.verdi && (
             <SkalBarnetBoHosSøker

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedLagtTil.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedLagtTil.tsx
@@ -25,7 +25,7 @@ const BarnetsBostedLagtTil: React.FC<Props> = ({
   const barnetsNavn =
     barn.navn && barn.navn.verdi !== ''
       ? barn.navn.verdi
-      : hentTekst('barnet.litenForBokstav', intl);
+      : hentTekst('barnet.storForBokstav', intl);
   if (!forelder) return null;
 
   const endreInformasjon = () => {

--- a/src/søknad/steg/7-oppsummering/OppsummeringAktiviteter.tsx
+++ b/src/søknad/steg/7-oppsummering/OppsummeringAktiviteter.tsx
@@ -7,7 +7,13 @@ import { IAktivitet } from '../../../models/steg/aktivitet/aktivitet';
 import { Undertittel } from 'nav-frontend-typografi';
 import { useHistory } from 'react-router-dom';
 import { useIntl } from 'react-intl';
-import { VisLabelOgSvar, visListeAvLabelOgSvar } from '../../../utils/visning';
+import {
+  VisLabelOgSvar,
+  visLabelOgVerdiForSpørsmålFelt,
+  visLabelOgVerdiForSpørsmålListeFelt,
+  visListeAvLabelOgSvar,
+} from '../../../utils/visning';
+import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
 
 interface Props {
   aktivitet: IAktivitet;
@@ -22,72 +28,76 @@ const OppsummeringAktiviteter: React.FC<Props> = ({
 }) => {
   const history = useHistory();
   const intl = useIntl();
-  const erIArbeid = aktivitet.erIArbeid
-    ? VisLabelOgSvar(aktivitet.erIArbeid)
-    : null;
-
-  const virksomhet = aktivitet.etablererEgenVirksomhet
-    ? VisLabelOgSvar(aktivitet.etablererEgenVirksomhet)
-    : null;
-
-  const arbeidssituasjon = VisLabelOgSvar(aktivitet);
-
-  const firmaer = aktivitet.firmaer
-    ? visListeAvLabelOgSvar(
-        aktivitet.firmaer,
-        hentTekst('firmaer.tittel', intl)
-      )
-    : null;
-
-  const arbeidsforhold = aktivitet.arbeidsforhold
-    ? visListeAvLabelOgSvar(
-        aktivitet.arbeidsforhold,
-        hentTekst('arbeidsforhold.tittel.arbeidsgiver', intl)
-      )
-    : null;
-
-  const egetAS = aktivitet.egetAS
-    ? visListeAvLabelOgSvar(
-        aktivitet.egetAS,
-        hentTekst('arbeidsforhold.tittel.egetAS', intl)
-      )
-    : null;
-
-  const tidligereUtdanning = aktivitet.underUtdanning?.tidligereUtdanning
-    ? visListeAvLabelOgSvar(
-        aktivitet.underUtdanning.tidligereUtdanning,
-        hentTekst('utdanning.tittel.tidligere', intl)
-      )
-    : null;
-
-  const arbeidssøker = aktivitet.arbeidssøker
-    ? VisLabelOgSvar(aktivitet.arbeidssøker)
-    : null;
-
-  const underUtdanning = aktivitet.underUtdanning
-    ? VisLabelOgSvar(aktivitet.underUtdanning)
-    : null;
 
   return (
     <Ekspanderbartpanel
       className="aktiviteter"
       tittel={<Undertittel>{tittel}</Undertittel>}
     >
-      {erIArbeid && <div className={'seksjon'}>{erIArbeid} </div>}
-      {virksomhet ? <div className="seksjon">{virksomhet}</div> : null}
-      {arbeidssituasjon ? (
-        <div className="seksjon">{arbeidssituasjon}</div>
-      ) : null}
-      {arbeidsforhold ? <div className="seksjon">{arbeidsforhold}</div> : null}
-      {firmaer ? <div className="seksjon">{firmaer}</div> : null}
-      {egetAS ? <div className="seksjon">{egetAS}</div> : null}
-      {arbeidssøker ? <div className="seksjon">{arbeidssøker}</div> : null}
-      {underUtdanning ? (
-        <div className="seksjon">
-          {underUtdanning}
-          {tidligereUtdanning}
-        </div>
-      ) : null}
+      {aktivitet.erIArbeid && (
+        <SeksjonGruppe>
+          {visLabelOgVerdiForSpørsmålFelt(aktivitet?.erIArbeid, intl)}
+        </SeksjonGruppe>
+      )}
+      {aktivitet.hvaErDinArbeidssituasjon && (
+        <SeksjonGruppe>
+          {visLabelOgVerdiForSpørsmålListeFelt(
+            aktivitet.hvaErDinArbeidssituasjon
+          )}
+        </SeksjonGruppe>
+      )}
+
+      {aktivitet.etablererEgenVirksomhet && (
+        <SeksjonGruppe>
+          {visLabelOgVerdiForSpørsmålFelt(
+            aktivitet.etablererEgenVirksomhet,
+            intl,
+            hentTekst('arbeidssituasjon.tittel.etablererEgenVirksomhet', intl)
+          )}
+        </SeksjonGruppe>
+      )}
+
+      {aktivitet.arbeidsforhold && (
+        <SeksjonGruppe>
+          {visListeAvLabelOgSvar(
+            aktivitet.arbeidsforhold,
+            hentTekst('arbeidsforhold.tittel.arbeidsgiver', intl)
+          )}
+        </SeksjonGruppe>
+      )}
+
+      {aktivitet.firmaer && (
+        <SeksjonGruppe>
+          {visListeAvLabelOgSvar(
+            aktivitet.firmaer,
+            hentTekst('firmaer.tittel', intl)
+          )}
+        </SeksjonGruppe>
+      )}
+
+      {aktivitet.egetAS && (
+        <SeksjonGruppe>
+          {visListeAvLabelOgSvar(
+            aktivitet.egetAS,
+            hentTekst('arbeidsforhold.tittel.egetAS', intl)
+          )}
+        </SeksjonGruppe>
+      )}
+
+      {aktivitet.arbeidssøker && (
+        <SeksjonGruppe>{VisLabelOgSvar(aktivitet.arbeidssøker)}</SeksjonGruppe>
+      )}
+
+      {aktivitet.underUtdanning && (
+        <SeksjonGruppe>
+          {VisLabelOgSvar(aktivitet.underUtdanning)}
+          {aktivitet.underUtdanning?.tidligereUtdanning &&
+            visListeAvLabelOgSvar(
+              aktivitet.underUtdanning.tidligereUtdanning,
+              hentTekst('utdanning.tittel.tidligere', intl)
+            )}
+        </SeksjonGruppe>
+      )}
       <LenkeMedIkon
         onClick={() =>
           history.replace({

--- a/src/søknad/steg/7-oppsummering/OppsummeringBarn.tsx
+++ b/src/søknad/steg/7-oppsummering/OppsummeringBarn.tsx
@@ -1,0 +1,83 @@
+import React, { FC } from 'react';
+import { IBarn } from '../../../models/steg/barn';
+import { Element, Normaltekst } from 'nav-frontend-typografi';
+import FeltGruppe from '../../../components/gruppe/FeltGruppe';
+import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { verdiTilTekstsvar } from '../../../utils/visning';
+import { useIntl } from 'react-intl';
+
+interface Props {
+  stønadstype: Stønadstype;
+  barn: IBarn;
+}
+
+const OppsummeringBarn: FC<Props> = ({ stønadstype, barn }) => {
+  const intl = useIntl();
+  const {
+    alder,
+    fødselsdato,
+    ident,
+    navn,
+    født,
+    skalHaBarnepass,
+    harSammeAdresse,
+    lagtTil,
+  } = barn;
+
+  return (
+    <>
+      {navn && (
+        <FeltGruppe>
+          <Element>{navn?.label}</Element>
+          <Normaltekst>{navn.verdi}</Normaltekst>
+        </FeltGruppe>
+      )}
+
+      {ident && ident.verdi !== '' && (
+        <FeltGruppe>
+          <Element>{ident?.label}</Element>
+          <Normaltekst>{ident.verdi}</Normaltekst>
+        </FeltGruppe>
+      )}
+
+      {alder && (
+        <FeltGruppe>
+          <Element>{alder.label}</Element>
+          <Normaltekst>{alder.verdi}</Normaltekst>
+        </FeltGruppe>
+      )}
+
+      {fødselsdato.verdi !== '' && (
+        <FeltGruppe>
+          <Element>{fødselsdato.label}</Element>
+          <Normaltekst>{fødselsdato.verdi}</Normaltekst>
+        </FeltGruppe>
+      )}
+
+      {født && lagtTil && (
+        <FeltGruppe>
+          <Element>{født?.label}</Element>
+          <Normaltekst>{verdiTilTekstsvar(født.verdi)}</Normaltekst>
+        </FeltGruppe>
+      )}
+
+      {stønadstype === Stønadstype.barnetilsyn && skalHaBarnepass && (
+        <FeltGruppe>
+          <Element>{skalHaBarnepass?.label}</Element>
+          <Normaltekst>
+            {verdiTilTekstsvar(skalHaBarnepass?.verdi, intl)}
+          </Normaltekst>
+        </FeltGruppe>
+      )}
+
+      {harSammeAdresse && (
+        <FeltGruppe>
+          <Element>{harSammeAdresse.label}</Element>
+          <Normaltekst>{verdiTilTekstsvar(harSammeAdresse.verdi)}</Normaltekst>
+        </FeltGruppe>
+      )}
+    </>
+  );
+};
+
+export default OppsummeringBarn;

--- a/src/søknad/steg/7-oppsummering/OppsummeringBarnaDine.tsx
+++ b/src/søknad/steg/7-oppsummering/OppsummeringBarnaDine.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
-import { VisLabelOgSvar } from '../../../utils/visning';
 import endre from '../../../assets/endre.svg';
 import { useHistory } from 'react-router-dom';
 import { useIntl } from 'react-intl';
@@ -8,21 +7,35 @@ import { Undertittel } from 'nav-frontend-typografi';
 import LenkeMedIkon from '../../../components/knapper/LenkeMedIkon';
 import { hentTekst } from '../../../utils/søknad';
 import { IBarn } from '../../../models/steg/barn';
+import OppsummeringBarn from './OppsummeringBarn';
+import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import BarneHeader from '../../../components/BarneHeader';
+import styled from 'styled-components';
+
+const StyledOppsummering = styled.section`
+  margin-top: 3rem;
+
+  .typo-element {
+    margin-top: 1.5rem;
+    margin-bottom: 1rem;
+  }
+`;
 
 interface Props {
   barn: IBarn[];
+  stønadstype: Stønadstype;
   endreInformasjonPath?: string;
 }
 const OppsummeringBarnaDine: React.FC<Props> = ({
   barn,
+  stønadstype,
   endreInformasjonPath,
 }) => {
   const intl = useIntl();
   const history = useHistory();
+  const barnaDine: IBarn[] = barn;
 
-  const barna = barn;
-
-  const felterAlleBarna = barna.map((barn, index) => {
+  const hentEndretBarn = (barn: IBarn) => {
     let nyttBarn = { ...barn };
 
     if (!barn.født?.verdi) {
@@ -35,18 +48,22 @@ const OppsummeringBarnaDine: React.FC<Props> = ({
         verdi: barn.fødselsdato.verdi,
       };
     }
+    return nyttBarn;
+  };
+  const oppsummeringBarnaDine = barnaDine.map((barn, index) => {
+    const endretBarn = hentEndretBarn(barn);
 
     return (
-      <div className="oppsummering-barn" key={index}>
-        {VisLabelOgSvar(nyttBarn)}
-        {index < barna.length - 1 && <hr />}
-      </div>
+      <StyledOppsummering>
+        <BarneHeader barn={barn} />
+        <OppsummeringBarn stønadstype={stønadstype} barn={endretBarn} />
+      </StyledOppsummering>
     );
   });
 
   return (
     <Ekspanderbartpanel tittel={<Undertittel>Barna dine</Undertittel>}>
-      {felterAlleBarna}
+      {oppsummeringBarnaDine}
       <LenkeMedIkon
         onClick={() =>
           history.push({

--- a/src/utils/visning.tsx
+++ b/src/utils/visning.tsx
@@ -9,7 +9,9 @@ import { hentBeskjedMedNavn } from '../utils/språk';
 import {
   ISpørsmålBooleanFelt,
   ISpørsmålFelt,
+  ISpørsmålListeFelt,
 } from '../models/søknad/søknadsfelter';
+import LabelVerdiGruppe from '../components/gruppe/LabelVerdiGruppe';
 
 export const visListeAvLabelOgSvar = (
   liste: any[] | undefined,
@@ -135,13 +137,34 @@ export const VisLabelOgSvar = (objekt: Object | undefined, navn?: string) => {
 
 export const visLabelOgVerdiForSpørsmålFelt = (
   feltObjekt: ISpørsmålFelt | ISpørsmålBooleanFelt,
-  intl: IntlShape
+  intl: IntlShape,
+  overskrift?: string
 ) => {
   return (
-    <div className="spørsmål-og-svar" key={feltObjekt.spørsmålid}>
-      <Element>{feltObjekt.label}</Element>
-      {verdiTilTekstsvar(feltObjekt.verdi, intl)}
-    </div>
+    <>
+      <Ingress>{overskrift}</Ingress>
+      <LabelVerdiGruppe>
+        <Element>{feltObjekt.label}</Element>
+        {verdiTilTekstsvar(feltObjekt.verdi, intl)}
+      </LabelVerdiGruppe>
+    </>
+  );
+};
+
+export const visLabelOgVerdiForSpørsmålListeFelt = (
+  feltListeObjekt: ISpørsmålListeFelt
+) => {
+  return (
+    <LabelVerdiGruppe>
+      <Element>{feltListeObjekt.label}</Element>
+      <ul className={'verdi'}>
+        {feltListeObjekt.verdi.map((svar) => (
+          <li>
+            <Normaltekst>{svar}</Normaltekst>
+          </li>
+        ))}
+      </ul>
+    </LabelVerdiGruppe>
   );
 };
 

--- a/src/utils/visning.tsx
+++ b/src/utils/visning.tsx
@@ -12,6 +12,7 @@ import {
   ISpørsmålListeFelt,
 } from '../models/søknad/søknadsfelter';
 import LabelVerdiGruppe from '../components/gruppe/LabelVerdiGruppe';
+import { LocationStateSøknad } from '../models/søknad/søknad';
 
 export const visListeAvLabelOgSvar = (
   liste: any[] | undefined,
@@ -169,7 +170,7 @@ export const visLabelOgVerdiForSpørsmålListeFelt = (
 };
 
 export const ScrollToTop = () => {
-  const { pathname } = useLocation();
+  const { pathname } = useLocation<LocationStateSøknad>();
 
   useEffect(() => {
     window.scrollTo(0, 0);


### PR DESCRIPTION
Viser BarnaDine i hver sin feltgruppe enn å mappe gjennom hele objektet for så å plassere label og svar. 
Har lagt til BarneHeader for å skille bedre mellom hvert barn (godkjent av Tuva & Tone). 