### PR TITLE
Bugfix/Barnas bosted og foreldresamvær -  Bruker kan ikke gå videre i søknad

### DIFF
--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -119,12 +119,20 @@ export const erAlleFelterOgSpørsmålBesvart = (
     harValgtSvar(ikkeOppgittAnnenForelderBegrunnelse?.verdi) &&
     ikkeOppgittAnnenForelderBegrunnelse?.verdi !== hvorforIkkeOppgi?.verdi;
 
+  const harIkkeBeskrivendeNokSamværsavtale =
+    harDereSkriftligSamværsavtale?.svarid ===
+      EHarSkriftligSamværsavtale.jaIkkeKonkreteTidspunkter ||
+    harDereSkriftligSamværsavtale?.svarid === EHarSkriftligSamværsavtale.nei;
+
   if (harValgtSvar(barnHarSammeForelder) && barnHarSammeForelder === true) {
     return (
       avtaleOmDeltBosted?.svarid === ESvar.JA ||
       harAnnenForelderSamværMedBarn?.svarid === EHarSamværMedBarn.nei ||
       harDereSkriftligSamværsavtale?.svarid ===
         EHarSkriftligSamværsavtale.jaKonkreteTidspunkter ||
+      (harAnnenForelderSamværMedBarn?.svarid ===
+        EHarSamværMedBarn.jaIkkeMerEnnVanlig &&
+        harIkkeBeskrivendeNokSamværsavtale) ||
       harValgtSvar(hvordanPraktiseresSamværet?.verdi)
     );
   } else {


### PR DESCRIPTION
Saken som er meldt: https://jira.adeo.no/browse/FAGSYSTEM-126647

**CASE:** 
Søker har minst 2 barn. 
Fyll inn informasjon på første barnet. 
Velg "Samme som barn1". 

Velg så disse svarsalternativene til spørsmålene under: 

**Spm:** "Har annen forelder samvær med Barn?"
**Alt:** "Ja, men ikke mer enn vanlig"

**Spm:** "Har dere skriftlig samværsavtale?"
**Alt:** "Ja, men beskriver ikke ... " ELLER "Nei"

Sjekk om søker får opp "Neste" knapp slik at de kan gå videre i søknaden. 

