### PR TITLE
Barnetilsyn - Fjern visning av avhukingsalternativ for dokbehov "faktura Barnepass"

### DIFF
--- a/src/søknad/steg/8-dokumentasjon/LastOppVedlegg.tsx
+++ b/src/søknad/steg/8-dokumentasjon/LastOppVedlegg.tsx
@@ -6,7 +6,10 @@ import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
 import { Checkbox } from 'nav-frontend-skjema';
 import { FormattedHTMLMessage, useIntl } from 'react-intl';
 import { hentTekst } from '../../../utils/søknad';
-import { IDokumentasjon } from '../../../models/steg/dokumentasjon';
+import {
+  BarnetilsynDokumentasjon,
+  IDokumentasjon,
+} from '../../../models/steg/dokumentasjon';
 import { Normaltekst, Undertittel } from 'nav-frontend-typografi';
 import { IVedlegg } from '../../../models/steg/vedlegg';
 
@@ -31,6 +34,9 @@ const LastOppVedlegg: React.FC<Props> = ({
     oppdaterDokumentasjon(dokumentasjon.id, vedlegg, huketAv);
   };
 
+  const hvisIkkeFakturaForBarnepass =
+    dokumentasjon.id !== BarnetilsynDokumentasjon.FAKTURA_BARNEPASSORDNING;
+
   return (
     <SeksjonGruppe>
       <FeltGruppe>
@@ -45,13 +51,15 @@ const LastOppVedlegg: React.FC<Props> = ({
           </Normaltekst>
         </FeltGruppe>
       )}
-      <FeltGruppe>
-        <Checkbox
-          label={hentTekst('dokumentasjon.checkbox.sendtTidligere', intl)}
-          checked={dokumentasjon.harSendtInn}
-          onChange={settHarSendtInnTidligere}
-        />
-      </FeltGruppe>
+      {hvisIkkeFakturaForBarnepass && (
+        <FeltGruppe>
+          <Checkbox
+            label={hentTekst('dokumentasjon.checkbox.sendtTidligere', intl)}
+            checked={dokumentasjon.harSendtInn}
+            onChange={settHarSendtInnTidligere}
+          />
+        </FeltGruppe>
+      )}
       {!dokumentasjon.harSendtInn && (
         <Filopplaster
           oppdaterDokumentasjon={oppdaterDokumentasjon}


### PR DESCRIPTION
Fjern visning av  avhukingsalternativ "Jeg har sendt inn denne dokumentasjonen til NAV tidligere" for dokumentasjonsbehovet "Faktura for barnepassordning"

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-2312

**Ser ut sånn her nå:** 
![Skjermbilde 2020-09-23 kl  14 22 26](https://user-images.githubusercontent.com/8249453/94014515-ef0c0a00-fdab-11ea-918e-4ef2f553bf1b.png)


