### PR TITLE
Fiks adressesperre

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,8 @@ import { AlertStripeFeil } from 'nav-frontend-alertstriper';
 import { EAlvorlighetsgrad } from './models/felles/feilmelding';
 import LocaleTekst from './language/LocaleTekst';
 import { useIntl } from 'react-intl';
+import { logAdressesperre } from './utils/amplitude';
+import { ESkjemanavn } from './utils/skjemanavn';
 
 const App = () => {
   const [autentisert, settAutentisering] = useState<boolean>(false);
@@ -58,6 +60,7 @@ const App = () => {
         const feil = e.response?.data?.feil;
 
         if (feil === 'adressesperre') {
+          logAdressesperre(ESkjemanavn.Overgangsstønad);
           settAlvorlighetsgrad(EAlvorlighetsgrad.INFO);
           settFeilmelding(
             intl.formatMessage({

--- a/src/barnetilsyn/BarnetilsynApp.tsx
+++ b/src/barnetilsyn/BarnetilsynApp.tsx
@@ -18,11 +18,20 @@ import { IPerson } from '../models/søknad/person';
 import { Helmet } from 'react-helmet';
 import { erLokaltMedMock } from '../utils/miljø';
 import SøknadsdialogBarnetilsyn from './Søknadsdialog';
+import { EAlvorlighetsgrad } from '../models/felles/feilmelding';
+import { logAdressesperre } from '../utils/amplitude';
+import { useIntl } from 'react-intl';
+import { ESkjemanavn } from '../utils/skjemanavn';
 
 const BarnetilsynApp = () => {
   const [autentisert, settAutentisering] = useState<boolean>(false);
   const [fetching, settFetching] = useState<boolean>(true);
   const [error, settError] = useState<boolean>(false);
+  const [feilmelding, settFeilmelding] = useState<string>('');
+  const [
+    alvorlighetsgrad,
+    settAlvorlighetsgrad,
+  ] = useState<EAlvorlighetsgrad>();
   const { settPerson } = usePersonContext();
   const {
     søknad,
@@ -30,6 +39,8 @@ const BarnetilsynApp = () => {
     hentMellomlagretBarnetilsyn,
   } = useBarnetilsynSøknad();
   const { settToggles } = useToggles();
+
+  const intl = useIntl();
 
   autentiseringsInterceptor();
 
@@ -46,7 +57,23 @@ const BarnetilsynApp = () => {
         });
         oppdaterSøknadMedBarn(response, response.barn);
       })
-      .catch(() => settError(true));
+      .catch((e) => {
+        const feil = e.response?.data?.feil;
+
+        if (feil === 'adressesperre') {
+          logAdressesperre(ESkjemanavn.Barnetilsyn);
+          settAlvorlighetsgrad(EAlvorlighetsgrad.INFO);
+          settFeilmelding(
+            intl.formatMessage({
+              id: 'barnasbosted.feilmelding.adressebeskyttelse',
+            })
+          );
+        } else {
+          settFeilmelding(feil);
+        }
+
+        settError(true);
+      });
   };
 
   const oppdaterSøknadMedBarn = (person: IPerson, barneliste: any[]) => {
@@ -98,7 +125,9 @@ const BarnetilsynApp = () => {
         </>
       );
     } else if (error) {
-      return <Feilside />;
+      return (
+        <Feilside tekstId={feilmelding} alvorlighetsgrad={alvorlighetsgrad} />
+      );
     } else {
       return <NavFrontendSpinner className="spinner" />;
     }

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -102,3 +102,10 @@ export const logSidevisningSkolepenger = (side: string) => {
     skjemanavn: ESkjemanavn.Skolepenger,
   });
 };
+
+export const logAdressesperre = (skjemanavn: string) => {
+  logEvent('adressesperre', {
+    team_id: 'familie',
+    skjemanavn,
+  });
+};


### PR DESCRIPTION
Legger til riktig adressesperre-feilmelding på sidene for barnetilsyn og skolepenger, i tillegg til å logge dette til amplitude.