### PR TITLE
Feature/teksttweaking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12954,8 +12954,7 @@
         },
         "dot-prop": {
           "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+          "resolved": "",
           "requires": {
             "is-obj": "^1.0.0"
           }
@@ -14056,8 +14055,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "resolved": ""
         },
         "minizlib": {
           "version": "1.3.3",

--- a/src/barnetilsyn/steg/7-oppsummering/OppsummeringBarnepass.tsx
+++ b/src/barnetilsyn/steg/7-oppsummering/OppsummeringBarnepass.tsx
@@ -53,7 +53,7 @@ const OppsummeringBarnepass: FC<Props> = ({
 
         return (
           <KomponentGruppe>
-            <StyledOppsummeringForBarn>
+            <StyledOppsummeringForBarn key={barn.id}>
               <FeltGruppe>
                 <BarneHeader barn={barn} />
               </FeltGruppe>

--- a/src/language/tekster.ts
+++ b/src/language/tekster.ts
@@ -707,7 +707,7 @@ export default {
       'Du kan ha rett til stønad i inntil 3 måneder før du søker. Det vil si fra og med april 2020.' +
       'Hvis du er gravid, kan du ha rett til overgangsstønad fra måneden før fødsel.' +
       'Hvis du har fått barn i løpet av de siste 3 månedene, kan du få stønad i inntil 5 måneder før du søker. Det vil si fra og med februar 2020.' +
-      'Vi vil vurdere fra hvilket tidspunkt du har rett til stønad selv om du søker fra en bestemt måned.',
+      'Selv om du søker fra en bestemt måned vil vi vurdere om du har rett til stønad fra denne måneden eller senere.',
     'søkerFraBestemtMåned.hjelpetekst-innhold.barnepass':
       'Stønad til barnetilsyn utbetales fra og med den måneden du fyller vilkårene for stønad. Du kan få etterbetalt stønad for inntil 3 måneder fra du søker dersom du har rett til stønad tilbake i tid. Vi vil vurdere fra hvilket tidspunkt du har rett til stønad selv om du søker fra en bestemt måned.',
     'søkerFraBestemtMåned.svar.neiNavKanVurdere':

--- a/src/language/tekster.ts
+++ b/src/language/tekster.ts
@@ -353,7 +353,8 @@ export default {
     'barnasbosted.forelder.annen': 'Annen forelder',
     'barnasbosted.forelder.sammesom': 'Samme som',
     'barnasbosted.knapp.endre': 'Endre informasjon',
-    'barnasbosted.hjelpetekst.bosted.apne': 'Dette er avtale om delt bosted',
+    'barnasbosted.hjelpetekst.bosted.apne':
+      ' Avtale om delt bosted sier ikke kun noe om hvor mye tid barnet bor hos hver av dere',
     'barnasbosted.hjelpetekst.bosted.innhold':
       'Foreldre kan velge å inngå en avtale om delt bosted for barnet/barna. Dette er en juridisk avtale i henhold til barneloven §36 som sier noe om hvilke avgjørelser dere må ta sammen - ikke hvor mye tid barnet er hos hver av dere.<br/>' +
       '\n' +

--- a/src/language/tekster.ts
+++ b/src/language/tekster.ts
@@ -802,8 +802,6 @@ export default {
       'Jeg har sendt inn denne dokumentasjonen til NAV tidligere',
 
     'dokumentasjon.inngåttEkteskap.tittel': 'Dokumentasjon på inngått ekteskap',
-    'dokumentasjon.inngåttEkteskap.beskrivelse':
-      'Beskrivelse for inngått ekteskap',
     'dokumentasjon.separasjonEllerSkilsmisse.tittel':
       'Dokumentasjon på separasjon eller skilsmisse',
     'dokumentasjon.separasjonEllerSkilsmisse.beskrivelse':

--- a/src/søknad/steg/7-oppsummering/OppsummeringBarnaDine.tsx
+++ b/src/søknad/steg/7-oppsummering/OppsummeringBarnaDine.tsx
@@ -46,7 +46,7 @@ const OppsummeringBarnaDine: React.FC<Props> = ({
     const endretBarn = hentEndretBarn(barn);
 
     return (
-      <StyledOppsummeringForBarn>
+      <StyledOppsummeringForBarn key={barn.id}>
         <BarneHeader barn={barn} />
         <OppsummeringBarn stønadstype={stønadstype} barn={endretBarn} />
       </StyledOppsummeringForBarn>

--- a/src/søknad/steg/7-oppsummering/OppsummeringBarnasBosituasjon.tsx
+++ b/src/søknad/steg/7-oppsummering/OppsummeringBarnasBosituasjon.tsx
@@ -40,7 +40,7 @@ const OppsummeringBarnasBosituasjon: FC<Props> = ({
       const forelderFelter = VisLabelOgSvar(nyForelder, barnetsNavn);
 
       return (
-        <StyledOppsummeringForBarn>
+        <StyledOppsummeringForBarn key={barn.id}>
           <BarneHeader barn={barn} />
           {forelderFelter}
         </StyledOppsummeringForBarn>


### PR DESCRIPTION
- Fjerner noen warnings pga. at de trengte key value. 
- Endrer tekst: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-2157
- Endre tekst: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-2374

Når hjelpetekst sin åpningstekst gikk over to linjer ble den litt weird: 

![Skjermbilde 2020-09-30 kl  14 52 11](https://user-images.githubusercontent.com/8249453/94695443-34917f80-0336-11eb-9f73-678eff0792dd.png)


Har tatt det opp med Tuva, og kommer med styling endringer i en annen nanoPR  maybe :)
