### PR TITLE
Endre tekst fra 'Donorbarn' til 'Donor'

### DIFF
--- a/src/language/tekster_nb.ts
+++ b/src/language/tekster_nb.ts
@@ -345,7 +345,7 @@ export default {
   'barnasbosted.land': 'Land',
   'barnasbosted.spm.hvorforikkeoppgi':
     'Hvorfor kan du ikke oppgi den andre forelderen?',
-  'barnasbosted.spm.donorbarn': 'Donorbarn',
+  'barnasbosted.spm.donorbarn': 'Donor',
   'barnasbosted.spm.annet': 'Annet',
   'barnasbosted.avtale':
     'Har du og den andre forelderen skriftlig avtale om delt bosted for [0]?',


### PR DESCRIPTION
Er en gammel fiks som tydeligvis har blitt reversert, endrer tilbake til "Donor".