### PR TITLE
Utvid ISpørsmålListeFelt til å ha svarsalternativer

### DIFF
--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -11,7 +11,7 @@ import {
 } from '../helpers/steg/dokumentasjon';
 import { IMellomlagretBarnetilsynSøknad } from './models/mellomlagretSøknad';
 import Environment from '../Environment';
-import { useIntl } from 'react-intl';
+import { IntlShape, useIntl } from 'react-intl';
 import { EArbeidssituasjon } from '../models/steg/aktivitet/aktivitet';
 import {
   hentMellomlagretSøknadFraDokument,
@@ -21,9 +21,11 @@ import {
 import { MellomlagredeStønadstyper } from '../models/søknad/stønadstyper';
 import { IPerson } from '../models/søknad/person';
 import { IBarn } from '../models/steg/barn';
+import { oversettSvarsalternativer } from '../utils/spørsmålogsvar';
+import { hvaErDinArbeidssituasjonSpm } from './steg/5-aktivitet/AktivitetConfig';
 
 // -----------  CONTEXT  -----------
-const initialState = (): ISøknad => {
+const initialState = (intl: IntlShape): ISøknad => {
   return {
     person: tomPerson,
     sivilstatus: {},
@@ -42,6 +44,10 @@ const initialState = (): ISøknad => {
         svarid: [],
         label: '',
         verdi: [],
+        alternativer: oversettSvarsalternativer(
+          hvaErDinArbeidssituasjonSpm(intl).svaralternativer,
+          intl
+        ),
       },
     },
     dokumentasjonsbehov: [],
@@ -51,12 +57,11 @@ const initialState = (): ISøknad => {
 
 const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
   () => {
-    const [søknad, settSøknad] = useState<ISøknad>(initialState());
-
+    const intl = useIntl();
+    const [søknad, settSøknad] = useState<ISøknad>(initialState(intl));
     const [mellomlagretBarnetilsyn, settMellomlagretBarnetilsyn] = useState<
       IMellomlagretBarnetilsynSøknad
     >();
-    const intl = useIntl();
 
     const hentMellomlagretBarnetilsyn = (): Promise<void> => {
       return hentMellomlagretSøknadFraDokument<IMellomlagretBarnetilsynSøknad>(
@@ -98,7 +103,7 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
       barnMedLabels: IBarn[]
     ) => {
       settSøknad({
-        ...initialState(),
+        ...initialState(intl),
         person: { ...person, barn: barnMedLabels },
       });
       settMellomlagretBarnetilsyn(undefined);

--- a/src/barnetilsyn/steg/5-aktivitet/Aktivitet.tsx
+++ b/src/barnetilsyn/steg/5-aktivitet/Aktivitet.tsx
@@ -73,6 +73,8 @@ const Aktivitet: React.FC = () => {
           svarid: [],
           label: '',
           verdi: [],
+          alternativer:
+            endretArbeidssituasjon.hvaErDinArbeidssituasjon.alternativer,
         },
       };
     }
@@ -96,8 +98,7 @@ const Aktivitet: React.FC = () => {
     const { avhukedeSvar, svarider } = returnerAvhukedeSvar(
       hvaErDinArbeidssituasjon,
       svarHuketAv,
-      svar,
-      intl
+      svar
     );
 
     const endretArbeidssituasjon = fjernAktivitet(svarider, arbeidssituasjon);
@@ -109,6 +110,8 @@ const Aktivitet: React.FC = () => {
         svarid: svarider,
         label: hentTekst(spørsmål.tekstid, intl),
         verdi: avhukedeSvar,
+        alternativer:
+          endretArbeidssituasjon.hvaErDinArbeidssituasjon.alternativer,
       },
     });
     settDokumentasjonsbehov(spørsmål, svar, svarHuketAv);

--- a/src/context/SøknadContext.tsx
+++ b/src/context/SøknadContext.tsx
@@ -18,14 +18,17 @@ import {
 } from '../utils/søknad';
 import { IMellomlagretOvergangsstønad } from '../models/søknad/mellomlagretSøknad';
 import Environment from '../Environment';
-import { useIntl } from 'react-intl';
+import { IntlShape, useIntl } from 'react-intl';
 import { MellomlagredeStønadstyper } from '../models/søknad/stønadstyper';
 import { IBarn } from '../models/steg/barn';
 import { oppdaterBarneliste } from '../utils/barn';
 import { IPerson } from '../models/søknad/person';
+import { oversettSvarsalternativer } from '../utils/spørsmålogsvar';
+import { gjelderNoeAvDetteDeg } from '../søknad/steg/6-meromsituasjon/SituasjonConfig';
+import { hvaErDinArbeidssituasjonSpm } from '../søknad/steg/5-aktivitet/AktivitetConfig';
 
 // -----------  CONTEXT  -----------
-const initialState = (): ISøknad => {
+const initialState = (intl: IntlShape): ISøknad => {
   return {
     person: tomPerson,
     sivilstatus: {},
@@ -44,6 +47,10 @@ const initialState = (): ISøknad => {
         svarid: [],
         label: '',
         verdi: [],
+        alternativer: oversettSvarsalternativer(
+          hvaErDinArbeidssituasjonSpm(intl).svaralternativer,
+          intl
+        ),
       },
     },
     merOmDinSituasjon: {
@@ -52,6 +59,10 @@ const initialState = (): ISøknad => {
         svarid: [],
         label: '',
         verdi: [],
+        alternativer: oversettSvarsalternativer(
+          gjelderNoeAvDetteDeg(intl).svaralternativer,
+          intl
+        ),
       },
     },
     dokumentasjonsbehov: [],
@@ -60,12 +71,13 @@ const initialState = (): ISøknad => {
 };
 
 const [SøknadProvider, useSøknad] = createUseContext(() => {
-  const [søknad, settSøknad] = useState<ISøknad>(initialState());
+  const intl = useIntl();
+  const [søknad, settSøknad] = useState<ISøknad>(initialState(intl));
+
   const [
     mellomlagretOvergangsstønad,
     settMellomlagretOvergangsstønad,
   ] = useState<IMellomlagretOvergangsstønad>();
-  const intl = useIntl();
 
   const hentMellomlagretOvergangsstønad = (): Promise<void> => {
     return hentMellomlagretSøknadFraDokument<IMellomlagretOvergangsstønad>(
@@ -107,7 +119,7 @@ const [SøknadProvider, useSøknad] = createUseContext(() => {
     barnMedLabels: IBarn[]
   ) => {
     settSøknad({
-      ...initialState(),
+      ...initialState(intl),
       person: { ...person, barn: barnMedLabels },
     });
     settMellomlagretOvergangsstønad(undefined);

--- a/src/helpers/tommeSøknadsfelter.ts
+++ b/src/helpers/tommeSøknadsfelter.ts
@@ -27,6 +27,7 @@ export const nyttSpørsmålListeFelt: ISpørsmålListeFelt = {
   svarid: [],
   label: '',
   verdi: [],
+  alternativer: [],
 };
 
 export const nyttTekstFelt: ITekstFelt = {

--- a/src/models/søknad/søknadsfelter.ts
+++ b/src/models/søknad/søknadsfelter.ts
@@ -31,4 +31,5 @@ export interface ISpørsmålBooleanFelt extends IBooleanFelt {
 export interface ISpørsmålListeFelt extends ITekstListeFelt {
   spørsmålid: string;
   svarid: string[];
+  alternativer: string[];
 }

--- a/src/overgangsstønad/steg/5-aktivitet/Aktivitet.tsx
+++ b/src/overgangsstønad/steg/5-aktivitet/Aktivitet.tsx
@@ -65,8 +65,7 @@ const Aktivitet: React.FC = () => {
     const { avhukedeSvar, svarider } = returnerAvhukedeSvar(
       hvaErDinArbeidssituasjon,
       svarHuketAv,
-      svar,
-      intl
+      svar
     );
 
     const endretArbeidssituasjon = fjernAktivitet(svarider, arbeidssituasjon);

--- a/src/overgangsstønad/steg/6-meromsituasjon/MerOmDinSituasjon.tsx
+++ b/src/overgangsstønad/steg/6-meromsituasjon/MerOmDinSituasjon.tsx
@@ -125,8 +125,7 @@ const MerOmDinSituasjon: React.FC = () => {
     const { avhukedeSvar, svarider } = returnerAvhukedeSvar(
       dinSituasjon.gjelderDetteDeg,
       svarHuketAv,
-      svar,
-      intl
+      svar
     );
 
     settDinSituasjon({
@@ -136,6 +135,7 @@ const MerOmDinSituasjon: React.FC = () => {
         svarid: svarider,
         label: spørsmålTekst,
         verdi: avhukedeSvar,
+        alternativer: dinSituasjon.gjelderDetteDeg.alternativer,
       },
     });
     settDokumentasjonsbehov(spørsmål, svar, svarHuketAv);

--- a/src/utils/spørsmålogsvar.ts
+++ b/src/utils/spørsmålogsvar.ts
@@ -1,6 +1,7 @@
 import { ESvar, ISvar } from '../models/felles/spørsmålogsvar';
 import { IntlShape } from 'react-intl';
 import { ISpørsmålListeFelt } from '../models/søknad/søknadsfelter';
+import { hentTekst } from './søknad';
 
 export const hentBooleanFraValgtSvar = (valgtSvar: ISvar) =>
   valgtSvar.id === ESvar.JA;
@@ -35,8 +36,7 @@ export const erValgtSvarLiktSomSvar = (
 export const returnerAvhukedeSvar = (
   spørsmålliste: ISpørsmålListeFelt,
   erHuketAv: boolean,
-  svar: ISvar,
-  intl: IntlShape
+  svar: ISvar
 ) => {
   let avhukedeSvar: string[] = spørsmålliste.verdi;
   let svarider: string[] = spørsmålliste.svarid;
@@ -54,4 +54,11 @@ export const returnerAvhukedeSvar = (
     svarider.push(svar.id);
   }
   return { avhukedeSvar, svarider };
+};
+
+export const oversettSvarsalternativer = (
+  svarsalternativer: ISvar[],
+  intl: IntlShape
+): string[] => {
+  return svarsalternativer.map((svar) => hentTekst(svar.svar_tekst, intl));
 };


### PR DESCRIPTION
ref dette [kortet](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-2602)

- Legg til alternativer i ISpørsmålListeFelt slik at det blir lettere å vite hva bruker har svart på i pdfen. 
(`verdi` er de valgte svarsalternativene, mens `alternativer` er alle tilgjengelige svarsalternativer.)
<img width="552" alt="Skjermbilde 2020-10-30 kl  13 13 58" src="https://user-images.githubusercontent.com/8249453/97705396-4fc9e900-1ab4-11eb-9e24-3926f3ecb72f.png">
 

