### PR TITLE
Fiks datoformat

### DIFF
--- a/src/components/dato/Datovelger.tsx
+++ b/src/components/dato/Datovelger.tsx
@@ -11,6 +11,7 @@ import styled from 'styled-components/macro';
 import { DatepickerLimitations } from 'nav-datovelger/lib/types';
 import Feilmelding from '../feil/Feilmelding';
 import { erDatoInnaforBegrensinger } from './utils';
+import { strengTilDato } from '../../utils/dato';
 
 export const StyledDatovelger = styled.div<{ fetSkrift?: boolean }>`
   .typo-normal {
@@ -67,6 +68,10 @@ const Datovelger: React.FC<Props> = ({
   const [_dato, _settDato] = useState<string>(valgtDato ? valgtDato : '');
   const [feilmelding, settFeilmelding] = useState<string>('');
 
+  const datoTilRiktigFormat = (dato: string) => {
+    return formatIsoDate(strengTilDato(dato));
+  };
+
   const limitations: DatepickerLimitations = hentDatobegrensninger(
     datobegrensning
   );
@@ -93,7 +98,7 @@ const Datovelger: React.FC<Props> = ({
   };
 
   useEffect(() => {
-    _dato !== '' && settDato(_dato);
+    _dato !== '' && settDato(datoTilRiktigFormat(_dato));
     _dato !== '' && settFeilmelding(hentFeilmelding(_dato, datobegrensning));
 
     // eslint-disable-next-line

--- a/src/components/dato/Datovelger.tsx
+++ b/src/components/dato/Datovelger.tsx
@@ -11,7 +11,6 @@ import styled from 'styled-components/macro';
 import { DatepickerLimitations } from 'nav-datovelger/lib/types';
 import Feilmelding from '../feil/Feilmelding';
 import { erDatoInnaforBegrensinger } from './utils';
-import { strengTilDato } from '../../utils/dato';
 
 export const StyledDatovelger = styled.div<{ fetSkrift?: boolean }>`
   .typo-normal {
@@ -68,10 +67,6 @@ const Datovelger: React.FC<Props> = ({
   const [_dato, _settDato] = useState<string>(valgtDato ? valgtDato : '');
   const [feilmelding, settFeilmelding] = useState<string>('');
 
-  const datoTilRiktigFormat = (dato: string) => {
-    return formatIsoDate(strengTilDato(dato));
-  };
-
   const limitations: DatepickerLimitations = hentDatobegrensninger(
     datobegrensning
   );
@@ -98,7 +93,7 @@ const Datovelger: React.FC<Props> = ({
   };
 
   useEffect(() => {
-    _dato !== '' && settDato(datoTilRiktigFormat(_dato));
+    _dato !== '' && settDato(_dato);
     _dato !== '' && settFeilmelding(hentFeilmelding(_dato, datobegrensning));
 
     // eslint-disable-next-line

--- a/src/utils/dato.ts
+++ b/src/utils/dato.ts
@@ -25,6 +25,13 @@ export const GYLDIGE_DATOFORMAT = [
   'ddMMyy',
 ];
 
+const erGyldigFormat = (verdi: string) => {
+  var regEx = /^\d{4}-\d{2}-\d{2}$/;
+  if (!verdi.match(regEx)) return false;
+
+  return true;
+};
+
 export const parseDate = (date: string) => {
   return parse(date, STANDARD_DATOFORMAT, new Date());
 };
@@ -68,7 +75,7 @@ export const dagensDato = startOfToday();
 export const dagensDatoMedTidspunktStreng = new Date().toISOString();
 
 export const erGyldigDato = (verdi: string | undefined): boolean => {
-  return verdi ? isValid(new Date(verdi)) : false;
+  return verdi ? erGyldigFormat(verdi) && isValid(new Date(verdi)) : false;
 };
 
 // Vedlegg er lagret ut neste døgn

--- a/src/utils/dato.ts
+++ b/src/utils/dato.ts
@@ -26,8 +26,8 @@ export const GYLDIGE_DATOFORMAT = [
 ];
 
 const erGyldigFormat = (verdi: string) => {
-  var regEx = /^\d{4}-\d{2}-\d{2}$/;
-  if (!verdi.match(regEx)) return false;
+  const YYYYMMDD = /^\d{4}-\d{2}-\d{2}$/;
+  if (!verdi.match(YYYYMMDD)) return false;
 
   return true;
 };

--- a/src/utils/dato.ts
+++ b/src/utils/dato.ts
@@ -27,9 +27,8 @@ export const GYLDIGE_DATOFORMAT = [
 
 const erGyldigFormat = (verdi: string) => {
   const YYYYMMDD = /^\d{4}-\d{2}-\d{2}$/;
-  if (!verdi.match(YYYYMMDD)) return false;
 
-  return true;
+  return verdi.match(YYYYMMDD);
 };
 
 export const parseDate = (date: string) => {

--- a/src/utils/dato.ts
+++ b/src/utils/dato.ts
@@ -28,7 +28,7 @@ export const GYLDIGE_DATOFORMAT = [
 const erGyldigFormat = (verdi: string) => {
   const YYYYMMDD = /^\d{4}-\d{2}-\d{2}$/;
 
-  return verdi.match(YYYYMMDD);
+  return !!verdi.match(YYYYMMDD);
 };
 
 export const parseDate = (date: string) => {


### PR DESCRIPTION
Hindrer at man får sendt inn søknad med dato på format `mm.dd-yyyy`, som kræsjer backend.