### PR TITLE
Tracking av sidevisning på søknader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12834,7 +12834,8 @@
         },
         "dot-prop": {
           "version": "4.2.0",
-          "resolved": "",
+          "resolved": false,
+          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
           "requires": {
             "is-obj": "^1.0.0"
           }
@@ -13455,7 +13456,7 @@
         },
         "is-ci": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
           "requires": {
             "ci-info": "^1.0.0"
@@ -13526,7 +13527,7 @@
         },
         "is-retry-allowed": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
         },
         "is-stream": {
@@ -13935,7 +13936,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "minizlib": {
           "version": "1.3.3",
@@ -14471,7 +14473,7 @@
         },
         "rc": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+          "resolved": false,
           "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "requires": {
             "deep-extend": "^0.5.1",
@@ -14562,7 +14564,7 @@
         },
         "registry-auth-token": {
           "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+          "resolved": false,
           "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
           "requires": {
             "rc": "^1.1.6",
@@ -14805,7 +14807,7 @@
         },
         "spdx-license-ids": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+          "resolved": false,
           "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
         },
         "split-on-first": {
@@ -15225,7 +15227,7 @@
         },
         "widest-line": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
           "requires": {
             "string-width": "^2.1.1"

--- a/src/arbeidssøkerskjema/Forside.tsx
+++ b/src/arbeidssøkerskjema/Forside.tsx
@@ -25,7 +25,7 @@ import { hentPath } from '../utils/routing';
 import Språkvelger from '../components/språkvelger/Språkvelger';
 import { ToggleName } from '../models/søknad/toggles';
 import { useToggles } from '../context/TogglesContext';
-import { logEvent } from '../utils/amplitude';
+import { logSidevisningArbeidssokerskjema } from '../utils/amplitude';
 
 const BlockContent = require('@sanity/block-content-to-react');
 
@@ -38,11 +38,7 @@ const Forside: React.FC<any> = ({ intl }) => {
   const { skjema, settSkjema } = useSkjema();
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Forside',
-      team: 'familie',
-      app: 'Arbeidssokerskjema',
-    });
+    logSidevisningArbeidssokerskjema('Forside');
   }, []);
 
   const settBekreftelse = (bekreftelse: boolean) => {

--- a/src/arbeidssøkerskjema/Forside.tsx
+++ b/src/arbeidssøkerskjema/Forside.tsx
@@ -25,7 +25,7 @@ import { hentPath } from '../utils/routing';
 import Språkvelger from '../components/språkvelger/Språkvelger';
 import { ToggleName } from '../models/søknad/toggles';
 import { useToggles } from '../context/TogglesContext';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../utils/amplitude';
 
 const BlockContent = require('@sanity/block-content-to-react');
 

--- a/src/arbeidssøkerskjema/Forside.tsx
+++ b/src/arbeidssøkerskjema/Forside.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Panel } from 'nav-frontend-paneler';
 import FeltGruppe from '../components/gruppe/FeltGruppe';
 import { BekreftCheckboksPanel } from 'nav-frontend-skjema';
@@ -25,6 +25,7 @@ import { hentPath } from '../utils/routing';
 import Språkvelger from '../components/språkvelger/Språkvelger';
 import { ToggleName } from '../models/søknad/toggles';
 import { useToggles } from '../context/TogglesContext';
+import { logEvent } from 'amplitude-js';
 
 const BlockContent = require('@sanity/block-content-to-react');
 
@@ -35,6 +36,14 @@ const Forside: React.FC<any> = ({ intl }) => {
   const { toggles } = useToggles();
 
   const { skjema, settSkjema } = useSkjema();
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'Forside',
+      team: 'familie',
+      app: 'Arbeidssokerskjema',
+    });
+  }, []);
 
   const settBekreftelse = (bekreftelse: boolean) => {
     settSkjema({

--- a/src/arbeidssøkerskjema/Forside.tsx
+++ b/src/arbeidssøkerskjema/Forside.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Panel } from 'nav-frontend-paneler';
 import FeltGruppe from '../components/gruppe/FeltGruppe';
 import { BekreftCheckboksPanel } from 'nav-frontend-skjema';
@@ -26,6 +26,7 @@ import Språkvelger from '../components/språkvelger/Språkvelger';
 import { ToggleName } from '../models/søknad/toggles';
 import { useToggles } from '../context/TogglesContext';
 import { logSidevisningArbeidssokerskjema } from '../utils/amplitude';
+import { useMount } from '../utils/hooks';
 
 const BlockContent = require('@sanity/block-content-to-react');
 
@@ -37,9 +38,7 @@ const Forside: React.FC<any> = ({ intl }) => {
 
   const { skjema, settSkjema } = useSkjema();
 
-  useEffect(() => {
-    logSidevisningArbeidssokerskjema('Forside');
-  }, []);
+  useMount(() => logSidevisningArbeidssokerskjema('Forside'));
 
   const settBekreftelse = (bekreftelse: boolean) => {
     settSkjema({

--- a/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
+++ b/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
@@ -29,7 +29,7 @@ import {
 } from '../routes/routesArbeidssokerskjema';
 import { hentPath } from '../../utils/routing';
 import { LocationStateSøknad } from '../../models/søknad/søknad';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../utils/amplitude';
 
 const Spørsmål: FC = () => {
   const location = useLocation<LocationStateSøknad>();

--- a/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
+++ b/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import Side from '../side/Side';
 import { useIntl } from 'react-intl';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -29,6 +29,7 @@ import {
 } from '../routes/routesArbeidssokerskjema';
 import { hentPath } from '../../utils/routing';
 import { LocationStateSøknad } from '../../models/søknad/søknad';
+import { logEvent } from 'amplitude-js';
 
 const Spørsmål: FC = () => {
   const location = useLocation<LocationStateSøknad>();
@@ -37,6 +38,14 @@ const Spørsmål: FC = () => {
   const intl = useIntl();
   const { skjema, settSkjema } = useSkjema();
   const [arbeidssøker, settArbeidssøker] = React.useState(skjema.arbeidssøker);
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'Forside',
+      team: 'familie',
+      app: 'Arbeidssokerskjema',
+    });
+  }, []);
 
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
 

--- a/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
+++ b/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
 import Side from '../side/Side';
 import { useIntl } from 'react-intl';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -30,6 +30,7 @@ import {
 import { hentPath } from '../../utils/routing';
 import { LocationStateSøknad } from '../../models/søknad/søknad';
 import { logSidevisningArbeidssokerskjema } from '../../utils/amplitude';
+import { useMount } from '../../utils/hooks';
 
 const Spørsmål: FC = () => {
   const location = useLocation<LocationStateSøknad>();
@@ -39,9 +40,7 @@ const Spørsmål: FC = () => {
   const { skjema, settSkjema } = useSkjema();
   const [arbeidssøker, settArbeidssøker] = React.useState(skjema.arbeidssøker);
 
-  useEffect(() => {
-    logSidevisningArbeidssokerskjema('OmArbeidssoker');
-  }, []);
+  useMount(() => logSidevisningArbeidssokerskjema('OmArbeidssoker'));
 
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
 

--- a/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
+++ b/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
@@ -29,7 +29,7 @@ import {
 } from '../routes/routesArbeidssokerskjema';
 import { hentPath } from '../../utils/routing';
 import { LocationStateSøknad } from '../../models/søknad/søknad';
-import { logEvent } from '../../utils/amplitude';
+import { logSidevisningArbeidssokerskjema } from '../../utils/amplitude';
 
 const Spørsmål: FC = () => {
   const location = useLocation<LocationStateSøknad>();
@@ -40,11 +40,7 @@ const Spørsmål: FC = () => {
   const [arbeidssøker, settArbeidssøker] = React.useState(skjema.arbeidssøker);
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Forside',
-      team: 'familie',
-      app: 'Arbeidssokerskjema',
-    });
+    logSidevisningArbeidssokerskjema('OmArbeidssoker');
   }, []);
 
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;

--- a/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
+++ b/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import Side from '../side/Side';
 import { useIntl } from 'react-intl';
 import endre from '../../assets/endre.svg';
@@ -30,6 +30,7 @@ import {
 } from '../../utils/routing';
 import { LocationStateSøknad } from '../../models/søknad/søknad';
 import { logSidevisningArbeidssokerskjema } from '../../utils/amplitude';
+import { useMount } from '../../utils/hooks';
 
 interface Innsending {
   status: IStatus;
@@ -57,9 +58,7 @@ const Oppsummering: React.FC = () => {
   );
   const spørsmålOgSvar = VisLabelOgSvar(skjema.arbeidssøker);
 
-  useEffect(() => {
-    logSidevisningArbeidssokerskjema('Oppsummering');
-  }, []);
+  useMount(() => logSidevisningArbeidssokerskjema('Oppsummering'));
 
   const sendSkjema = (arbeidssøker: IArbeidssøker) => {
     const mappetSkjema = mapDataTilLabelOgVerdiTyper(arbeidssøker);

--- a/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
+++ b/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
@@ -29,7 +29,7 @@ import {
   hentPath,
 } from '../../utils/routing';
 import { LocationStateSøknad } from '../../models/søknad/søknad';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../utils/amplitude';
 
 interface Innsending {
   status: IStatus;

--- a/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
+++ b/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Side from '../side/Side';
 import { useIntl } from 'react-intl';
 import endre from '../../assets/endre.svg';
@@ -29,6 +29,7 @@ import {
   hentPath,
 } from '../../utils/routing';
 import { LocationStateSøknad } from '../../models/søknad/søknad';
+import { logEvent } from 'amplitude-js';
 
 interface Innsending {
   status: IStatus;
@@ -55,6 +56,14 @@ const Oppsummering: React.FC = () => {
     location.pathname
   );
   const spørsmålOgSvar = VisLabelOgSvar(skjema.arbeidssøker);
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'Oppsummering',
+      team: 'familie',
+      app: 'Arbeidssokerskjema',
+    });
+  }, []);
 
   const sendSkjema = (arbeidssøker: IArbeidssøker) => {
     const mappetSkjema = mapDataTilLabelOgVerdiTyper(arbeidssøker);

--- a/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
+++ b/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
@@ -29,7 +29,7 @@ import {
   hentPath,
 } from '../../utils/routing';
 import { LocationStateSøknad } from '../../models/søknad/søknad';
-import { logEvent } from '../../utils/amplitude';
+import { logSidevisningArbeidssokerskjema } from '../../utils/amplitude';
 
 interface Innsending {
   status: IStatus;
@@ -58,11 +58,7 @@ const Oppsummering: React.FC = () => {
   const spørsmålOgSvar = VisLabelOgSvar(skjema.arbeidssøker);
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Oppsummering',
-      team: 'familie',
-      app: 'Arbeidssokerskjema',
-    });
+    logSidevisningArbeidssokerskjema('Oppsummering');
   }, []);
 
   const sendSkjema = (arbeidssøker: IArbeidssøker) => {

--- a/src/arbeidssøkerskjema/steg/3-Kvittering.tsx
+++ b/src/arbeidssøkerskjema/steg/3-Kvittering.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Side from '../side/Side';
 import { useIntl } from 'react-intl';
 import AlertStripe from 'nav-frontend-alertstriper';
@@ -12,6 +12,7 @@ import Feilside from '../../components/feil/Feilside';
 import Lenke from 'nav-frontend-lenker';
 import FeltGruppe from '../../components/gruppe/FeltGruppe';
 import styled from 'styled-components/macro';
+import { logEvent } from 'amplitude-js';
 
 const StyledBeskrivelse = styled.div`
   .typo-normal {
@@ -24,6 +25,14 @@ const StyledBeskrivelse = styled.div`
 const Kvittering: React.FC = () => {
   const intl = useIntl();
   const { skjema } = useSkjema();
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'Forside',
+      team: 'familie',
+      app: 'Kvittering',
+    });
+  }, []);
 
   const mottattAlert: string =
     hentTekst('skjema.alert.mottatt', intl) +

--- a/src/arbeidssøkerskjema/steg/3-Kvittering.tsx
+++ b/src/arbeidssøkerskjema/steg/3-Kvittering.tsx
@@ -12,7 +12,7 @@ import Feilside from '../../components/feil/Feilside';
 import Lenke from 'nav-frontend-lenker';
 import FeltGruppe from '../../components/gruppe/FeltGruppe';
 import styled from 'styled-components/macro';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../utils/amplitude';
 
 const StyledBeskrivelse = styled.div`
   .typo-normal {

--- a/src/arbeidssøkerskjema/steg/3-Kvittering.tsx
+++ b/src/arbeidssøkerskjema/steg/3-Kvittering.tsx
@@ -12,7 +12,7 @@ import Feilside from '../../components/feil/Feilside';
 import Lenke from 'nav-frontend-lenker';
 import FeltGruppe from '../../components/gruppe/FeltGruppe';
 import styled from 'styled-components/macro';
-import { logEvent } from '../../utils/amplitude';
+import { logSidevisningArbeidssokerskjema } from '../../utils/amplitude';
 
 const StyledBeskrivelse = styled.div`
   .typo-normal {
@@ -27,11 +27,7 @@ const Kvittering: React.FC = () => {
   const { skjema } = useSkjema();
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Forside',
-      team: 'familie',
-      app: 'Kvittering',
-    });
+    logSidevisningArbeidssokerskjema('Kvittering');
   }, []);
 
   const mottattAlert: string =

--- a/src/arbeidssøkerskjema/steg/3-Kvittering.tsx
+++ b/src/arbeidssøkerskjema/steg/3-Kvittering.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import Side from '../side/Side';
 import { useIntl } from 'react-intl';
 import AlertStripe from 'nav-frontend-alertstriper';
@@ -13,6 +13,7 @@ import Lenke from 'nav-frontend-lenker';
 import FeltGruppe from '../../components/gruppe/FeltGruppe';
 import styled from 'styled-components/macro';
 import { logSidevisningArbeidssokerskjema } from '../../utils/amplitude';
+import { useMount } from '../../utils/hooks';
 
 const StyledBeskrivelse = styled.div`
   .typo-normal {
@@ -26,9 +27,7 @@ const Kvittering: React.FC = () => {
   const intl = useIntl();
   const { skjema } = useSkjema();
 
-  useEffect(() => {
-    logSidevisningArbeidssokerskjema('Kvittering');
-  }, []);
+  useMount(() => logSidevisningArbeidssokerskjema('Kvittering'));
 
   const mottattAlert: string =
     hentTekst('skjema.alert.mottatt', intl) +

--- a/src/barnetilsyn/Forside.tsx
+++ b/src/barnetilsyn/Forside.tsx
@@ -18,6 +18,7 @@ import {
 import Forsideinformasjon from '../søknad/forside/Forsideinformasjon';
 import { hentPath } from '../utils/routing';
 import LocaleTekst from '../language/LocaleTekst';
+import { logEvent } from 'amplitude-js';
 
 const Forside: React.FC<any> = ({ intl }) => {
   useEffect(() => {

--- a/src/barnetilsyn/Forside.tsx
+++ b/src/barnetilsyn/Forside.tsx
@@ -18,7 +18,7 @@ import {
 import Forsideinformasjon from '../søknad/forside/Forsideinformasjon';
 import { hentPath } from '../utils/routing';
 import LocaleTekst from '../language/LocaleTekst';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../utils/amplitude';
 
 const Forside: React.FC<any> = ({ intl }) => {
   useEffect(() => {

--- a/src/barnetilsyn/Forside.tsx
+++ b/src/barnetilsyn/Forside.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Panel } from 'nav-frontend-paneler';
 import { Sidetittel } from 'nav-frontend-typografi';
 import { usePersonContext } from '../context/PersonContext';
@@ -19,11 +19,10 @@ import Forsideinformasjon from '../søknad/forside/Forsideinformasjon';
 import { hentPath } from '../utils/routing';
 import LocaleTekst from '../language/LocaleTekst';
 import { logSidevisningBarnetilsyn } from '../utils/amplitude';
+import { useMount } from '../utils/hooks';
 
 const Forside: React.FC<any> = ({ intl }) => {
-  useEffect(() => {
-    logSidevisningBarnetilsyn('Forside');
-  }, []);
+  useMount(() => logSidevisningBarnetilsyn('Forside'));
 
   const { person } = usePersonContext();
   const [locale] = useSpråkContext();

--- a/src/barnetilsyn/Forside.tsx
+++ b/src/barnetilsyn/Forside.tsx
@@ -18,15 +18,11 @@ import {
 import Forsideinformasjon from '../søknad/forside/Forsideinformasjon';
 import { hentPath } from '../utils/routing';
 import LocaleTekst from '../language/LocaleTekst';
-import { logEvent } from '../utils/amplitude';
+import { logSidevisningBarnetilsyn } from '../utils/amplitude';
 
 const Forside: React.FC<any> = ({ intl }) => {
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Kvittering',
-      team: 'familie',
-      app: 'OS-soknadsdialog',
-    });
+    logSidevisningBarnetilsyn('Forside');
   }, []);
 
   const { person } = usePersonContext();

--- a/src/barnetilsyn/Forside.tsx
+++ b/src/barnetilsyn/Forside.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Panel } from 'nav-frontend-paneler';
 import { Sidetittel } from 'nav-frontend-typografi';
 import { usePersonContext } from '../context/PersonContext';
@@ -20,6 +20,14 @@ import { hentPath } from '../utils/routing';
 import LocaleTekst from '../language/LocaleTekst';
 
 const Forside: React.FC<any> = ({ intl }) => {
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'Kvittering',
+      team: 'familie',
+      app: 'OS-soknadsdialog',
+    });
+  }, []);
+
   const { person } = usePersonContext();
   const [locale] = useSpråkContext();
   const {

--- a/src/barnetilsyn/steg/1-omdeg/OmDeg.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/OmDeg.tsx
@@ -20,7 +20,7 @@ import { hentPathBarnetilsynOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import Show from '../../../utils/showIf';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../../utils/amplitude';
 
 const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
   useEffect(() => {

--- a/src/barnetilsyn/steg/1-omdeg/OmDeg.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/OmDeg.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
 import { injectIntl, IntlShape } from 'react-intl';
 import { useLocation } from 'react-router-dom';
 import {
@@ -21,11 +21,10 @@ import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import Show from '../../../utils/showIf';
 import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
-  useEffect(() => {
-    logSidevisningBarnetilsyn('OmDeg');
-  }, []);
+  useMount(() => logSidevisningBarnetilsyn('OmDeg'));
 
   const location = useLocation<LocationStateSøknad>();
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;

--- a/src/barnetilsyn/steg/1-omdeg/OmDeg.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/OmDeg.tsx
@@ -20,15 +20,11 @@ import { hentPathBarnetilsynOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import Show from '../../../utils/showIf';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 
 const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'OmDeg',
-      team: 'familie',
-      app: 'BT-soknadsdialog',
-    });
+    logSidevisningBarnetilsyn('OmDeg');
   }, []);
 
   const location = useLocation<LocationStateSøknad>();

--- a/src/barnetilsyn/steg/1-omdeg/OmDeg.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/OmDeg.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import { injectIntl, IntlShape } from 'react-intl';
 import { useLocation } from 'react-router-dom';
 import {
@@ -20,8 +20,17 @@ import { hentPathBarnetilsynOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import Show from '../../../utils/showIf';
+import { logEvent } from 'amplitude-js';
 
 const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'OmDeg',
+      team: 'familie',
+      app: 'BT-soknadsdialog',
+    });
+  }, []);
+
   const location = useLocation<LocationStateSøknad>();
   const kommerFraOppsummering = location.state?.kommerFraOppsummering;
   const skalViseKnapper = !kommerFraOppsummering

--- a/src/barnetilsyn/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/barnetilsyn/steg/2-bosituasjon/Bosituasjon.tsx
@@ -10,7 +10,7 @@ import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
 import { hentPathBarnetilsynOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../../utils/amplitude';
 
 const Bosituasjon: FC = () => {
   useEffect(() => {

--- a/src/barnetilsyn/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/barnetilsyn/steg/2-bosituasjon/Bosituasjon.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import { IBosituasjon } from '../../../models/steg/bosituasjon';
 import { useLocation } from 'react-router-dom';
@@ -10,8 +10,17 @@ import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
 import { hentPathBarnetilsynOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
+import { logEvent } from 'amplitude-js';
 
 const Bosituasjon: FC = () => {
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'Bosituasjon',
+      team: 'familie',
+      app: 'BT-soknadsdialog',
+    });
+  }, []);
+
   const intl = useIntl();
   const {
     søknad,

--- a/src/barnetilsyn/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/barnetilsyn/steg/2-bosituasjon/Bosituasjon.tsx
@@ -10,15 +10,11 @@ import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
 import { hentPathBarnetilsynOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 
 const Bosituasjon: FC = () => {
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Bosituasjon',
-      team: 'familie',
-      app: 'BT-soknadsdialog',
-    });
+    logSidevisningBarnetilsyn('Bosituasjon');
   }, []);
 
   const intl = useIntl();

--- a/src/barnetilsyn/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/barnetilsyn/steg/2-bosituasjon/Bosituasjon.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
 import { useIntl } from 'react-intl';
 import { IBosituasjon } from '../../../models/steg/bosituasjon';
 import { useLocation } from 'react-router-dom';
@@ -11,11 +11,10 @@ import { hentPathBarnetilsynOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const Bosituasjon: FC = () => {
-  useEffect(() => {
-    logSidevisningBarnetilsyn('Bosituasjon');
-  }, []);
+  useMount(() => logSidevisningBarnetilsyn('Bosituasjon'));
 
   const intl = useIntl();
   const {

--- a/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
+++ b/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Hovedknapp, Knapp } from 'nav-frontend-knapper';
 import Modal from 'nav-frontend-modal';
 import { AlertStripeInfo } from 'nav-frontend-alertstriper';
@@ -20,11 +20,10 @@ import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import LocaleTekst from '../../../language/LocaleTekst';
 import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const BarnaDine: React.FC = () => {
-  useEffect(() => {
-    logSidevisningBarnetilsyn('BarnaDine');
-  }, []);
+  useMount(() => logSidevisningBarnetilsyn('BarnaDine'));
 
   const intl = useIntl();
   const {

--- a/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
+++ b/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Hovedknapp, Knapp } from 'nav-frontend-knapper';
 import Modal from 'nav-frontend-modal';
 import { AlertStripeInfo } from 'nav-frontend-alertstriper';
@@ -19,8 +19,17 @@ import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import LocaleTekst from '../../../language/LocaleTekst';
+import { logEvent } from 'amplitude-js';
 
 const BarnaDine: React.FC = () => {
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'BarnaDine',
+      team: 'familie',
+      app: 'BT-soknadsdialog',
+    });
+  }, []);
+
   const intl = useIntl();
   const {
     søknad,

--- a/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
+++ b/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
@@ -19,7 +19,7 @@ import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import LocaleTekst from '../../../language/LocaleTekst';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../../utils/amplitude';
 
 const BarnaDine: React.FC = () => {
   useEffect(() => {

--- a/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
+++ b/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
@@ -19,15 +19,11 @@ import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import LocaleTekst from '../../../language/LocaleTekst';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 
 const BarnaDine: React.FC = () => {
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'BarnaDine',
-      team: 'familie',
-      app: 'BT-soknadsdialog',
-    });
+    logSidevisningBarnetilsyn('BarnaDine');
   }, []);
 
   const intl = useIntl();

--- a/src/barnetilsyn/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/BarnasBosted.tsx
@@ -11,7 +11,7 @@ import { hentPathBarnetilsynOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../../utils/amplitude';
 
 const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
   if (!ref || !ref.current) return;

--- a/src/barnetilsyn/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/BarnasBosted.tsx
@@ -11,7 +11,7 @@ import { hentPathBarnetilsynOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 
 const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
   if (!ref || !ref.current) return;
@@ -29,11 +29,7 @@ const BarnasBosted: React.FC = () => {
   } = useBarnetilsynSøknad();
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'BarnasBosted',
-      team: 'familie',
-      app: 'BT-soknadsdialog',
-    });
+    logSidevisningBarnetilsyn('BarnasBosted');
   }, []);
 
   const settBarneliste = (nyBarneListe: IBarn[]) => {

--- a/src/barnetilsyn/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/BarnasBosted.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useRef, useState, useEffect } from 'react';
+import React, { RefObject, useRef, useState } from 'react';
 import { hentTekst } from '../../../utils/søknad';
 import { useLocation } from 'react-router-dom';
 import { useIntl } from 'react-intl';
@@ -12,6 +12,7 @@ import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
   if (!ref || !ref.current) return;
@@ -28,9 +29,7 @@ const BarnasBosted: React.FC = () => {
     settDokumentasjonsbehovForBarn,
   } = useBarnetilsynSøknad();
 
-  useEffect(() => {
-    logSidevisningBarnetilsyn('BarnasBosted');
-  }, []);
+  useMount(() => logSidevisningBarnetilsyn('BarnasBosted'));
 
   const settBarneliste = (nyBarneListe: IBarn[]) => {
     settSøknad((prevSoknad) => {

--- a/src/barnetilsyn/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/BarnasBosted.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useRef, useState } from 'react';
+import React, { RefObject, useRef, useState, useEffect } from 'react';
 import { hentTekst } from '../../../utils/søknad';
 import { useLocation } from 'react-router-dom';
 import { useIntl } from 'react-intl';
@@ -11,11 +11,20 @@ import { hentPathBarnetilsynOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
+import { logEvent } from 'amplitude-js';
 
 const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
   if (!ref || !ref.current) return;
   window.scrollTo({ top: ref.current!.offsetTop, left: 0, behavior: 'smooth' });
 };
+
+useEffect(() => {
+  logEvent('sidevisning', {
+    side: 'BarnasBosted',
+    team: 'familie',
+    app: 'BT-soknadsdialog',
+  });
+}, []);
 
 const BarnasBosted: React.FC = () => {
   const intl = useIntl();

--- a/src/barnetilsyn/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/BarnasBosted.tsx
@@ -18,14 +18,6 @@ const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
   window.scrollTo({ top: ref.current!.offsetTop, left: 0, behavior: 'smooth' });
 };
 
-useEffect(() => {
-  logEvent('sidevisning', {
-    side: 'BarnasBosted',
-    team: 'familie',
-    app: 'BT-soknadsdialog',
-  });
-}, []);
-
 const BarnasBosted: React.FC = () => {
   const intl = useIntl();
   const location = useLocation<LocationStateSøknad>();
@@ -35,6 +27,14 @@ const BarnasBosted: React.FC = () => {
     settSøknad,
     settDokumentasjonsbehovForBarn,
   } = useBarnetilsynSøknad();
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'BarnasBosted',
+      team: 'familie',
+      app: 'BT-soknadsdialog',
+    });
+  }, []);
 
   const settBarneliste = (nyBarneListe: IBarn[]) => {
     settSøknad((prevSoknad) => {

--- a/src/barnetilsyn/steg/5-aktivitet/Aktivitet.tsx
+++ b/src/barnetilsyn/steg/5-aktivitet/Aktivitet.tsx
@@ -30,7 +30,7 @@ import { hentPathBarnetilsynOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 
 const Aktivitet: React.FC = () => {
   const intl = useIntl();
@@ -55,11 +55,7 @@ const Aktivitet: React.FC = () => {
   }, [arbeidssituasjon]);
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Aktivitet',
-      team: 'familie',
-      app: 'BT-soknadsdialog',
-    });
+    logSidevisningBarnetilsyn('Aktivitet');
   }, []);
 
   const oppdaterArbeidssituasjon = (nyArbeidssituasjon: IAktivitet) => {

--- a/src/barnetilsyn/steg/5-aktivitet/Aktivitet.tsx
+++ b/src/barnetilsyn/steg/5-aktivitet/Aktivitet.tsx
@@ -30,7 +30,7 @@ import { hentPathBarnetilsynOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../../utils/amplitude';
 
 const Aktivitet: React.FC = () => {
   const intl = useIntl();

--- a/src/barnetilsyn/steg/5-aktivitet/Aktivitet.tsx
+++ b/src/barnetilsyn/steg/5-aktivitet/Aktivitet.tsx
@@ -30,6 +30,7 @@ import { hentPathBarnetilsynOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
+import { logEvent } from 'amplitude-js';
 
 const Aktivitet: React.FC = () => {
   const intl = useIntl();
@@ -52,6 +53,14 @@ const Aktivitet: React.FC = () => {
     settSøknad({ ...søknad, aktivitet: arbeidssituasjon });
     // eslint-disable-next-line
   }, [arbeidssituasjon]);
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'Aktivitet',
+      team: 'familie',
+      app: 'BT-soknadsdialog',
+    });
+  }, []);
 
   const oppdaterArbeidssituasjon = (nyArbeidssituasjon: IAktivitet) => {
     settArbeidssituasjon({ ...arbeidssituasjon, ...nyArbeidssituasjon });

--- a/src/barnetilsyn/steg/5-aktivitet/Aktivitet.tsx
+++ b/src/barnetilsyn/steg/5-aktivitet/Aktivitet.tsx
@@ -31,6 +31,7 @@ import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const Aktivitet: React.FC = () => {
   const intl = useIntl();
@@ -54,9 +55,7 @@ const Aktivitet: React.FC = () => {
     // eslint-disable-next-line
   }, [arbeidssituasjon]);
 
-  useEffect(() => {
-    logSidevisningBarnetilsyn('Aktivitet');
-  }, []);
+  useMount(() => logSidevisningBarnetilsyn('Aktivitet'));
 
   const oppdaterArbeidssituasjon = (nyArbeidssituasjon: IAktivitet) => {
     settArbeidssituasjon({ ...arbeidssituasjon, ...nyArbeidssituasjon });

--- a/src/barnetilsyn/steg/6-barnepass/Barnepass.tsx
+++ b/src/barnetilsyn/steg/6-barnepass/Barnepass.tsx
@@ -26,7 +26,7 @@ import { hentPathBarnetilsynOppsummering } from '../../utils';
 import { useLocation } from 'react-router';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../../utils/amplitude';
 
 interface Props {}
 const Barnepass: FC<Props> = () => {

--- a/src/barnetilsyn/steg/6-barnepass/Barnepass.tsx
+++ b/src/barnetilsyn/steg/6-barnepass/Barnepass.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
 import { useIntl } from 'react-intl';
 import { useBarnetilsynSøknad } from '../../BarnetilsynContext';
 import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
@@ -27,6 +27,7 @@ import { useLocation } from 'react-router';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 interface Props {}
 const Barnepass: FC<Props> = () => {
@@ -51,9 +52,7 @@ const Barnepass: FC<Props> = () => {
   const hjelpetekstInnholdTekstid =
     'søkerFraBestemtMåned.hjelpetekst-innhold.barnepass';
 
-  useEffect(() => {
-    logSidevisningBarnetilsyn('Barnepass');
-  }, []);
+  useMount(() => logSidevisningBarnetilsyn('Barnepass'));
 
   const settBarnepass = (barnepass: IBarnepass, barnid: string) => {
     const endretBarn = barnSomSkalHaBarnepass.map((barn) => {

--- a/src/barnetilsyn/steg/6-barnepass/Barnepass.tsx
+++ b/src/barnetilsyn/steg/6-barnepass/Barnepass.tsx
@@ -26,7 +26,7 @@ import { hentPathBarnetilsynOppsummering } from '../../utils';
 import { useLocation } from 'react-router';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 
 interface Props {}
 const Barnepass: FC<Props> = () => {
@@ -52,11 +52,7 @@ const Barnepass: FC<Props> = () => {
     'søkerFraBestemtMåned.hjelpetekst-innhold.barnepass';
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Barnepass',
-      team: 'familie',
-      app: 'BT-soknadsdialog',
-    });
+    logSidevisningBarnetilsyn('Barnepass');
   }, []);
 
   const settBarnepass = (barnepass: IBarnepass, barnid: string) => {

--- a/src/barnetilsyn/steg/6-barnepass/Barnepass.tsx
+++ b/src/barnetilsyn/steg/6-barnepass/Barnepass.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import { useBarnetilsynSøknad } from '../../BarnetilsynContext';
 import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
@@ -26,6 +26,7 @@ import { hentPathBarnetilsynOppsummering } from '../../utils';
 import { useLocation } from 'react-router';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
+import { logEvent } from 'amplitude-js';
 
 interface Props {}
 const Barnepass: FC<Props> = () => {
@@ -49,6 +50,14 @@ const Barnepass: FC<Props> = () => {
   const datovelgerLabel = 'søkerStønadFraBestemtMnd.datovelger.barnepass';
   const hjelpetekstInnholdTekstid =
     'søkerFraBestemtMåned.hjelpetekst-innhold.barnepass';
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'Barnepass',
+      team: 'familie',
+      app: 'BT-soknadsdialog',
+    });
+  }, []);
 
   const settBarnepass = (barnepass: IBarnepass, barnid: string) => {
     const endretBarn = barnSomSkalHaBarnepass.map((barn) => {

--- a/src/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
 import OppsummeringAktiviteter from '../../../søknad/steg/7-oppsummering/OppsummeringAktiviteter';
 import OppsummeringBarnaDine from '../../../søknad/steg/7-oppsummering/OppsummeringBarnaDine';
@@ -19,6 +19,7 @@ import Side, { ESide } from '../../../components/side/Side';
 import { hentTekst } from '../../../utils/søknad';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const Oppsummering: React.FC = () => {
   const intl = useIntl();
@@ -27,9 +28,7 @@ const Oppsummering: React.FC = () => {
     (barn) => barn.skalHaBarnepass?.verdi
   );
 
-  useEffect(() => {
-    logSidevisningBarnetilsyn('Oppsummering');
-  }, []);
+  useMount(() => logSidevisningBarnetilsyn('Oppsummering'));
 
   return (
     <>

--- a/src/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -18,7 +18,7 @@ import { hentPath } from '../../../utils/routing';
 import Side, { ESide } from '../../../components/side/Side';
 import { hentTekst } from '../../../utils/søknad';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../../utils/amplitude';
 
 const Oppsummering: React.FC = () => {
   const intl = useIntl();

--- a/src/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -18,7 +18,7 @@ import { hentPath } from '../../../utils/routing';
 import Side, { ESide } from '../../../components/side/Side';
 import { hentTekst } from '../../../utils/søknad';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 
 const Oppsummering: React.FC = () => {
   const intl = useIntl();
@@ -28,11 +28,7 @@ const Oppsummering: React.FC = () => {
   );
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Oppsummering',
-      team: 'familie',
-      app: 'BT-soknadsdialog',
-    });
+    logSidevisningBarnetilsyn('Oppsummering');
   }, []);
 
   return (

--- a/src/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
 import OppsummeringAktiviteter from '../../../søknad/steg/7-oppsummering/OppsummeringAktiviteter';
 import OppsummeringBarnaDine from '../../../søknad/steg/7-oppsummering/OppsummeringBarnaDine';
@@ -18,6 +18,7 @@ import { hentPath } from '../../../utils/routing';
 import Side, { ESide } from '../../../components/side/Side';
 import { hentTekst } from '../../../utils/søknad';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { logEvent } from 'amplitude-js';
 
 const Oppsummering: React.FC = () => {
   const intl = useIntl();
@@ -25,6 +26,15 @@ const Oppsummering: React.FC = () => {
   const barnSomSkalHaBarnepass: IBarn[] = søknad.person.barn.filter(
     (barn) => barn.skalHaBarnepass?.verdi
   );
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'Oppsummering',
+      team: 'familie',
+      app: 'BT-soknadsdialog',
+    });
+  }, []);
+
   return (
     <>
       <Side

--- a/src/barnetilsyn/steg/8-dokumentasjon/Dokumentasjon.tsx
+++ b/src/barnetilsyn/steg/8-dokumentasjon/Dokumentasjon.tsx
@@ -14,6 +14,7 @@ import { IVedlegg } from '../../../models/steg/vedlegg';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const Dokumentasjon: React.FC = () => {
   const intl = useIntl();
@@ -23,9 +24,7 @@ const Dokumentasjon: React.FC = () => {
   const sidetittel: string = hentTekst('dokumentasjon.tittel', intl);
   const forrigeDokumentasjonsbehov = usePrevious(søknad.dokumentasjonsbehov);
 
-  useEffect(() => {
-    logSidevisningBarnetilsyn('Dokumentasjon');
-  }, []);
+  useMount(() => logSidevisningBarnetilsyn('Dokumentasjon'));
 
   const oppdaterDokumentasjon = (
     dokumentasjonsid: string,

--- a/src/barnetilsyn/steg/8-dokumentasjon/Dokumentasjon.tsx
+++ b/src/barnetilsyn/steg/8-dokumentasjon/Dokumentasjon.tsx
@@ -13,7 +13,7 @@ import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
 import { IVedlegg } from '../../../models/steg/vedlegg';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 
 const Dokumentasjon: React.FC = () => {
   const intl = useIntl();
@@ -24,11 +24,7 @@ const Dokumentasjon: React.FC = () => {
   const forrigeDokumentasjonsbehov = usePrevious(søknad.dokumentasjonsbehov);
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Dokumentasjon',
-      team: 'familie',
-      app: 'BT-soknadsdialog',
-    });
+    logSidevisningBarnetilsyn('Dokumentasjon');
   }, []);
 
   const oppdaterDokumentasjon = (

--- a/src/barnetilsyn/steg/8-dokumentasjon/Dokumentasjon.tsx
+++ b/src/barnetilsyn/steg/8-dokumentasjon/Dokumentasjon.tsx
@@ -13,6 +13,7 @@ import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
 import { IVedlegg } from '../../../models/steg/vedlegg';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
+import { logEvent } from 'amplitude-js';
 
 const Dokumentasjon: React.FC = () => {
   const intl = useIntl();
@@ -27,6 +28,14 @@ const Dokumentasjon: React.FC = () => {
     opplastedeVedlegg: IVedlegg[] | undefined,
     harSendtInnTidligere: boolean
   ) => {
+    useEffect(() => {
+      logEvent('sidevisning', {
+        side: 'Dokumentasjon',
+        team: 'familie',
+        app: 'BT-soknadsdialog',
+      });
+    }, []);
+
     settSøknad((prevSoknad) => {
       const dokumentasjonMedVedlegg = prevSoknad.dokumentasjonsbehov.map(
         (dok) => {

--- a/src/barnetilsyn/steg/8-dokumentasjon/Dokumentasjon.tsx
+++ b/src/barnetilsyn/steg/8-dokumentasjon/Dokumentasjon.tsx
@@ -13,7 +13,7 @@ import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
 import { IVedlegg } from '../../../models/steg/vedlegg';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../../utils/amplitude';
 
 const Dokumentasjon: React.FC = () => {
   const intl = useIntl();

--- a/src/barnetilsyn/steg/8-dokumentasjon/Dokumentasjon.tsx
+++ b/src/barnetilsyn/steg/8-dokumentasjon/Dokumentasjon.tsx
@@ -23,19 +23,19 @@ const Dokumentasjon: React.FC = () => {
   const sidetittel: string = hentTekst('dokumentasjon.tittel', intl);
   const forrigeDokumentasjonsbehov = usePrevious(søknad.dokumentasjonsbehov);
 
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'Dokumentasjon',
+      team: 'familie',
+      app: 'BT-soknadsdialog',
+    });
+  }, []);
+
   const oppdaterDokumentasjon = (
     dokumentasjonsid: string,
     opplastedeVedlegg: IVedlegg[] | undefined,
     harSendtInnTidligere: boolean
   ) => {
-    useEffect(() => {
-      logEvent('sidevisning', {
-        side: 'Dokumentasjon',
-        team: 'familie',
-        app: 'BT-soknadsdialog',
-      });
-    }, []);
-
     settSøknad((prevSoknad) => {
       const dokumentasjonMedVedlegg = prevSoknad.dokumentasjonsbehov.map(
         (dok) => {

--- a/src/barnetilsyn/steg/9-kvittering/Kvittering.tsx
+++ b/src/barnetilsyn/steg/9-kvittering/Kvittering.tsx
@@ -20,7 +20,7 @@ import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { usePersonContext } from '../../../context/PersonContext';
 import { hentFilePath } from '../../../utils/språk';
 import { useSpråkContext } from '../../../context/SpråkContext';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 
 const Kvittering: React.FC = () => {
   const intl = useIntl();
@@ -36,11 +36,7 @@ const Kvittering: React.FC = () => {
   );
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Kvittering',
-      team: 'familie',
-      app: 'BT-soknadsdialog',
-    });
+    logSidevisningBarnetilsyn('Kvittering');
   }, []);
 
   useEffect(() => {

--- a/src/barnetilsyn/steg/9-kvittering/Kvittering.tsx
+++ b/src/barnetilsyn/steg/9-kvittering/Kvittering.tsx
@@ -20,6 +20,7 @@ import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { usePersonContext } from '../../../context/PersonContext';
 import { hentFilePath } from '../../../utils/språk';
 import { useSpråkContext } from '../../../context/SpråkContext';
+import { logEvent } from 'amplitude-js';
 
 const Kvittering: React.FC = () => {
   const intl = useIntl();
@@ -33,6 +34,14 @@ const Kvittering: React.FC = () => {
   const barnSomSkalHaBarnepass = søknad.person.barn.filter(
     (barn) => barn.skalHaBarnepass?.verdi
   );
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'Kvittering',
+      team: 'familie',
+      app: 'BT-soknadsdialog',
+    });
+  }, []);
 
   useEffect(() => {
     nullstillMellomlagretBarnetilsyn();

--- a/src/barnetilsyn/steg/9-kvittering/Kvittering.tsx
+++ b/src/barnetilsyn/steg/9-kvittering/Kvittering.tsx
@@ -21,6 +21,7 @@ import { usePersonContext } from '../../../context/PersonContext';
 import { hentFilePath } from '../../../utils/språk';
 import { useSpråkContext } from '../../../context/SpråkContext';
 import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const Kvittering: React.FC = () => {
   const intl = useIntl();
@@ -35,9 +36,7 @@ const Kvittering: React.FC = () => {
     (barn) => barn.skalHaBarnepass?.verdi
   );
 
-  useEffect(() => {
-    logSidevisningBarnetilsyn('Kvittering');
-  }, []);
+  useMount(() => logSidevisningBarnetilsyn('Kvittering'));
 
   useEffect(() => {
     nullstillMellomlagretBarnetilsyn();

--- a/src/barnetilsyn/steg/9-kvittering/Kvittering.tsx
+++ b/src/barnetilsyn/steg/9-kvittering/Kvittering.tsx
@@ -20,7 +20,7 @@ import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { usePersonContext } from '../../../context/PersonContext';
 import { hentFilePath } from '../../../utils/språk';
 import { useSpråkContext } from '../../../context/SpråkContext';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../../utils/amplitude';
 
 const Kvittering: React.FC = () => {
   const intl = useIntl();

--- a/src/overgangsstønad/Forside.tsx
+++ b/src/overgangsstønad/Forside.tsx
@@ -19,16 +19,12 @@ import { useForsideInnhold } from '../utils/hooks';
 import { ForsideType } from '../models/søknad/stønadstyper';
 import { hentPath } from '../utils/routing';
 import { useIntl } from 'react-intl';
-import { logEvent } from '../utils/amplitude';
+import { logSidevisningOvergangsstonad } from '../utils/amplitude';
 import LocaleTekst from '../language/LocaleTekst';
 
 const Forside: React.FC = () => {
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Forside',
-      team: 'familie',
-      app: 'OS-soknadsdialog',
-    });
+    logSidevisningOvergangsstonad('Forside');
   }, []);
 
   const intl = useIntl();

--- a/src/overgangsstønad/Forside.tsx
+++ b/src/overgangsstønad/Forside.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Panel } from 'nav-frontend-paneler';
 import { Sidetittel } from 'nav-frontend-typografi';
 import { usePersonContext } from '../context/PersonContext';
@@ -21,11 +21,10 @@ import { hentPath } from '../utils/routing';
 import { useIntl } from 'react-intl';
 import { logSidevisningOvergangsstonad } from '../utils/amplitude';
 import LocaleTekst from '../language/LocaleTekst';
+import { useMount } from '../utils/hooks';
 
 const Forside: React.FC = () => {
-  useEffect(() => {
-    logSidevisningOvergangsstonad('Forside');
-  }, []);
+  useMount(() => logSidevisningOvergangsstonad('Forside'));
 
   const intl = useIntl();
   const { person } = usePersonContext();

--- a/src/overgangsstønad/Forside.tsx
+++ b/src/overgangsstønad/Forside.tsx
@@ -24,7 +24,11 @@ import LocaleTekst from '../language/LocaleTekst';
 
 const Forside: React.FC = () => {
   useEffect(() => {
-    logEvent('sidevisning', { side: 'Forside' });
+    logEvent('sidevisning', {
+      side: 'Forside',
+      team: 'familie',
+      app: 'OS-soknadsdialog',
+    });
   }, []);
 
   const intl = useIntl();

--- a/src/overgangsstønad/steg/1-omdeg/OmDeg.tsx
+++ b/src/overgangsstønad/steg/1-omdeg/OmDeg.tsx
@@ -43,7 +43,11 @@ const OmDeg: FC = () => {
   } = søknad.sivilstatus;
 
   useEffect(() => {
-    logEvent('sidevisning', { side: 'OmDeg' });
+    logEvent('sidevisning', {
+      side: 'OmDeg',
+      team: 'familie',
+      app: 'OS-soknadsdialog',
+    });
   }, []);
 
   const settMedlemskap = (medlemskap: IMedlemskap) => {

--- a/src/overgangsstønad/steg/1-omdeg/OmDeg.tsx
+++ b/src/overgangsstønad/steg/1-omdeg/OmDeg.tsx
@@ -4,7 +4,7 @@ import Personopplysninger from '../../../søknad/steg/1-omdeg/personopplysninger
 import Sivilstatus from '../../../søknad/steg/1-omdeg/sivilstatus/Sivilstatus';
 import { useSøknad } from '../../../context/SøknadContext';
 import { useLocation } from 'react-router-dom';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningOvergangsstonad } from '../../../utils/amplitude';
 import {
   erStegFerdigUtfylt,
   erSøknadsBegrunnelseBesvart,
@@ -43,11 +43,7 @@ const OmDeg: FC = () => {
   } = søknad.sivilstatus;
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'OmDeg',
-      team: 'familie',
-      app: 'OS-soknadsdialog',
-    });
+    logSidevisningOvergangsstonad('OmDeg');
   }, []);
 
   const settMedlemskap = (medlemskap: IMedlemskap) => {

--- a/src/overgangsstønad/steg/1-omdeg/OmDeg.tsx
+++ b/src/overgangsstønad/steg/1-omdeg/OmDeg.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
 import Medlemskap from '../../../søknad/steg/1-omdeg/medlemskap/Medlemskap';
 import Personopplysninger from '../../../søknad/steg/1-omdeg/personopplysninger/Personopplysninger';
 import Sivilstatus from '../../../søknad/steg/1-omdeg/sivilstatus/Sivilstatus';
@@ -21,6 +21,7 @@ import { useIntl } from 'react-intl';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import Show from '../../../utils/showIf';
+import { useMount } from '../../../utils/hooks';
 
 const OmDeg: FC = () => {
   const intl = useIntl();
@@ -42,9 +43,7 @@ const OmDeg: FC = () => {
     datoFlyttetFraHverandre,
   } = søknad.sivilstatus;
 
-  useEffect(() => {
-    logSidevisningOvergangsstonad('OmDeg');
-  }, []);
+  useMount(() => logSidevisningOvergangsstonad('OmDeg'));
 
   const settMedlemskap = (medlemskap: IMedlemskap) => {
     settSøknad((prevSoknad) => {

--- a/src/overgangsstønad/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/overgangsstønad/steg/2-bosituasjon/Bosituasjon.tsx
@@ -10,7 +10,7 @@ import { hentPathOvergangsstønadOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningOvergangsstonad } from '../../../utils/amplitude';
 
 const Bosituasjon: FC = () => {
   const intl = useIntl();
@@ -28,11 +28,7 @@ const Bosituasjon: FC = () => {
     : ESide.visTilbakeTilOppsummeringKnapp;
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Bosituasjon',
-      team: 'familie',
-      app: 'OS-soknadsdialog',
-    });
+    logSidevisningOvergangsstonad('Bosituasjon');
   }, []);
 
   const settBosituasjon = (bosituasjon: IBosituasjon) => {

--- a/src/overgangsstønad/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/overgangsstønad/steg/2-bosituasjon/Bosituasjon.tsx
@@ -28,7 +28,11 @@ const Bosituasjon: FC = () => {
     : ESide.visTilbakeTilOppsummeringKnapp;
 
   useEffect(() => {
-    logEvent('sidevisning', { side: 'Bosituasjon' });
+    logEvent('sidevisning', {
+      side: 'Bosituasjon',
+      team: 'familie',
+      app: 'OS-soknadsdialog',
+    });
   }, []);
 
   const settBosituasjon = (bosituasjon: IBosituasjon) => {

--- a/src/overgangsstønad/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/overgangsstønad/steg/2-bosituasjon/Bosituasjon.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
 import { useIntl } from 'react-intl';
 import { useSøknad } from '../../../context/SøknadContext';
 import { IBosituasjon } from '../../../models/steg/bosituasjon';
@@ -11,6 +11,7 @@ import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { logSidevisningOvergangsstonad } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const Bosituasjon: FC = () => {
   const intl = useIntl();
@@ -27,9 +28,7 @@ const Bosituasjon: FC = () => {
     ? ESide.visTilbakeNesteAvbrytKnapp
     : ESide.visTilbakeTilOppsummeringKnapp;
 
-  useEffect(() => {
-    logSidevisningOvergangsstonad('Bosituasjon');
-  }, []);
+  useMount(() => logSidevisningOvergangsstonad('Bosituasjon'));
 
   const settBosituasjon = (bosituasjon: IBosituasjon) => {
     settSøknad((prevSoknad) => {

--- a/src/overgangsstønad/steg/3-barnadine/BarnaDine.tsx
+++ b/src/overgangsstønad/steg/3-barnadine/BarnaDine.tsx
@@ -34,7 +34,11 @@ const BarnaDine: React.FC = () => {
   const [åpenModal, settÅpenModal] = useState(false);
 
   useEffect(() => {
-    logEvent('sidevisning', { side: 'BarnaDine' });
+    logEvent('sidevisning', {
+      side: 'BarnaDine',
+      team: 'familie',
+      app: 'OS-soknadsdialog',
+    });
   }, []);
 
   const barna = søknad.person.barn;

--- a/src/overgangsstønad/steg/3-barnadine/BarnaDine.tsx
+++ b/src/overgangsstønad/steg/3-barnadine/BarnaDine.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Barnekort from '../../../søknad/steg/3-barnadine/Barnekort';
 import LeggTilBarn from '../../../søknad/steg/3-barnadine/LeggTilBarn';
 import { Knapp } from 'nav-frontend-knapper';
@@ -16,6 +16,7 @@ import { hentPathOvergangsstønadOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { logSidevisningOvergangsstonad } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const BarnaDine: React.FC = () => {
   const intl = useIntl();
@@ -33,9 +34,7 @@ const BarnaDine: React.FC = () => {
 
   const [åpenModal, settÅpenModal] = useState(false);
 
-  useEffect(() => {
-    logSidevisningOvergangsstonad('BarnaDine');
-  }, []);
+  useMount(() => logSidevisningOvergangsstonad('BarnaDine'));
 
   const barna = søknad.person.barn;
   const slettBarn = (id: string) => {

--- a/src/overgangsstønad/steg/3-barnadine/BarnaDine.tsx
+++ b/src/overgangsstønad/steg/3-barnadine/BarnaDine.tsx
@@ -15,7 +15,7 @@ import { RoutesOvergangsstonad } from '../../routing/routesOvergangsstonad';
 import { hentPathOvergangsstønadOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningOvergangsstonad } from '../../../utils/amplitude';
 
 const BarnaDine: React.FC = () => {
   const intl = useIntl();
@@ -34,11 +34,7 @@ const BarnaDine: React.FC = () => {
   const [åpenModal, settÅpenModal] = useState(false);
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'BarnaDine',
-      team: 'familie',
-      app: 'OS-soknadsdialog',
-    });
+    logSidevisningOvergangsstonad('BarnaDine');
   }, []);
 
   const barna = søknad.person.barn;

--- a/src/overgangsstønad/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/overgangsstønad/steg/4-barnasbosted/BarnasBosted.tsx
@@ -12,7 +12,7 @@ import { RoutesOvergangsstonad } from '../../routing/routesOvergangsstonad';
 import { hentPathOvergangsstønadOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningOvergangsstonad } from '../../../utils/amplitude';
 
 const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
   if (!ref || !ref.current) return;
@@ -36,11 +36,7 @@ const BarnasBosted: React.FC = () => {
   const [sisteBarnUtfylt, settSisteBarnUtfylt] = useState<boolean>(false);
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'BarnasBosted',
-      team: 'familie',
-      app: 'OS-soknadsdialog',
-    });
+    logSidevisningOvergangsstonad('BarnasBosted');
   }, []);
 
   const settBarneliste = (nyBarneListe: IBarn[]) => {

--- a/src/overgangsstønad/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/overgangsstønad/steg/4-barnasbosted/BarnasBosted.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef } from 'react';
 import BarnetsBostedEndre from '../../../søknad/steg/4-barnasbosted/BarnetsBostedEndre';
 import BarnetsBostedLagtTil from '../../../søknad/steg/4-barnasbosted/BarnetsBostedLagtTil';
 import { hentTekst } from '../../../utils/søknad';
@@ -13,6 +13,7 @@ import { hentPathOvergangsstønadOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { logSidevisningOvergangsstonad } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
   if (!ref || !ref.current) return;
@@ -35,9 +36,7 @@ const BarnasBosted: React.FC = () => {
     : ESide.visTilbakeTilOppsummeringKnapp;
   const [sisteBarnUtfylt, settSisteBarnUtfylt] = useState<boolean>(false);
 
-  useEffect(() => {
-    logSidevisningOvergangsstonad('BarnasBosted');
-  }, []);
+  useMount(() => logSidevisningOvergangsstonad('BarnasBosted'));
 
   const settBarneliste = (nyBarneListe: IBarn[]) => {
     settSøknad((prevSoknad) => {

--- a/src/overgangsstønad/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/overgangsstønad/steg/4-barnasbosted/BarnasBosted.tsx
@@ -36,7 +36,11 @@ const BarnasBosted: React.FC = () => {
   const [sisteBarnUtfylt, settSisteBarnUtfylt] = useState<boolean>(false);
 
   useEffect(() => {
-    logEvent('sidevisning', { side: 'BarnasBosted' });
+    logEvent('sidevisning', {
+      side: 'BarnasBosted',
+      team: 'familie',
+      app: 'OS-soknadsdialog',
+    });
   }, []);
 
   const settBarneliste = (nyBarneListe: IBarn[]) => {

--- a/src/overgangsstønad/steg/5-aktivitet/Aktivitet.tsx
+++ b/src/overgangsstønad/steg/5-aktivitet/Aktivitet.tsx
@@ -20,7 +20,7 @@ import { RoutesOvergangsstonad } from '../../routing/routesOvergangsstonad';
 import { hentPathOvergangsstønadOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningOvergangsstonad } from '../../../utils/amplitude';
 
 const Aktivitet: React.FC = () => {
   const intl = useIntl();
@@ -46,11 +46,7 @@ const Aktivitet: React.FC = () => {
   }, [arbeidssituasjon]);
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Aktivitet',
-      team: 'familie',
-      app: 'OS-soknadsdialog',
-    });
+    logSidevisningOvergangsstonad('Aktivitet');
   }, []);
 
   const oppdaterArbeidssituasjon = (nyArbeidssituasjon: IAktivitet) => {

--- a/src/overgangsstønad/steg/5-aktivitet/Aktivitet.tsx
+++ b/src/overgangsstønad/steg/5-aktivitet/Aktivitet.tsx
@@ -21,6 +21,7 @@ import { hentPathOvergangsstønadOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { logSidevisningOvergangsstonad } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const Aktivitet: React.FC = () => {
   const intl = useIntl();
@@ -45,9 +46,7 @@ const Aktivitet: React.FC = () => {
     // eslint-disable-next-line
   }, [arbeidssituasjon]);
 
-  useEffect(() => {
-    logSidevisningOvergangsstonad('Aktivitet');
-  }, []);
+  useMount(() => logSidevisningOvergangsstonad('Aktivitet'));
 
   const oppdaterArbeidssituasjon = (nyArbeidssituasjon: IAktivitet) => {
     settArbeidssituasjon({ ...arbeidssituasjon, ...nyArbeidssituasjon });

--- a/src/overgangsstønad/steg/5-aktivitet/Aktivitet.tsx
+++ b/src/overgangsstønad/steg/5-aktivitet/Aktivitet.tsx
@@ -46,7 +46,11 @@ const Aktivitet: React.FC = () => {
   }, [arbeidssituasjon]);
 
   useEffect(() => {
-    logEvent('sidevisning', { side: 'Aktivitet' });
+    logEvent('sidevisning', {
+      side: 'Aktivitet',
+      team: 'familie',
+      app: 'OS-soknadsdialog',
+    });
   }, []);
 
   const oppdaterArbeidssituasjon = (nyArbeidssituasjon: IAktivitet) => {

--- a/src/overgangsstønad/steg/6-meromsituasjon/MerOmDinSituasjon.tsx
+++ b/src/overgangsstønad/steg/6-meromsituasjon/MerOmDinSituasjon.tsx
@@ -40,6 +40,8 @@ import { useLeggTilSærligeBehovHvisHarEttBarMedSærligeBehov } from '../../../u
 import { hentBeskjedMedNavn } from '../../../utils/språk';
 import { Normaltekst } from 'nav-frontend-typografi';
 import styled from 'styled-components';
+import { useMount } from '../../../utils/hooks';
+
 const StyledHjelpetekst = styled.div`
   .typo-normal {
     padding-bottom: 1rem;
@@ -67,9 +69,7 @@ const MerOmDinSituasjon: React.FC = () => {
     søknad
   );
 
-  useEffect(() => {
-    logSidevisningOvergangsstonad('MerOmDinSituasjon');
-  }, []);
+  useMount(() => logSidevisningOvergangsstonad('MerOmDinSituasjon'));
 
   const datovelgerLabel = 'søkerFraBestemtMåned.datovelger.overgangsstønad';
 

--- a/src/overgangsstønad/steg/6-meromsituasjon/MerOmDinSituasjon.tsx
+++ b/src/overgangsstønad/steg/6-meromsituasjon/MerOmDinSituasjon.tsx
@@ -68,7 +68,11 @@ const MerOmDinSituasjon: React.FC = () => {
   );
 
   useEffect(() => {
-    logEvent('sidevisning', { side: 'MerOmDinSituasjon' });
+    logEvent('sidevisning', {
+      side: 'MerOmDinSituasjon',
+      team: 'familie',
+      app: 'OS-soknadsdialog',
+    });
   }, []);
 
   const datovelgerLabel = 'søkerFraBestemtMåned.datovelger.overgangsstønad';

--- a/src/overgangsstønad/steg/6-meromsituasjon/MerOmDinSituasjon.tsx
+++ b/src/overgangsstønad/steg/6-meromsituasjon/MerOmDinSituasjon.tsx
@@ -35,7 +35,7 @@ import { RoutesOvergangsstonad } from '../../routing/routesOvergangsstonad';
 import { hentPathOvergangsstønadOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningOvergangsstonad } from '../../../utils/amplitude';
 import { useLeggTilSærligeBehovHvisHarEttBarMedSærligeBehov } from '../../../utils/hooks';
 import { hentBeskjedMedNavn } from '../../../utils/språk';
 import { Normaltekst } from 'nav-frontend-typografi';
@@ -68,11 +68,7 @@ const MerOmDinSituasjon: React.FC = () => {
   );
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'MerOmDinSituasjon',
-      team: 'familie',
-      app: 'OS-soknadsdialog',
-    });
+    logSidevisningOvergangsstonad('MerOmDinSituasjon');
   }, []);
 
   const datovelgerLabel = 'søkerFraBestemtMåned.datovelger.overgangsstønad';

--- a/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
@@ -24,7 +24,11 @@ const Oppsummering: React.FC = () => {
   const { mellomlagreOvergangsstønad, søknad } = useSøknad();
 
   useEffect(() => {
-    logEvent('sidevisning', { side: 'Oppsummering' });
+    logEvent('sidevisning', {
+      side: 'Oppsummering',
+      team: 'familie',
+      app: 'OS-soknadsdialog',
+    });
   }, []);
 
   const barnMedsærligeTilsynsbehov = søknad.person.barn

--- a/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Normaltekst } from 'nav-frontend-typografi';
 import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
 import { useIntl } from 'react-intl';
@@ -18,14 +18,13 @@ import Side, { ESide } from '../../../components/side/Side';
 import { hentTekst } from '../../../utils/søknad';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { logSidevisningOvergangsstonad } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const Oppsummering: React.FC = () => {
   const intl = useIntl();
   const { mellomlagreOvergangsstønad, søknad } = useSøknad();
 
-  useEffect(() => {
-    logSidevisningOvergangsstonad('Oppsummering');
-  }, []);
+  useMount(() => logSidevisningOvergangsstonad('Oppsummering'));
 
   const barnMedsærligeTilsynsbehov = søknad.person.barn
     .filter((barn) => barn.særligeTilsynsbehov)

--- a/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
@@ -17,18 +17,14 @@ import { hentPath } from '../../../utils/routing';
 import Side, { ESide } from '../../../components/side/Side';
 import { hentTekst } from '../../../utils/søknad';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningOvergangsstonad } from '../../../utils/amplitude';
 
 const Oppsummering: React.FC = () => {
   const intl = useIntl();
   const { mellomlagreOvergangsstønad, søknad } = useSøknad();
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Oppsummering',
-      team: 'familie',
-      app: 'OS-soknadsdialog',
-    });
+    logSidevisningOvergangsstonad('Oppsummering');
   }, []);
 
   const barnMedsærligeTilsynsbehov = søknad.person.barn

--- a/src/overgangsstønad/steg/8-dokumentasjon/Dokumentasjon.tsx
+++ b/src/overgangsstønad/steg/8-dokumentasjon/Dokumentasjon.tsx
@@ -17,6 +17,7 @@ import { IVedlegg } from '../../../models/steg/vedlegg';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { logSidevisningOvergangsstonad } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const Dokumentasjon: React.FC = () => {
   const intl = useIntl();
@@ -26,9 +27,7 @@ const Dokumentasjon: React.FC = () => {
   const sidetittel: string = hentTekst('dokumentasjon.tittel', intl);
   const forrigeDokumentasjonsbehov = usePrevious(søknad.dokumentasjonsbehov);
 
-  useEffect(() => {
-    logSidevisningOvergangsstonad('Dokumentasjon');
-  }, []);
+  useMount(() => logSidevisningOvergangsstonad('Dokumentasjon'));
 
   const oppdaterDokumentasjon = (
     dokumentasjonsid: string,

--- a/src/overgangsstønad/steg/8-dokumentasjon/Dokumentasjon.tsx
+++ b/src/overgangsstønad/steg/8-dokumentasjon/Dokumentasjon.tsx
@@ -16,7 +16,7 @@ import { RoutesOvergangsstonad } from '../../routing/routesOvergangsstonad';
 import { IVedlegg } from '../../../models/steg/vedlegg';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningOvergangsstonad } from '../../../utils/amplitude';
 
 const Dokumentasjon: React.FC = () => {
   const intl = useIntl();
@@ -27,11 +27,7 @@ const Dokumentasjon: React.FC = () => {
   const forrigeDokumentasjonsbehov = usePrevious(søknad.dokumentasjonsbehov);
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Dokumentasjon',
-      team: 'familie',
-      app: 'OS-soknadsdialog',
-    });
+    logSidevisningOvergangsstonad('Dokumentasjon');
   }, []);
 
   const oppdaterDokumentasjon = (

--- a/src/overgangsstønad/steg/8-dokumentasjon/Dokumentasjon.tsx
+++ b/src/overgangsstønad/steg/8-dokumentasjon/Dokumentasjon.tsx
@@ -27,7 +27,11 @@ const Dokumentasjon: React.FC = () => {
   const forrigeDokumentasjonsbehov = usePrevious(søknad.dokumentasjonsbehov);
 
   useEffect(() => {
-    logEvent('sidevisning', { side: 'Dokumentasjon' });
+    logEvent('sidevisning', {
+      side: 'Dokumentasjon',
+      team: 'familie',
+      app: 'OS-soknadsdialog',
+    });
   }, []);
 
   const oppdaterDokumentasjon = (

--- a/src/overgangsstønad/steg/9-kvittering/Kvittering.tsx
+++ b/src/overgangsstønad/steg/9-kvittering/Kvittering.tsx
@@ -24,7 +24,7 @@ import RegistrerBarnIFolkeregister from '../../../søknad/steg/9-kvittering/Regi
 import EttersendDokumentasjon from '../../../søknad/steg/9-kvittering/EttersendDokumentasjon';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { usePersonContext } from '../../../context/PersonContext';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningOvergangsstonad } from '../../../utils/amplitude';
 import { useSpråkContext } from '../../../context/SpråkContext';
 import { hentFilePath } from '../../../utils/språk';
 
@@ -37,11 +37,7 @@ const Kvittering: React.FC = () => {
   } = useSøknad();
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Kvittering',
-      team: 'familie',
-      app: 'OS-soknadsdialog',
-    });
+    logSidevisningOvergangsstonad('Kvittering');
   }, []);
 
   const { person } = usePersonContext();

--- a/src/overgangsstønad/steg/9-kvittering/Kvittering.tsx
+++ b/src/overgangsstønad/steg/9-kvittering/Kvittering.tsx
@@ -37,7 +37,11 @@ const Kvittering: React.FC = () => {
   } = useSøknad();
 
   useEffect(() => {
-    logEvent('sidevisning', { side: 'Kvittering' });
+    logEvent('sidevisning', {
+      side: 'Kvittering',
+      team: 'familie',
+      app: 'OS-soknadsdialog',
+    });
   }, []);
 
   const { person } = usePersonContext();

--- a/src/overgangsstønad/steg/9-kvittering/Kvittering.tsx
+++ b/src/overgangsstønad/steg/9-kvittering/Kvittering.tsx
@@ -27,6 +27,7 @@ import { usePersonContext } from '../../../context/PersonContext';
 import { logSidevisningOvergangsstonad } from '../../../utils/amplitude';
 import { useSpråkContext } from '../../../context/SpråkContext';
 import { hentFilePath } from '../../../utils/språk';
+import { useMount } from '../../../utils/hooks';
 
 const Kvittering: React.FC = () => {
   const intl = useIntl();
@@ -36,9 +37,7 @@ const Kvittering: React.FC = () => {
     nullstillSøknadOvergangsstønad,
   } = useSøknad();
 
-  useEffect(() => {
-    logSidevisningOvergangsstonad('Kvittering');
-  }, []);
+  useMount(() => logSidevisningOvergangsstonad('Kvittering'));
 
   const { person } = usePersonContext();
   const { locale } = useSpråkContext();

--- a/src/skolepenger/Forside.tsx
+++ b/src/skolepenger/Forside.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Panel } from 'nav-frontend-paneler';
 import { Sidetittel } from 'nav-frontend-typografi';
 import { usePersonContext } from '../context/PersonContext';
@@ -15,6 +15,7 @@ import { ForsideType } from '../models/søknad/stønadstyper';
 import Forsideinformasjon from '../søknad/forside/Forsideinformasjon';
 import { ERouteSkolepenger, RoutesSkolepenger } from './routing/routes';
 import { hentPath } from '../utils/routing';
+import { logEvent } from 'amplitude-js';
 
 const Forside: React.FC<any> = ({ intl }) => {
   const { person } = usePersonContext();
@@ -26,6 +27,15 @@ const Forside: React.FC<any> = ({ intl }) => {
     søknad,
     settSøknad,
   } = useSkolepengerSøknad();
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'Forside',
+      team: 'familie',
+      app: 'SP-soknadsdialog',
+    });
+  }, []);
+
   const settBekreftelse = (bekreftelse: boolean) => {
     settSøknad({
       ...søknad,

--- a/src/skolepenger/Forside.tsx
+++ b/src/skolepenger/Forside.tsx
@@ -15,7 +15,7 @@ import { ForsideType } from '../models/søknad/stønadstyper';
 import Forsideinformasjon from '../søknad/forside/Forsideinformasjon';
 import { ERouteSkolepenger, RoutesSkolepenger } from './routing/routes';
 import { hentPath } from '../utils/routing';
-import { logEvent } from '../utils/amplitude';
+import { logSidevisningSkolepenger } from '../utils/amplitude';
 
 const Forside: React.FC<any> = ({ intl }) => {
   const { person } = usePersonContext();
@@ -29,11 +29,7 @@ const Forside: React.FC<any> = ({ intl }) => {
   } = useSkolepengerSøknad();
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Forside',
-      team: 'familie',
-      app: 'SP-soknadsdialog',
-    });
+    logSidevisningSkolepenger('Forside');
   }, []);
 
   const settBekreftelse = (bekreftelse: boolean) => {

--- a/src/skolepenger/Forside.tsx
+++ b/src/skolepenger/Forside.tsx
@@ -15,7 +15,7 @@ import { ForsideType } from '../models/søknad/stønadstyper';
 import Forsideinformasjon from '../søknad/forside/Forsideinformasjon';
 import { ERouteSkolepenger, RoutesSkolepenger } from './routing/routes';
 import { hentPath } from '../utils/routing';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../utils/amplitude';
 
 const Forside: React.FC<any> = ({ intl }) => {
   const { person } = usePersonContext();

--- a/src/skolepenger/Forside.tsx
+++ b/src/skolepenger/Forside.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Panel } from 'nav-frontend-paneler';
 import { Sidetittel } from 'nav-frontend-typografi';
 import { usePersonContext } from '../context/PersonContext';
@@ -16,6 +16,7 @@ import Forsideinformasjon from '../søknad/forside/Forsideinformasjon';
 import { ERouteSkolepenger, RoutesSkolepenger } from './routing/routes';
 import { hentPath } from '../utils/routing';
 import { logSidevisningSkolepenger } from '../utils/amplitude';
+import { useMount } from '../utils/hooks';
 
 const Forside: React.FC<any> = ({ intl }) => {
   const { person } = usePersonContext();
@@ -28,9 +29,7 @@ const Forside: React.FC<any> = ({ intl }) => {
     settSøknad,
   } = useSkolepengerSøknad();
 
-  useEffect(() => {
-    logSidevisningSkolepenger('Forside');
-  }, []);
+  useMount(() => logSidevisningSkolepenger('Forside'));
 
   const settBekreftelse = (bekreftelse: boolean) => {
     settSøknad({

--- a/src/skolepenger/steg/1-omdeg/OmDeg.tsx
+++ b/src/skolepenger/steg/1-omdeg/OmDeg.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import { IntlShape, injectIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
 import {
@@ -20,6 +20,7 @@ import { hentPathSkolepengerOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import Show from '../../../utils/showIf';
+import { logEvent } from 'amplitude-js';
 
 const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
   const location = useLocation<LocationStateSøknad>();
@@ -39,6 +40,14 @@ const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
     datoSøktSeparasjon,
     datoFlyttetFraHverandre,
   } = søknad.sivilstatus;
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'OmDeg',
+      team: 'familie',
+      app: 'SP-soknadsdialog',
+    });
+  }, []);
 
   const settMedlemskap = (medlemskap: IMedlemskap) => {
     settSøknad((prevSoknad) => {

--- a/src/skolepenger/steg/1-omdeg/OmDeg.tsx
+++ b/src/skolepenger/steg/1-omdeg/OmDeg.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
 import { IntlShape, injectIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
 import {
@@ -21,6 +21,7 @@ import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import Show from '../../../utils/showIf';
 import { logSidevisningSkolepenger } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
   const location = useLocation<LocationStateSøknad>();
@@ -41,9 +42,7 @@ const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
     datoFlyttetFraHverandre,
   } = søknad.sivilstatus;
 
-  useEffect(() => {
-    logSidevisningSkolepenger('OmDeg');
-  }, []);
+  useMount(() => logSidevisningSkolepenger('OmDeg'));
 
   const settMedlemskap = (medlemskap: IMedlemskap) => {
     settSøknad((prevSoknad) => {

--- a/src/skolepenger/steg/1-omdeg/OmDeg.tsx
+++ b/src/skolepenger/steg/1-omdeg/OmDeg.tsx
@@ -20,7 +20,7 @@ import { hentPathSkolepengerOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import Show from '../../../utils/showIf';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../../utils/amplitude';
 
 const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
   const location = useLocation<LocationStateSøknad>();

--- a/src/skolepenger/steg/1-omdeg/OmDeg.tsx
+++ b/src/skolepenger/steg/1-omdeg/OmDeg.tsx
@@ -20,7 +20,7 @@ import { hentPathSkolepengerOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import Show from '../../../utils/showIf';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningSkolepenger } from '../../../utils/amplitude';
 
 const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
   const location = useLocation<LocationStateSøknad>();
@@ -42,11 +42,7 @@ const OmDeg: FC<{ intl: IntlShape }> = ({ intl }) => {
   } = søknad.sivilstatus;
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'OmDeg',
-      team: 'familie',
-      app: 'SP-soknadsdialog',
-    });
+    logSidevisningSkolepenger('OmDeg');
   }, []);
 
   const settMedlemskap = (medlemskap: IMedlemskap) => {

--- a/src/skolepenger/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/skolepenger/steg/2-bosituasjon/Bosituasjon.tsx
@@ -10,7 +10,7 @@ import { RoutesSkolepenger } from '../../routing/routes';
 import { hentPathSkolepengerOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningSkolepenger } from '../../../utils/amplitude';
 
 const Bosituasjon: FC = () => {
   const intl = useIntl();
@@ -28,11 +28,7 @@ const Bosituasjon: FC = () => {
     : ESide.visTilbakeTilOppsummeringKnapp;
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Bosituasjon',
-      team: 'familie',
-      app: 'SP-soknadsdialog',
-    });
+    logSidevisningSkolepenger('Bosituasjon');
   }, []);
 
   const settBosituasjon = (bosituasjon: IBosituasjon) => {

--- a/src/skolepenger/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/skolepenger/steg/2-bosituasjon/Bosituasjon.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
 import { useIntl } from 'react-intl';
 import { IBosituasjon } from '../../../models/steg/bosituasjon';
 import { useLocation } from 'react-router-dom';
@@ -11,6 +11,7 @@ import { hentPathSkolepengerOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { logSidevisningSkolepenger } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const Bosituasjon: FC = () => {
   const intl = useIntl();
@@ -27,9 +28,7 @@ const Bosituasjon: FC = () => {
     ? ESide.visTilbakeNesteAvbrytKnapp
     : ESide.visTilbakeTilOppsummeringKnapp;
 
-  useEffect(() => {
-    logSidevisningSkolepenger('Bosituasjon');
-  }, []);
+  useMount(() => logSidevisningSkolepenger('Bosituasjon'));
 
   const settBosituasjon = (bosituasjon: IBosituasjon) => {
     settSøknad((prevSoknad) => {

--- a/src/skolepenger/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/skolepenger/steg/2-bosituasjon/Bosituasjon.tsx
@@ -10,7 +10,7 @@ import { RoutesSkolepenger } from '../../routing/routes';
 import { hentPathSkolepengerOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../../utils/amplitude';
 
 const Bosituasjon: FC = () => {
   const intl = useIntl();

--- a/src/skolepenger/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/skolepenger/steg/2-bosituasjon/Bosituasjon.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import { IBosituasjon } from '../../../models/steg/bosituasjon';
 import { useLocation } from 'react-router-dom';
@@ -10,6 +10,7 @@ import { RoutesSkolepenger } from '../../routing/routes';
 import { hentPathSkolepengerOppsummering } from '../../utils';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
+import { logEvent } from 'amplitude-js';
 
 const Bosituasjon: FC = () => {
   const intl = useIntl();
@@ -25,6 +26,14 @@ const Bosituasjon: FC = () => {
   const skalViseKnapper = !kommerFraOppsummering
     ? ESide.visTilbakeNesteAvbrytKnapp
     : ESide.visTilbakeTilOppsummeringKnapp;
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'Bosituasjon',
+      team: 'familie',
+      app: 'SP-soknadsdialog',
+    });
+  }, []);
 
   const settBosituasjon = (bosituasjon: IBosituasjon) => {
     settSøknad((prevSoknad) => {

--- a/src/skolepenger/steg/3-barnadine/BarnaDine.tsx
+++ b/src/skolepenger/steg/3-barnadine/BarnaDine.tsx
@@ -15,7 +15,7 @@ import { hentPathSkolepengerOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningSkolepenger } from '../../../utils/amplitude';
 
 const BarnaDine: React.FC = () => {
   const intl = useIntl();
@@ -32,11 +32,7 @@ const BarnaDine: React.FC = () => {
     : ESide.visTilbakeTilOppsummeringKnapp;
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'BarnaDine',
-      team: 'familie',
-      app: 'SP-soknadsdialog',
-    });
+    logSidevisningSkolepenger('BarnaDine');
   }, []);
 
   const [åpenModal, settÅpenModal] = useState(false);

--- a/src/skolepenger/steg/3-barnadine/BarnaDine.tsx
+++ b/src/skolepenger/steg/3-barnadine/BarnaDine.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Knapp } from 'nav-frontend-knapper';
 import Modal from 'nav-frontend-modal';
 import { AlertStripeInfo } from 'nav-frontend-alertstriper';
@@ -15,6 +15,7 @@ import { hentPathSkolepengerOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
+import { logEvent } from 'amplitude-js';
 
 const BarnaDine: React.FC = () => {
   const intl = useIntl();
@@ -29,6 +30,14 @@ const BarnaDine: React.FC = () => {
   const skalViseKnapper = !kommerFraOppsummering
     ? ESide.visTilbakeNesteAvbrytKnapp
     : ESide.visTilbakeTilOppsummeringKnapp;
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'BarnaDine',
+      team: 'familie',
+      app: 'SP-soknadsdialog',
+    });
+  }, []);
 
   const [åpenModal, settÅpenModal] = useState(false);
 

--- a/src/skolepenger/steg/3-barnadine/BarnaDine.tsx
+++ b/src/skolepenger/steg/3-barnadine/BarnaDine.tsx
@@ -15,7 +15,7 @@ import { hentPathSkolepengerOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../../utils/amplitude';
 
 const BarnaDine: React.FC = () => {
   const intl = useIntl();

--- a/src/skolepenger/steg/3-barnadine/BarnaDine.tsx
+++ b/src/skolepenger/steg/3-barnadine/BarnaDine.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Knapp } from 'nav-frontend-knapper';
 import Modal from 'nav-frontend-modal';
 import { AlertStripeInfo } from 'nav-frontend-alertstriper';
@@ -16,6 +16,7 @@ import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { logSidevisningSkolepenger } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const BarnaDine: React.FC = () => {
   const intl = useIntl();
@@ -31,9 +32,7 @@ const BarnaDine: React.FC = () => {
     ? ESide.visTilbakeNesteAvbrytKnapp
     : ESide.visTilbakeTilOppsummeringKnapp;
 
-  useEffect(() => {
-    logSidevisningSkolepenger('BarnaDine');
-  }, []);
+  useMount(() => logSidevisningSkolepenger('BarnaDine'));
 
   const [åpenModal, settÅpenModal] = useState(false);
 

--- a/src/skolepenger/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/skolepenger/steg/4-barnasbosted/BarnasBosted.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef } from 'react';
 import { hentTekst } from '../../../utils/søknad';
 import { useLocation } from 'react-router-dom';
 import { useIntl } from 'react-intl';
@@ -13,6 +13,7 @@ import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { logSidevisningSkolepenger } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
   if (!ref || !ref.current) return;
@@ -33,9 +34,7 @@ const BarnasBosted: React.FC = () => {
     settDokumentasjonsbehovForBarn,
   } = useSkolepengerSøknad();
 
-  useEffect(() => {
-    logSidevisningSkolepenger('BarnasBosted');
-  }, []);
+  useMount(() => logSidevisningSkolepenger('BarnasBosted'));
 
   const barna = søknad.person.barn;
   const [sisteBarnUtfylt, settSisteBarnUtfylt] = useState<boolean>(false);

--- a/src/skolepenger/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/skolepenger/steg/4-barnasbosted/BarnasBosted.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { hentTekst } from '../../../utils/søknad';
 import { useLocation } from 'react-router-dom';
 import { useIntl } from 'react-intl';
@@ -12,6 +12,7 @@ import { hentPathSkolepengerOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
+import { logEvent } from 'amplitude-js';
 
 const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
   if (!ref || !ref.current) return;
@@ -31,6 +32,14 @@ const BarnasBosted: React.FC = () => {
     settSøknad,
     settDokumentasjonsbehovForBarn,
   } = useSkolepengerSøknad();
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'BarnasBosted',
+      team: 'familie',
+      app: 'SP-soknadsdialog',
+    });
+  }, []);
 
   const barna = søknad.person.barn;
   const [sisteBarnUtfylt, settSisteBarnUtfylt] = useState<boolean>(false);

--- a/src/skolepenger/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/skolepenger/steg/4-barnasbosted/BarnasBosted.tsx
@@ -12,7 +12,7 @@ import { hentPathSkolepengerOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../../utils/amplitude';
 
 const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
   if (!ref || !ref.current) return;

--- a/src/skolepenger/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/skolepenger/steg/4-barnasbosted/BarnasBosted.tsx
@@ -12,7 +12,7 @@ import { hentPathSkolepengerOppsummering } from '../../utils';
 import Side, { ESide } from '../../../components/side/Side';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningSkolepenger } from '../../../utils/amplitude';
 
 const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
   if (!ref || !ref.current) return;
@@ -34,11 +34,7 @@ const BarnasBosted: React.FC = () => {
   } = useSkolepengerSøknad();
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'BarnasBosted',
-      team: 'familie',
-      app: 'SP-soknadsdialog',
-    });
+    logSidevisningSkolepenger('BarnasBosted');
   }, []);
 
   const barna = søknad.person.barn;

--- a/src/skolepenger/steg/5-aktivitet/UtdanningSituasjon.tsx
+++ b/src/skolepenger/steg/5-aktivitet/UtdanningSituasjon.tsx
@@ -10,7 +10,7 @@ import { useSkolepengerSøknad } from '../../SkolepengerContext';
 import UnderUtdanning from '../../../søknad/steg/5-aktivitet/underUtdanning/UnderUtdanning';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../../utils/amplitude';
 
 const UtdanningSituasjon: React.FC = () => {
   const intl = useIntl();

--- a/src/skolepenger/steg/5-aktivitet/UtdanningSituasjon.tsx
+++ b/src/skolepenger/steg/5-aktivitet/UtdanningSituasjon.tsx
@@ -10,7 +10,7 @@ import { useSkolepengerSøknad } from '../../SkolepengerContext';
 import UnderUtdanning from '../../../søknad/steg/5-aktivitet/underUtdanning/UnderUtdanning';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningSkolepenger } from '../../../utils/amplitude';
 
 const UtdanningSituasjon: React.FC = () => {
   const intl = useIntl();
@@ -22,11 +22,7 @@ const UtdanningSituasjon: React.FC = () => {
     : ESide.visTilbakeTilOppsummeringKnapp;
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Aktivitet',
-      team: 'familie',
-      app: 'SP-soknadsdialog',
-    });
+    logSidevisningSkolepenger('Aktivitet');
   }, []);
 
   const oppdaterUnderUtdanning = (underUtdanning: IDetaljertUtdanning) => {

--- a/src/skolepenger/steg/5-aktivitet/UtdanningSituasjon.tsx
+++ b/src/skolepenger/steg/5-aktivitet/UtdanningSituasjon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
 import { erAllUtdanningFerdigUtfylt } from '../../../helpers/steg/aktivitetvalidering';
@@ -10,6 +10,7 @@ import { useSkolepengerSøknad } from '../../SkolepengerContext';
 import UnderUtdanning from '../../../søknad/steg/5-aktivitet/underUtdanning/UnderUtdanning';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
+import { logEvent } from 'amplitude-js';
 
 const UtdanningSituasjon: React.FC = () => {
   const intl = useIntl();
@@ -19,6 +20,14 @@ const UtdanningSituasjon: React.FC = () => {
   const skalViseKnapper = !kommerFraOppsummering
     ? ESide.visTilbakeNesteAvbrytKnapp
     : ESide.visTilbakeTilOppsummeringKnapp;
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'Aktivitet',
+      team: 'familie',
+      app: 'SP-soknadsdialog',
+    });
+  }, []);
 
   const oppdaterUnderUtdanning = (underUtdanning: IDetaljertUtdanning) => {
     settSøknad((prevSøknad) => {

--- a/src/skolepenger/steg/5-aktivitet/UtdanningSituasjon.tsx
+++ b/src/skolepenger/steg/5-aktivitet/UtdanningSituasjon.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
 import { erAllUtdanningFerdigUtfylt } from '../../../helpers/steg/aktivitetvalidering';
@@ -11,6 +11,7 @@ import UnderUtdanning from '../../../søknad/steg/5-aktivitet/underUtdanning/Und
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { logSidevisningSkolepenger } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const UtdanningSituasjon: React.FC = () => {
   const intl = useIntl();
@@ -21,9 +22,7 @@ const UtdanningSituasjon: React.FC = () => {
     ? ESide.visTilbakeNesteAvbrytKnapp
     : ESide.visTilbakeTilOppsummeringKnapp;
 
-  useEffect(() => {
-    logSidevisningSkolepenger('Aktivitet');
-  }, []);
+  useMount(() => logSidevisningSkolepenger('Aktivitet'));
 
   const oppdaterUnderUtdanning = (underUtdanning: IDetaljertUtdanning) => {
     settSøknad((prevSøknad) => {

--- a/src/skolepenger/steg/6-oppsummering/Oppsummering.tsx
+++ b/src/skolepenger/steg/6-oppsummering/Oppsummering.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Normaltekst } from 'nav-frontend-typografi';
 import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
 import { useIntl } from 'react-intl';
@@ -14,14 +14,13 @@ import { useSkolepengerSøknad } from '../../SkolepengerContext';
 import OppsummeringDetaljertUtdanning from '../../../søknad/steg/7-oppsummering/OppsummeringDetaljertUtdanning';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { logSidevisningSkolepenger } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const Oppsummering: React.FC = () => {
   const intl = useIntl();
   const { mellomlagreSkolepenger, søknad } = useSkolepengerSøknad();
 
-  useEffect(() => {
-    logSidevisningSkolepenger('Oppsummering');
-  }, []);
+  useMount(() => logSidevisningSkolepenger('Oppsummering'));
 
   return (
     <>

--- a/src/skolepenger/steg/6-oppsummering/Oppsummering.tsx
+++ b/src/skolepenger/steg/6-oppsummering/Oppsummering.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Normaltekst } from 'nav-frontend-typografi';
 import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
 import { useIntl } from 'react-intl';
@@ -13,10 +13,20 @@ import { hentTekst } from '../../../utils/søknad';
 import { useSkolepengerSøknad } from '../../SkolepengerContext';
 import OppsummeringDetaljertUtdanning from '../../../søknad/steg/7-oppsummering/OppsummeringDetaljertUtdanning';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { logEvent } from 'amplitude-js';
 
 const Oppsummering: React.FC = () => {
   const intl = useIntl();
   const { mellomlagreSkolepenger, søknad } = useSkolepengerSøknad();
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'Oppsummering',
+      team: 'familie',
+      app: 'SP-soknadsdialog',
+    });
+  }, []);
+
   return (
     <>
       <Side

--- a/src/skolepenger/steg/6-oppsummering/Oppsummering.tsx
+++ b/src/skolepenger/steg/6-oppsummering/Oppsummering.tsx
@@ -13,18 +13,14 @@ import { hentTekst } from '../../../utils/søknad';
 import { useSkolepengerSøknad } from '../../SkolepengerContext';
 import OppsummeringDetaljertUtdanning from '../../../søknad/steg/7-oppsummering/OppsummeringDetaljertUtdanning';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningSkolepenger } from '../../../utils/amplitude';
 
 const Oppsummering: React.FC = () => {
   const intl = useIntl();
   const { mellomlagreSkolepenger, søknad } = useSkolepengerSøknad();
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Oppsummering',
-      team: 'familie',
-      app: 'SP-soknadsdialog',
-    });
+    logSidevisningSkolepenger('Oppsummering');
   }, []);
 
   return (

--- a/src/skolepenger/steg/6-oppsummering/Oppsummering.tsx
+++ b/src/skolepenger/steg/6-oppsummering/Oppsummering.tsx
@@ -13,7 +13,7 @@ import { hentTekst } from '../../../utils/søknad';
 import { useSkolepengerSøknad } from '../../SkolepengerContext';
 import OppsummeringDetaljertUtdanning from '../../../søknad/steg/7-oppsummering/OppsummeringDetaljertUtdanning';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../../utils/amplitude';
 
 const Oppsummering: React.FC = () => {
   const intl = useIntl();

--- a/src/skolepenger/steg/7-dokumentasjon/Dokumentasjon.tsx
+++ b/src/skolepenger/steg/7-dokumentasjon/Dokumentasjon.tsx
@@ -16,6 +16,7 @@ import { IVedlegg } from '../../../models/steg/vedlegg';
 import { useSkolepengerSøknad } from '../../SkolepengerContext';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { logEvent } from 'amplitude-js';
 
 const Dokumentasjon: React.FC = () => {
   const intl = useIntl();
@@ -24,6 +25,14 @@ const Dokumentasjon: React.FC = () => {
   const { dokumentasjonsbehov } = søknad;
   const sidetittel: string = hentTekst('dokumentasjon.tittel', intl);
   const forrigeDokumentasjonsbehov = usePrevious(søknad.dokumentasjonsbehov);
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'Dokumentasjon',
+      team: 'familie',
+      app: 'SP-soknadsdialog',
+    });
+  }, []);
 
   const oppdaterDokumentasjon = (
     dokumentasjonsid: string,

--- a/src/skolepenger/steg/7-dokumentasjon/Dokumentasjon.tsx
+++ b/src/skolepenger/steg/7-dokumentasjon/Dokumentasjon.tsx
@@ -17,6 +17,7 @@ import { useSkolepengerSøknad } from '../../SkolepengerContext';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { logSidevisningSkolepenger } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const Dokumentasjon: React.FC = () => {
   const intl = useIntl();
@@ -26,9 +27,7 @@ const Dokumentasjon: React.FC = () => {
   const sidetittel: string = hentTekst('dokumentasjon.tittel', intl);
   const forrigeDokumentasjonsbehov = usePrevious(søknad.dokumentasjonsbehov);
 
-  useEffect(() => {
-    logSidevisningSkolepenger('Dokumentasjon');
-  }, []);
+  useMount(() => logSidevisningSkolepenger('Dokumentasjon'));
 
   const oppdaterDokumentasjon = (
     dokumentasjonsid: string,

--- a/src/skolepenger/steg/7-dokumentasjon/Dokumentasjon.tsx
+++ b/src/skolepenger/steg/7-dokumentasjon/Dokumentasjon.tsx
@@ -16,7 +16,7 @@ import { IVedlegg } from '../../../models/steg/vedlegg';
 import { useSkolepengerSøknad } from '../../SkolepengerContext';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningSkolepenger } from '../../../utils/amplitude';
 
 const Dokumentasjon: React.FC = () => {
   const intl = useIntl();
@@ -27,11 +27,7 @@ const Dokumentasjon: React.FC = () => {
   const forrigeDokumentasjonsbehov = usePrevious(søknad.dokumentasjonsbehov);
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Dokumentasjon',
-      team: 'familie',
-      app: 'SP-soknadsdialog',
-    });
+    logSidevisningSkolepenger('Dokumentasjon');
   }, []);
 
   const oppdaterDokumentasjon = (

--- a/src/skolepenger/steg/7-dokumentasjon/Dokumentasjon.tsx
+++ b/src/skolepenger/steg/7-dokumentasjon/Dokumentasjon.tsx
@@ -16,7 +16,7 @@ import { IVedlegg } from '../../../models/steg/vedlegg';
 import { useSkolepengerSøknad } from '../../SkolepengerContext';
 import { LocationStateSøknad } from '../../../models/søknad/søknad';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../../utils/amplitude';
 
 const Dokumentasjon: React.FC = () => {
   const intl = useIntl();

--- a/src/skolepenger/steg/8-kvittering/Kvittering.tsx
+++ b/src/skolepenger/steg/8-kvittering/Kvittering.tsx
@@ -17,7 +17,7 @@ import EttersendDokumentasjon from '../../../søknad/steg/9-kvittering/Ettersend
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { useSkolepengerSøknad } from '../../SkolepengerContext';
 import { usePersonContext } from '../../../context/PersonContext';
-import { logEvent } from '../../../utils/amplitude';
+import { logSidevisningSkolepenger } from '../../../utils/amplitude';
 
 const Kvittering: React.FC = () => {
   const intl = useIntl();
@@ -29,11 +29,7 @@ const Kvittering: React.FC = () => {
   const { person } = usePersonContext();
 
   useEffect(() => {
-    logEvent('sidevisning', {
-      side: 'Kvittering',
-      team: 'familie',
-      app: 'SP-soknadsdialog',
-    });
+    logSidevisningSkolepenger('Kvittering');
   }, []);
 
   useEffect(() => {

--- a/src/skolepenger/steg/8-kvittering/Kvittering.tsx
+++ b/src/skolepenger/steg/8-kvittering/Kvittering.tsx
@@ -18,6 +18,7 @@ import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { useSkolepengerSøknad } from '../../SkolepengerContext';
 import { usePersonContext } from '../../../context/PersonContext';
 import { logSidevisningSkolepenger } from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
 
 const Kvittering: React.FC = () => {
   const intl = useIntl();
@@ -28,9 +29,7 @@ const Kvittering: React.FC = () => {
   } = useSkolepengerSøknad();
   const { person } = usePersonContext();
 
-  useEffect(() => {
-    logSidevisningSkolepenger('Kvittering');
-  }, []);
+  useMount(() => logSidevisningSkolepenger('Kvittering'));
 
   useEffect(() => {
     nullstillMellomlagretSkolepenger();

--- a/src/skolepenger/steg/8-kvittering/Kvittering.tsx
+++ b/src/skolepenger/steg/8-kvittering/Kvittering.tsx
@@ -17,7 +17,7 @@ import EttersendDokumentasjon from '../../../søknad/steg/9-kvittering/Ettersend
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { useSkolepengerSøknad } from '../../SkolepengerContext';
 import { usePersonContext } from '../../../context/PersonContext';
-import { logEvent } from 'amplitude-js';
+import { logEvent } from '../../../utils/amplitude';
 
 const Kvittering: React.FC = () => {
   const intl = useIntl();

--- a/src/skolepenger/steg/8-kvittering/Kvittering.tsx
+++ b/src/skolepenger/steg/8-kvittering/Kvittering.tsx
@@ -17,6 +17,7 @@ import EttersendDokumentasjon from '../../../søknad/steg/9-kvittering/Ettersend
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { useSkolepengerSøknad } from '../../SkolepengerContext';
 import { usePersonContext } from '../../../context/PersonContext';
+import { logEvent } from 'amplitude-js';
 
 const Kvittering: React.FC = () => {
   const intl = useIntl();
@@ -26,6 +27,14 @@ const Kvittering: React.FC = () => {
     nullstillSøknadSkolepenger,
   } = useSkolepengerSøknad();
   const { person } = usePersonContext();
+
+  useEffect(() => {
+    logEvent('sidevisning', {
+      side: 'Kvittering',
+      team: 'familie',
+      app: 'SP-soknadsdialog',
+    });
+  }, []);
 
   useEffect(() => {
     nullstillMellomlagretSkolepenger();

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -1,4 +1,5 @@
 import amplitude from 'amplitude-js';
+import { StringDecoder } from 'string_decoder';
 
 const amplitudeInstance = amplitude.getInstance();
 
@@ -13,3 +14,35 @@ amplitudeInstance.init('default', '', {
 export function logEvent(eventName: string, eventProperties: any) {
   amplitudeInstance.logEvent(eventName, eventProperties);
 }
+
+export const logSidevisningOvergangsstonad = (side: string) => {
+  logEvent('sidevisning', {
+    side,
+    team: 'familie',
+    app: 'OS-soknadsdialog',
+  });
+};
+
+export const logSidevisningArbeidssokerskjema = (side: string) => {
+  logEvent('sidevisning', {
+    side,
+    team: 'familie',
+    app: 'Arbeidssokerskjema',
+  });
+};
+
+export const logSidevisningBarnetilsyn = (side: string) => {
+  logEvent('sidevisning', {
+    side,
+    team: 'familie',
+    app: 'BT-soknadsdialog',
+  });
+};
+
+export const logSidevisningSkolepenger = (side: string) => {
+  logEvent('sidevisning', {
+    side,
+    team: 'familie',
+    app: 'SP-soknadsdialog',
+  });
+};

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -1,5 +1,4 @@
 import amplitude from 'amplitude-js';
-import { StringDecoder } from 'string_decoder';
 
 const amplitudeInstance = amplitude.getInstance();
 

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -56,3 +56,10 @@ export const useLeggTilSærligeBehovHvisHarEttBarMedSærligeBehov = (
     intl,
   ]);
 };
+
+export const useMount = (fn: () => void) => {
+  useEffect(() => {
+    fn();
+    //eslint-disable-next-line
+  }, []);
+};


### PR DESCRIPTION
Denne PRen legger til sidevisning-tracking på Barnetilsyn, Arbeidssøkerskjema og Skolepenger.

Med unntak av event-tagen (sidevisning), kan vi sende inn hvilke tags vi vil. Siden det er en SPA og hele appen er én side, får vi ikke automatisk tracket sidevisninger. Jeg har derfor lagt til en egen `side`-tag for å skille de forskjellige stegene i søknadene.

For å skille mellom Barnetilsyn, Arbeidssøkerskjema, Skolepenger og Overgangsstønad har jeg lagt til en `app`-tag (hhv. med verdiene "BT-soknadsdialog", "Arbeidssokerskjema", "SP-soknadsdialog" og "OS-soknadsdialog"). 

Jeg har også valgt å sende med en `team: familie`-tag, slik at vi kan filtrere på våre apper i Amplitude. Alle disse taggene og verdiene kan diskuteres, men vi kan ikke endre dem senere, siden vi da mister historikken. Gi også beskjed om det er noen flere tags vi burde sende med.