### PR TITLE
Nullstill foreldreinfo

### DIFF
--- a/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
+++ b/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
@@ -6,6 +6,7 @@ import { IForelder } from '../../../models/steg/forelder';
 import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
 import { harValgtSvar } from '../../../utils/spørsmålogsvar';
 import { hentBarnetsNavnEllerBeskrivelse } from '../../../utils/barn';
+import { hentUid } from '../../../utils/autentiseringogvalidering/uuid';
 
 interface Props {
   barn: IBarn;
@@ -59,14 +60,15 @@ const AnnenForelderKnapper: React.FC<Props> = ({
   const leggTilAnnenForelder = () => {
     settBarnHarSammeForelder(false);
     settAndreForelderRadioVerdi('annen-forelder');
+    const id = hentUid();
 
     !barn.harSammeAdresse.verdi &&
     harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi)
       ? settForelder({
-          ...forelder,
           skalBarnetBoHosSøker: forelder.skalBarnetBoHosSøker,
+          id
         })
-      : settForelder(forelder);
+      : settForelder({id});
   };
 
   const andreForelder = 'andre-forelder-';


### PR DESCRIPTION
Løser denne [Favro-oppgaven](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-3027) ved å nullstille foreldreinformasjonen når man velger "Annen forelder".