### PR TITLE
Mer amplitude-logging

### DIFF
--- a/src/barnetilsyn/Forside.tsx
+++ b/src/barnetilsyn/Forside.tsx
@@ -22,7 +22,10 @@ import { logSidevisningBarnetilsyn } from '../utils/amplitude';
 import { useMount } from '../utils/hooks';
 
 const Forside: React.FC<any> = ({ intl }) => {
-  useMount(() => logSidevisningBarnetilsyn('Forside'));
+  useMount(() => {
+    if (!(kanBrukeMellomlagretSøknad && mellomlagretBarnetilsyn))
+      logSidevisningBarnetilsyn('Forside');
+  });
 
   const { person } = usePersonContext();
   const [locale] = useSpråkContext();

--- a/src/barnetilsyn/Forside.tsx
+++ b/src/barnetilsyn/Forside.tsx
@@ -20,11 +20,15 @@ import { hentPath } from '../utils/routing';
 import LocaleTekst from '../language/LocaleTekst';
 import { logSidevisningBarnetilsyn } from '../utils/amplitude';
 import { useMount } from '../utils/hooks';
+import { ESkjemanavn } from '../utils/skjemanavn';
 
 const Forside: React.FC<any> = ({ intl }) => {
   useMount(() => {
     if (!(kanBrukeMellomlagretSøknad && mellomlagretBarnetilsyn))
       logSidevisningBarnetilsyn('Forside');
+    else {
+      logSidevisningBarnetilsyn('FortsettMedMellomlagret');
+    }
   });
 
   const { person } = usePersonContext();
@@ -76,6 +80,7 @@ const Forside: React.FC<any> = ({ intl }) => {
               gjeldendeSteg={mellomlagretBarnetilsyn.gjeldendeSteg}
               brukMellomlagretSøknad={brukMellomlagretBarnetilsyn}
               nullstillMellomlagretSøknad={nullstillMellomlagretBarnetilsyn}
+              skjemanavn={ESkjemanavn.Barnetilsyn}
             />
           ) : (
             <Forsideinformasjon

--- a/src/overgangsstønad/Forside.tsx
+++ b/src/overgangsstønad/Forside.tsx
@@ -22,11 +22,15 @@ import { useIntl } from 'react-intl';
 import { logSidevisningOvergangsstonad } from '../utils/amplitude';
 import LocaleTekst from '../language/LocaleTekst';
 import { useMount } from '../utils/hooks';
+import { ESkjemanavn } from '../utils/skjemanavn';
 
 const Forside: React.FC = () => {
   useMount(() => {
     if (!(kanBrukeMellomlagretSøknad && mellomlagretOvergangsstønad))
       logSidevisningOvergangsstonad('Forside');
+    else {
+      logSidevisningOvergangsstonad('FortsettMedMellomlagret');
+    }
   });
 
   const intl = useIntl();
@@ -87,6 +91,7 @@ const Forside: React.FC = () => {
               gjeldendeSteg={mellomlagretOvergangsstønad.gjeldendeSteg}
               brukMellomlagretSøknad={brukMellomlagretOvergangsstønad}
               nullstillMellomlagretSøknad={nullstillMellomlagretOvergangsstønad}
+              skjemanavn={ESkjemanavn.Overgangsstønad}
             />
           ) : (
             <Forsideinformasjon

--- a/src/overgangsstønad/Forside.tsx
+++ b/src/overgangsstønad/Forside.tsx
@@ -24,7 +24,10 @@ import LocaleTekst from '../language/LocaleTekst';
 import { useMount } from '../utils/hooks';
 
 const Forside: React.FC = () => {
-  useMount(() => logSidevisningOvergangsstonad('Forside'));
+  useMount(() => {
+    if (!(kanBrukeMellomlagretSøknad && mellomlagretOvergangsstønad))
+      logSidevisningOvergangsstonad('Forside');
+  });
 
   const intl = useIntl();
   const { person } = usePersonContext();

--- a/src/skolepenger/Forside.tsx
+++ b/src/skolepenger/Forside.tsx
@@ -29,7 +29,10 @@ const Forside: React.FC<any> = ({ intl }) => {
     settSøknad,
   } = useSkolepengerSøknad();
 
-  useMount(() => logSidevisningSkolepenger('Forside'));
+  useMount(() => {
+    if (!(kanBrukeMellomlagretSøknad && mellomlagretSkolepenger))
+      logSidevisningSkolepenger('Forside');
+  });
 
   const settBekreftelse = (bekreftelse: boolean) => {
     settSøknad({

--- a/src/skolepenger/Forside.tsx
+++ b/src/skolepenger/Forside.tsx
@@ -17,6 +17,7 @@ import { ERouteSkolepenger, RoutesSkolepenger } from './routing/routes';
 import { hentPath } from '../utils/routing';
 import { logSidevisningSkolepenger } from '../utils/amplitude';
 import { useMount } from '../utils/hooks';
+import { ESkjemanavn } from '../utils/skjemanavn';
 
 const Forside: React.FC<any> = ({ intl }) => {
   const { person } = usePersonContext();
@@ -32,6 +33,9 @@ const Forside: React.FC<any> = ({ intl }) => {
   useMount(() => {
     if (!(kanBrukeMellomlagretSøknad && mellomlagretSkolepenger))
       logSidevisningSkolepenger('Forside');
+    else {
+      logSidevisningSkolepenger('FortsettMedMellomlagret');
+    }
   });
 
   const settBekreftelse = (bekreftelse: boolean) => {
@@ -74,6 +78,7 @@ const Forside: React.FC<any> = ({ intl }) => {
               gjeldendeSteg={mellomlagretSkolepenger.gjeldendeSteg}
               brukMellomlagretSøknad={brukMellomlagretSkolepenger}
               nullstillMellomlagretSøknad={nullstillMellomlagretSkolepenger}
+              skjemanavn={ESkjemanavn.Skolepenger}
             />
           ) : (
             <Forsideinformasjon

--- a/src/søknad/forside/FortsettSøknad.tsx
+++ b/src/søknad/forside/FortsettSøknad.tsx
@@ -6,12 +6,14 @@ import LocaleTekst from '../../language/LocaleTekst';
 import { useHistory } from 'react-router-dom';
 import SeksjonGruppe from '../../components/gruppe/SeksjonGruppe';
 import { FortsettSøknadKnappWrapper } from './FortsettSøknadKnapper';
+import { logEvent } from '../../utils/amplitude';
 
 interface FortsettSøknadProps {
   intl: IntlShape;
   gjeldendeSteg: string;
   brukMellomlagretSøknad: () => void;
   nullstillMellomlagretSøknad: () => Promise<any>;
+  skjemanavn?: string;
 }
 
 const FortsettSøknad: React.FC<FortsettSøknadProps> = ({
@@ -19,6 +21,7 @@ const FortsettSøknad: React.FC<FortsettSøknadProps> = ({
   gjeldendeSteg,
   brukMellomlagretSøknad,
   nullstillMellomlagretSøknad,
+  skjemanavn,
 }) => {
   const history = useHistory();
 
@@ -33,6 +36,11 @@ const FortsettSøknad: React.FC<FortsettSøknadProps> = ({
         <FortsettSøknadKnappWrapper>
           <KnappBase
             onClick={() => {
+              logEvent('klikk_mellomlagret', {
+                type: 'fortsett',
+                skjemanavn,
+                gjeldendeSteg,
+              });
               brukMellomlagretSøknad();
               history.push(gjeldendeSteg);
             }}
@@ -43,6 +51,11 @@ const FortsettSøknad: React.FC<FortsettSøknadProps> = ({
           </KnappBase>
           <KnappBase
             onClick={() => {
+              logEvent('klikk_mellomlagret', {
+                type: 'nullstill',
+                skjemanavn,
+                gjeldendeSteg,
+              });
               nullstillMellomlagretSøknad().then(() => {
                 window.location.reload();
               });


### PR DESCRIPTION
Hvis man fortsetter en påbegynt søknad, vil det i amplitude se ut som man faller av etter Forsiden. Vi unngår å logge sidevisning på Forsiden i disse tilfellene.

Har også lagt på logging på "Fortsett mellomlagret søknad"-siden.