### PR TITLE
Bug/vis spm og veiledningstekst

### DIFF
--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -779,13 +779,22 @@ export default {
     '</ul>',
 
   // barnHarSærligeBehov
-  'dinSituasjon.alert.harBarnMedSærligeBehov.tittel':
+  'dinSituasjon.dok.harBarnMedSærligeBehov.tittel':
     'You must provide documentation of your child’s special supervision needs',
-  'dinSituasjon.alert.harBarnMedSærligeBehov.beskrivelse':
+  'dinSituasjon.dok.harBarnMedSærligeBehov.beskrivelse':
     'Documentation from your doctor must confirm:' +
     '<ul>' +
     '<li>that the child has medical, mental or major social problems and needs supervision</li>' +
     '<li>that this affects your ability to be in occupational activity</li>' +
+    '</ul>',
+  'dinSituasjon.alert.harBarnMedSærligeBehov.tittel':
+    'About [0]’s need for special supervision',
+  'dinSituasjon.alert.harBarnMedSærligeBehov.beskrivelse':
+    'We need information about:' +
+    '<ul>' +
+    '<li>how much supervision your child needs</li>' +
+    '<li>what kind of supervision</li>' +
+    '<li>how this affects your ability to be in occupational activity</li>' +
     '</ul>',
 
   'dinSituasjon.datovelger.jobb': 'When are you going to start your new job?',

--- a/src/language/tekster_nb.ts
+++ b/src/language/tekster_nb.ts
@@ -732,13 +732,22 @@ export default {
     '</ul>',
 
   // barnHarSærligeBehov
-  'dinSituasjon.alert.harBarnMedSærligeBehov.tittel':
-    'Du må legge ved dokumentasjon som bekrefter at barnet ditt har behov for særlig tilsyn.',
-  'dinSituasjon.alert.harBarnMedSærligeBehov.beskrivelse':
-    'Dokumentasjonen fra lege må bekrefte: ' +
+  'dinSituasjon.dok.harBarnMedSærligeBehov.tittel':
+    'Du må legge ved dokumentasjon som bekrefter at barnet ditt har behov for særlig tilsyn',
+  'dinSituasjon.dok.harBarnMedSærligeBehov.beskrivelse':
+    'Dokumentasjonen fra lege må bekrefte:' +
     '<ul>' +
     '<li>at barnet har medisinske, psykiske eller store sosiale problemer og trenger tilsyn</li>' +
     '<li>at dette påvirker muligheten din til å være i yrkesrettet aktivitet</li>' +
+    '</ul>',
+
+  'dinSituasjon.alert.harBarnMedSærligeBehov.tittel':
+    'Om tilsynsbehovet til [0]',
+  'dinSituasjon.alert.harBarnMedSærligeBehov.beskrivelse':
+    'Vi trenger opplysninger om:' +
+    '<ul>' +
+    '<li>hvor mye og hvordan barnet ditt trenger tilsyn</li>' +
+    '<li>hvordan det påvirker muligheten din til å være i yrkesrettet aktivitet</li>' +
     '</ul>',
 
   'dinSituasjon.datovelger.jobb': 'Når skal du starte i ny jobb?',

--- a/src/language/tekster_nn.ts
+++ b/src/language/tekster_nn.ts
@@ -775,13 +775,22 @@ export default {
     '</ul>',
 
   // barnHarSærligeBehov
-  'dinSituasjon.alert.harBarnMedSærligeBehov.tittel':
-    'You must provide documentation of your child’s special supervision needs',
-  'dinSituasjon.alert.harBarnMedSærligeBehov.beskrivelse':
-    'Documentation from your doctor must confirm:' +
+
+  'dinSituasjon.dok.harBarnMedSærligeBehov.tittel':
+    'Du må leggje ved dokumentasjon på tilsynsbehovet til barnet.',
+  'dinSituasjon.dok.harBarnMedSærligeBehov.beskrivelse':
+    'Dokumentasjon frå legen din som stadfestar: ' +
     '<ul>' +
-    '<li>that the child has medical, mental or major social problems and needs supervision</li>' +
-    '<li>that this affects your ability to be in occupational activity</li>' +
+    '<li>at barnet har medisinske, psykiske eller store sosiale problem og treng tilsyn</li>' +
+    '<li>kat dette påverkar i kva grad det er mogleg for deg å vere i yrkesretta aktivitet</li>' +
+    '</ul>',
+  'dinSituasjon.alert.harBarnMedSærligeBehov.tittel':
+    'Om tilsynsbehovet til [0]',
+  'dinSituasjon.alert.harBarnMedSærligeBehov.beskrivelse':
+    'Vi treng opplysningar om:' +
+    '<ul>' +
+    '<li>kor mykje og korleis barnet ditt treng tilsyn</li>' +
+    '<li>korleis dette påverkar i kva grad det er mogleg for deg å vere i yrkesretta aktivitet</li>' +
     '</ul>',
 
   'dinSituasjon.datovelger.jobb': 'When are you going to start your new job?',

--- a/src/søknad/steg/6-meromsituasjon/BarnMedSærligeBehov.tsx
+++ b/src/søknad/steg/6-meromsituasjon/BarnMedSærligeBehov.tsx
@@ -15,10 +15,10 @@ const BarnMedSærligeBehov: React.FC = () => {
         <AlertStripeDokumentasjon>
           <Normaltekst className="blokk-xs" style={{ fontWeight: 600 }}>
             {intl.formatMessage({
-              id: 'dinSituasjon.alert.harBarnMedSærligeBehov.tittel',
+              id: 'dinSituasjon.dok.harBarnMedSærligeBehov.tittel',
             })}
           </Normaltekst>
-          <LocaleTekst tekst="dinSituasjon.alert.harBarnMedSærligeBehov.beskrivelse" />
+          <LocaleTekst tekst="dinSituasjon.dok.harBarnMedSærligeBehov.beskrivelse" />
         </AlertStripeDokumentasjon>
       </KomponentGruppe>
       <HvilkeBarnHarSærligeBehov />

--- a/src/søknad/steg/6-meromsituasjon/SituasjonUtil.ts
+++ b/src/søknad/steg/6-meromsituasjon/SituasjonUtil.ts
@@ -24,7 +24,7 @@ export const erSituasjonIAvhukedeSvar = (
   });
 };
 export const harSøkerMindreEnnHalvStilling = (søknad: ISøknad): boolean => {
-  const { firmaer, underUtdanning, arbeidsforhold } = søknad.aktivitet;
+  const { firmaer, arbeidsforhold, firma, egetAS } = søknad.aktivitet;
 
   let totalArbeidsmengde: number = 0;
   if (firmaer)
@@ -33,8 +33,14 @@ export const harSøkerMindreEnnHalvStilling = (søknad: ISøknad): boolean => {
         ? initiell + fraStringTilTall(firma.arbeidsmengde?.verdi)
         : initiell;
     }, 0);
-  if (underUtdanning?.arbeidsmengde)
-    totalArbeidsmengde += fraStringTilTall(underUtdanning.arbeidsmengde.verdi);
+  if (firma?.arbeidsmengde)
+    totalArbeidsmengde += fraStringTilTall(firma.arbeidsmengde.verdi);
+  if (egetAS)
+    totalArbeidsmengde += egetAS.reduce((initiell, selskap) => {
+      return selskap.arbeidsmengde?.verdi
+        ? initiell + fraStringTilTall(selskap.arbeidsmengde?.verdi)
+        : initiell;
+    }, 0);
   if (arbeidsforhold) {
     const arbeidsmengder = arbeidsforhold.map((arbeidsgiver: IArbeidsgiver) => {
       return arbeidsgiver.arbeidsmengde


### PR DESCRIPTION
Fikser disse to bugsa opdaget av Mirja:
- [Viser ikke spørsmål (når man har mindre arbeid enn 50% totalt) ](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-4371)
- [Viser dobbelt opp med samme tekst (alert tekst for barn med særlig tilsynsbehov, situasjon)](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-4372)

![image](https://user-images.githubusercontent.com/8249453/115196550-52ff7280-a0f0-11eb-98d7-af48c0eb6b7b.png)
