### PR TITLE
Ikke la bruker gå videre med dato i feil format

### DIFF
--- a/src/components/dato/Datovelger.tsx
+++ b/src/components/dato/Datovelger.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { addYears, subYears, addMonths } from 'date-fns';
+import { addMonths, addYears, subYears } from 'date-fns';
 import { Normaltekst } from 'nav-frontend-typografi';
 import { Datepicker } from 'nav-datovelger';
 import { useSpråkContext } from '../../context/SpråkContext';
@@ -26,7 +26,7 @@ export enum DatoBegrensning {
 }
 
 const hentDatobegrensninger = (
-  datobegrensning: DatoBegrensning
+  datobegrensning: DatoBegrensning,
 ): DatepickerLimitations => {
   switch (datobegrensning) {
     case DatoBegrensning.AlleDatoer:
@@ -60,26 +60,26 @@ interface Props {
 }
 
 const Datovelger: React.FC<Props> = ({
-  tekstid,
-  datobegrensning,
-  valgtDato,
-  settDato,
-  disabled,
-  fetSkrift,
-  gjemFeilmelding,
-}) => {
+                                       tekstid,
+                                       datobegrensning,
+                                       valgtDato,
+                                       settDato,
+                                       disabled,
+                                       fetSkrift,
+                                       gjemFeilmelding,
+                                     }) => {
   const [locale] = useSpråkContext();
   const datolabelid = hentUid();
   const [_dato, _settDato] = useState<string>(valgtDato ? valgtDato : '');
   const [feilmelding, settFeilmelding] = useState<string>('');
 
   const limitations: DatepickerLimitations = hentDatobegrensninger(
-    datobegrensning
+    datobegrensning,
   );
 
   const hentFeilmelding = (
     dato: string,
-    datobegrensning: DatoBegrensning
+    datobegrensning: DatoBegrensning,
   ): string => {
     if (!erGyldigDato(dato)) {
       return 'datovelger.ugyldigDato';

--- a/src/components/dato/Datovelger.tsx
+++ b/src/components/dato/Datovelger.tsx
@@ -99,8 +99,8 @@ const Datovelger: React.FC<Props> = ({
   };
 
   useEffect(() => {
-    _dato !== '' && settDato(_dato);
-    _dato !== '' && settFeilmelding(hentFeilmelding(_dato, datobegrensning));
+    settDato(_dato);
+    (_dato !== '') && settFeilmelding(hentFeilmelding(_dato, datobegrensning));
 
     // eslint-disable-next-line
   }, [_dato]);

--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -20,10 +20,10 @@ export const erForelderUtfylt = (forelder: IForelder): boolean | undefined => {
   const utfyltBorINorge =
     borINorge?.verdi || (borINorge?.verdi === false && land?.verdi !== '');
 
-  const utfyltFødselsdato = (
-    fødselsdato?.verdi !== '' ? erGyldigDato(fødselsdato?.verdi) : true
+  const erFeltTomtEllerUtfyltMedGyldigFødselsdato = (
+    erGyldigDato(fødselsdato?.verdi) || fødselsdato?.verdi === ""
   );
-  const utfyltForelderInfo = navn?.verdi !== '' && (ident?.verdi !== '' || utfyltFødselsdato);
+  const utfyltForelderInfo = navn?.verdi !== '' && (ident?.verdi !== '' || erFeltTomtEllerUtfyltMedGyldigFødselsdato);
 
   const utfyltAvtaleDeltBosted = harValgtSvar(avtaleOmDeltBosted?.verdi);
   const forelderInfoOgSpørsmålBesvart: boolean | undefined =

--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -1,190 +1,191 @@
 import {
-    EBorAnnenForelderISammeHus,
-    EHarSamværMedBarn,
-    EHarSkriftligSamværsavtale,
-    EHvorforIkkeOppgi,
-    EHvorMyeSammen,
+  EBorAnnenForelderISammeHus,
+  EHarSamværMedBarn,
+  EHarSkriftligSamværsavtale,
+  EHvorforIkkeOppgi,
+  EHvorMyeSammen,
 } from '../../models/steg/barnasbosted';
-import {EForelder, IForelder} from '../../models/steg/forelder';
-import {ESvar, ISpørsmål, ISvar} from '../../models/felles/spørsmålogsvar';
-import {harValgtSvar} from '../../utils/spørsmålogsvar';
-import {erDatoGyldigOgInnaforBegrensninger} from '../../components/dato/utils';
-import {DatoBegrensning} from '../../components/dato/Datovelger';
-import {erGyldigDato} from '../../utils/dato';
+import { EForelder, IForelder } from '../../models/steg/forelder';
+import { ESvar, ISpørsmål, ISvar } from '../../models/felles/spørsmålogsvar';
+import { harValgtSvar } from '../../utils/spørsmålogsvar';
+import { erDatoGyldigOgInnaforBegrensninger } from '../../components/dato/utils';
+import { DatoBegrensning } from '../../components/dato/Datovelger';
+import { erGyldigDato } from '../../utils/dato';
 
 export const erAlleForeldreUtfylt = (foreldre: IForelder[]) =>
-    foreldre.every((forelder) => erForelderUtfylt(forelder));
+  foreldre.every((forelder) => erForelderUtfylt(forelder));
 
 export const erForelderUtfylt = (forelder: IForelder): boolean | undefined => {
-    const {navn, fødselsdato, ident, borINorge, land, avtaleOmDeltBosted} = forelder;
-    const utfyltBorINorge =
-        borINorge?.verdi || (borINorge?.verdi === false && land?.verdi !== '');
+  const { navn, fødselsdato, ident, borINorge, land, avtaleOmDeltBosted } = forelder;
+  const utfyltBorINorge =
+    borINorge?.verdi || (borINorge?.verdi === false && land?.verdi !== '');
 
-    const utfyltFødselsdato = (
-        fødselsdato?.verdi !== "" ? erGyldigDato(fødselsdato?.verdi) : true
-    );
-    const utfyltForelderInfo = navn?.verdi !== "" && (ident?.verdi !== "" || utfyltFødselsdato);
+  const utfyltFødselsdato = (
+    fødselsdato?.verdi !== '' ? erGyldigDato(fødselsdato?.verdi) : true
+  );
+  const utfyltForelderInfo = navn?.verdi !== '' && (ident?.verdi !== '' || utfyltFødselsdato);
 
-    const utfyltAvtaleDeltBosted = harValgtSvar(avtaleOmDeltBosted?.verdi);
-    const forelderInfoOgSpørsmålBesvart: boolean | undefined =
-        utfyltForelderInfo &&
-        utfyltBorINorge &&
-        utfyltAvtaleDeltBosted &&
-        utfyltNødvendigeSamværSpørsmål(forelder) &&
-        utfyltNødvendigBostedSpørsmål(forelder);
+  const utfyltAvtaleDeltBosted = harValgtSvar(avtaleOmDeltBosted?.verdi);
+  const forelderInfoOgSpørsmålBesvart: boolean | undefined =
+    utfyltForelderInfo &&
+    utfyltBorINorge &&
+    utfyltAvtaleDeltBosted &&
+    utfyltNødvendigeSamværSpørsmål(forelder) &&
+    utfyltNødvendigBostedSpørsmål(forelder);
 
-    const kanIkkeOppgiAnnenForelderRuteUtfylt = utfyltNødvendigSpørsmålUtenOppgiAnnenForelder(
-        forelder
-    );
+  const kanIkkeOppgiAnnenForelderRuteUtfylt = utfyltNødvendigSpørsmålUtenOppgiAnnenForelder(
+    forelder,
+  );
 
-    return forelderInfoOgSpørsmålBesvart || kanIkkeOppgiAnnenForelderRuteUtfylt;
+  return forelderInfoOgSpørsmålBesvart || kanIkkeOppgiAnnenForelderRuteUtfylt;
 };
 
+
 export const utfyltNødvendigSpørsmålUtenOppgiAnnenForelder = (
-    forelder: IForelder
+  forelder: IForelder,
 ) => {
-    const {
-        hvorforIkkeOppgi,
-        ikkeOppgittAnnenForelderBegrunnelse,
-        kanIkkeOppgiAnnenForelderFar,
-    } = forelder;
+  const {
+    hvorforIkkeOppgi,
+    ikkeOppgittAnnenForelderBegrunnelse,
+    kanIkkeOppgiAnnenForelderFar,
+  } = forelder;
 
-    const pgaDonorBarn = hvorforIkkeOppgi?.svarid === EHvorforIkkeOppgi.donorbarn;
-    const pgaAnnet =
-        hvorforIkkeOppgi?.svarid === EHvorforIkkeOppgi.annet &&
-        harValgtSvar(forelder?.ikkeOppgittAnnenForelderBegrunnelse?.verdi) &&
-        ikkeOppgittAnnenForelderBegrunnelse?.verdi !== hvorforIkkeOppgi?.verdi;
+  const pgaDonorBarn = hvorforIkkeOppgi?.svarid === EHvorforIkkeOppgi.donorbarn;
+  const pgaAnnet =
+    hvorforIkkeOppgi?.svarid === EHvorforIkkeOppgi.annet &&
+    harValgtSvar(forelder?.ikkeOppgittAnnenForelderBegrunnelse?.verdi) &&
+    ikkeOppgittAnnenForelderBegrunnelse?.verdi !== hvorforIkkeOppgi?.verdi;
 
-    return kanIkkeOppgiAnnenForelderFar?.verdi && (pgaDonorBarn || pgaAnnet);
+  return kanIkkeOppgiAnnenForelderFar?.verdi && (pgaDonorBarn || pgaAnnet);
 };
 
 export const utfyltNødvendigeSamværSpørsmål = (forelder: IForelder) => {
-    const {
-        avtaleOmDeltBosted,
-        harAnnenForelderSamværMedBarn,
-        harDereSkriftligSamværsavtale,
-        hvordanPraktiseresSamværet,
-    } = forelder;
-    const harIkkeAvtaleOmDeltBosted = avtaleOmDeltBosted?.svarid === ESvar.NEI;
+  const {
+    avtaleOmDeltBosted,
+    harAnnenForelderSamværMedBarn,
+    harDereSkriftligSamværsavtale,
+    hvordanPraktiseresSamværet,
+  } = forelder;
+  const harIkkeAvtaleOmDeltBosted = avtaleOmDeltBosted?.svarid === ESvar.NEI;
 
-    if (
-        harIkkeAvtaleOmDeltBosted &&
-        harForelderSamværMedBarn(harAnnenForelderSamværMedBarn?.svarid)
+  if (
+    harIkkeAvtaleOmDeltBosted &&
+    harForelderSamværMedBarn(harAnnenForelderSamværMedBarn?.svarid)
+  )
+    return harValgtSvar(harAnnenForelderSamværMedBarn?.verdi);
+  else if (
+    harIkkeAvtaleOmDeltBosted &&
+    måBeskriveSamværet(
+      harDereSkriftligSamværsavtale?.svarid,
+      harAnnenForelderSamværMedBarn?.svarid,
     )
-        return harValgtSvar(harAnnenForelderSamværMedBarn?.verdi);
-    else if (
-        harIkkeAvtaleOmDeltBosted &&
-        måBeskriveSamværet(
-            harDereSkriftligSamværsavtale?.svarid,
-            harAnnenForelderSamværMedBarn?.svarid
-        )
-    )
-        return harValgtSvar(hvordanPraktiseresSamværet?.verdi);
-    else return true;
+  )
+    return harValgtSvar(hvordanPraktiseresSamværet?.verdi);
+  else return true;
 };
 
 export const utfyltNødvendigBostedSpørsmål = (forelder?: IForelder) => {
-    const utfyltBorISammeHus =
-        forelder?.borINorge?.verdi &&
-        forelder?.borAnnenForelderISammeHus?.svarid ===
-        EBorAnnenForelderISammeHus.ja
-            ? forelder?.borAnnenForelderISammeHusBeskrivelse?.verdi !== ''
-            : true;
+  const utfyltBorISammeHus =
+    forelder?.borINorge?.verdi &&
+    forelder?.borAnnenForelderISammeHus?.svarid ===
+    EBorAnnenForelderISammeHus.ja
+      ? forelder?.borAnnenForelderISammeHusBeskrivelse?.verdi !== ''
+      : true;
 
-    const harFlyttetFraDato: boolean =
-        forelder?.flyttetFra?.verdi &&
-        erDatoGyldigOgInnaforBegrensninger(
-            forelder.flyttetFra?.verdi,
-            DatoBegrensning.TidligereDatoer
-        )
-            ? true
-            : false;
+  const harFlyttetFraDato: boolean =
+    forelder?.flyttetFra?.verdi &&
+    erDatoGyldigOgInnaforBegrensninger(
+      forelder.flyttetFra?.verdi,
+      DatoBegrensning.TidligereDatoer,
+    )
+      ? true
+      : false;
 
-    const utfyltBoddSammenFør =
-        forelder?.boddSammenFør?.svarid === ESvar.JA
-            ? harValgtSvar(forelder?.boddSammenFør?.verdi) && harFlyttetFraDato
-            : harValgtSvar(forelder?.boddSammenFør?.verdi);
-    const utfyltHvorMyeSammen =
-        forelder?.hvorMyeSammen?.svarid === EHvorMyeSammen.møtesUtenom
-            ? harValgtSvar(forelder.beskrivSamværUtenBarn?.verdi)
-            : harValgtSvar(forelder?.hvorMyeSammen?.verdi);
+  const utfyltBoddSammenFør =
+    forelder?.boddSammenFør?.svarid === ESvar.JA
+      ? harValgtSvar(forelder?.boddSammenFør?.verdi) && harFlyttetFraDato
+      : harValgtSvar(forelder?.boddSammenFør?.verdi);
+  const utfyltHvorMyeSammen =
+    forelder?.hvorMyeSammen?.svarid === EHvorMyeSammen.møtesUtenom
+      ? harValgtSvar(forelder.beskrivSamværUtenBarn?.verdi)
+      : harValgtSvar(forelder?.hvorMyeSammen?.verdi);
 
-    return utfyltBorISammeHus && utfyltBoddSammenFør && utfyltHvorMyeSammen;
+  return utfyltBorISammeHus && utfyltBoddSammenFør && utfyltHvorMyeSammen;
 };
 
 export const harForelderSamværMedBarn = (svarid: string | undefined) => {
-    switch (svarid) {
-        case EHarSamværMedBarn.jaIkkeMerEnnVanlig:
-            return true;
-        case EHarSamværMedBarn.jaMerEnnVanlig:
-            return true;
-        case EHarSamværMedBarn.nei:
-            return false;
+  switch (svarid) {
+    case EHarSamværMedBarn.jaIkkeMerEnnVanlig:
+      return true;
+    case EHarSamværMedBarn.jaMerEnnVanlig:
+      return true;
+    case EHarSamværMedBarn.nei:
+      return false;
 
-        default:
-            return false;
-    }
+    default:
+      return false;
+  }
 };
 export const harSkriftligSamværsavtale = (svarid: string | undefined) => {
-    switch (svarid) {
-        case EHarSkriftligSamværsavtale.jaKonkreteTidspunkter:
-            return false;
-        case EHarSkriftligSamværsavtale.jaIkkeKonkreteTidspunkter:
-            return true;
-        case EHarSkriftligSamværsavtale.nei:
-            return true;
+  switch (svarid) {
+    case EHarSkriftligSamværsavtale.jaKonkreteTidspunkter:
+      return false;
+    case EHarSkriftligSamværsavtale.jaIkkeKonkreteTidspunkter:
+      return true;
+    case EHarSkriftligSamværsavtale.nei:
+      return true;
 
-        default:
-            return false;
-    }
+    default:
+      return false;
+  }
 };
 
 export const måBeskriveSamværet = (
-    samværsavtale: string | undefined,
-    samværMedBarn: string | undefined
+  samværsavtale: string | undefined,
+  samværMedBarn: string | undefined,
 ) => {
-    return (
-        samværMedBarn === EHarSamværMedBarn.jaMerEnnVanlig &&
-        (samværsavtale === EHarSkriftligSamværsavtale.jaIkkeKonkreteTidspunkter ||
-            samværsavtale === EHarSkriftligSamværsavtale.nei)
-    );
+  return (
+    samværMedBarn === EHarSamværMedBarn.jaMerEnnVanlig &&
+    (samværsavtale === EHarSkriftligSamværsavtale.jaIkkeKonkreteTidspunkter ||
+      samværsavtale === EHarSkriftligSamværsavtale.nei)
+  );
 };
 
 export const visSpørsmålHvisIkkeSammeForelder = (forelder: IForelder) => {
-    if (forelder.harAnnenForelderSamværMedBarn?.svarid === EHarSamværMedBarn.nei)
-        return true;
-    else if (
-        forelder.hvordanPraktiseresSamværet &&
-        forelder.hvordanPraktiseresSamværet?.verdi !== ''
-    )
-        return true;
-    else if (forelder.avtaleOmDeltBosted?.svarid === ESvar.JA) return true;
-    else if (forelder.harDereSkriftligSamværsavtale?.svarid)
-        return !måBeskriveSamværet(
-            forelder.harDereSkriftligSamværsavtale.svarid,
-            forelder.harAnnenForelderSamværMedBarn?.svarid
-        );
+  if (forelder.harAnnenForelderSamværMedBarn?.svarid === EHarSamværMedBarn.nei)
+    return true;
+  else if (
+    forelder.hvordanPraktiseresSamværet &&
+    forelder.hvordanPraktiseresSamværet?.verdi !== ''
+  )
+    return true;
+  else if (forelder.avtaleOmDeltBosted?.svarid === ESvar.JA) return true;
+  else if (forelder.harDereSkriftligSamværsavtale?.svarid)
+    return !måBeskriveSamværet(
+      forelder.harDereSkriftligSamværsavtale.svarid,
+      forelder.harAnnenForelderSamværMedBarn?.svarid,
+    );
 
-    return false;
+  return false;
 };
 
 export const hvisEndretSvarSlettFeltHvordanPraktiseresSamværet = (
-    spørsmål: ISpørsmål,
-    svar: ISvar
+  spørsmål: ISpørsmål,
+  svar: ISvar,
 ) => {
-    return (
-        (spørsmål.søknadid === EForelder.harDereSkriftligSamværsavtale &&
-            svar.id === EHarSkriftligSamværsavtale.nei) ||
-        (spørsmål.søknadid === EForelder.harAnnenForelderSamværMedBarn &&
-            svar.id === EHarSamværMedBarn.nei)
-    );
+  return (
+    (spørsmål.søknadid === EForelder.harDereSkriftligSamværsavtale &&
+      svar.id === EHarSkriftligSamværsavtale.nei) ||
+    (spørsmål.søknadid === EForelder.harAnnenForelderSamværMedBarn &&
+      svar.id === EHarSamværMedBarn.nei)
+  );
 };
 
 export const harSkriftligAvtaleOmDeltBosted = (
-    spørsmål: ISpørsmål,
-    svar: ISvar
+  spørsmål: ISpørsmål,
+  svar: ISvar,
 ) => {
-    return (
-        spørsmål.søknadid === EForelder.avtaleOmDeltBosted && svar.id === ESvar.JA
-    );
+  return (
+    spørsmål.søknadid === EForelder.avtaleOmDeltBosted && svar.id === ESvar.JA
+  );
 };

--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -1,183 +1,190 @@
 import {
-  EBorAnnenForelderISammeHus,
-  EHarSamværMedBarn,
-  EHarSkriftligSamværsavtale,
-  EHvorforIkkeOppgi,
-  EHvorMyeSammen,
+    EBorAnnenForelderISammeHus,
+    EHarSamværMedBarn,
+    EHarSkriftligSamværsavtale,
+    EHvorforIkkeOppgi,
+    EHvorMyeSammen,
 } from '../../models/steg/barnasbosted';
-import { EForelder, IForelder } from '../../models/steg/forelder';
-import { ESvar, ISpørsmål, ISvar } from '../../models/felles/spørsmålogsvar';
-import { harValgtSvar } from '../../utils/spørsmålogsvar';
-import { erDatoGyldigOgInnaforBegrensninger } from '../../components/dato/utils';
-import { DatoBegrensning } from '../../components/dato/Datovelger';
+import {EForelder, IForelder} from '../../models/steg/forelder';
+import {ESvar, ISpørsmål, ISvar} from '../../models/felles/spørsmålogsvar';
+import {harValgtSvar} from '../../utils/spørsmålogsvar';
+import {erDatoGyldigOgInnaforBegrensninger} from '../../components/dato/utils';
+import {DatoBegrensning} from '../../components/dato/Datovelger';
+import {erGyldigDato} from '../../utils/dato';
 
 export const erAlleForeldreUtfylt = (foreldre: IForelder[]) =>
-  foreldre.every((forelder) => erForelderUtfylt(forelder));
+    foreldre.every((forelder) => erForelderUtfylt(forelder));
 
 export const erForelderUtfylt = (forelder: IForelder): boolean | undefined => {
-  const { borINorge, land, avtaleOmDeltBosted } = forelder;
-  const utfyltBorINorge =
-    borINorge?.verdi || (borINorge?.verdi === false && land?.verdi !== '');
+    const {navn, fødselsdato, ident, borINorge, land, avtaleOmDeltBosted} = forelder;
+    const utfyltBorINorge =
+        borINorge?.verdi || (borINorge?.verdi === false && land?.verdi !== '');
 
-  const utfyltAvtaleDeltBosted = harValgtSvar(avtaleOmDeltBosted?.verdi);
-  const forelderInfoOgSpørsmålBesvart: boolean | undefined =
-    utfyltBorINorge &&
-    utfyltAvtaleDeltBosted &&
-    utfyltNødvendigeSamværSpørsmål(forelder) &&
-    utfyltNødvendigBostedSpørsmål(forelder);
+    const utfyltFødselsdato = (
+        fødselsdato?.verdi !== "" ? erGyldigDato(fødselsdato?.verdi) : true
+    );
+    const utfyltForelderInfo = navn?.verdi !== "" && (ident?.verdi !== "" || utfyltFødselsdato);
 
-  const kanIkkeOppgiAnnenForelderRuteUtfylt = utfyltNødvendigSpørsmålUtenOppgiAnnenForelder(
-    forelder
-  );
+    const utfyltAvtaleDeltBosted = harValgtSvar(avtaleOmDeltBosted?.verdi);
+    const forelderInfoOgSpørsmålBesvart: boolean | undefined =
+        utfyltForelderInfo &&
+        utfyltBorINorge &&
+        utfyltAvtaleDeltBosted &&
+        utfyltNødvendigeSamværSpørsmål(forelder) &&
+        utfyltNødvendigBostedSpørsmål(forelder);
 
-  return forelderInfoOgSpørsmålBesvart || kanIkkeOppgiAnnenForelderRuteUtfylt;
+    const kanIkkeOppgiAnnenForelderRuteUtfylt = utfyltNødvendigSpørsmålUtenOppgiAnnenForelder(
+        forelder
+    );
+
+    return forelderInfoOgSpørsmålBesvart || kanIkkeOppgiAnnenForelderRuteUtfylt;
 };
 
 export const utfyltNødvendigSpørsmålUtenOppgiAnnenForelder = (
-  forelder: IForelder
+    forelder: IForelder
 ) => {
-  const {
-    hvorforIkkeOppgi,
-    ikkeOppgittAnnenForelderBegrunnelse,
-    kanIkkeOppgiAnnenForelderFar,
-  } = forelder;
+    const {
+        hvorforIkkeOppgi,
+        ikkeOppgittAnnenForelderBegrunnelse,
+        kanIkkeOppgiAnnenForelderFar,
+    } = forelder;
 
-  const pgaDonorBarn = hvorforIkkeOppgi?.svarid === EHvorforIkkeOppgi.donorbarn;
-  const pgaAnnet =
-    hvorforIkkeOppgi?.svarid === EHvorforIkkeOppgi.annet &&
-    harValgtSvar(forelder?.ikkeOppgittAnnenForelderBegrunnelse?.verdi) &&
-    ikkeOppgittAnnenForelderBegrunnelse?.verdi !== hvorforIkkeOppgi?.verdi;
+    const pgaDonorBarn = hvorforIkkeOppgi?.svarid === EHvorforIkkeOppgi.donorbarn;
+    const pgaAnnet =
+        hvorforIkkeOppgi?.svarid === EHvorforIkkeOppgi.annet &&
+        harValgtSvar(forelder?.ikkeOppgittAnnenForelderBegrunnelse?.verdi) &&
+        ikkeOppgittAnnenForelderBegrunnelse?.verdi !== hvorforIkkeOppgi?.verdi;
 
-  return kanIkkeOppgiAnnenForelderFar?.verdi && (pgaDonorBarn || pgaAnnet);
+    return kanIkkeOppgiAnnenForelderFar?.verdi && (pgaDonorBarn || pgaAnnet);
 };
 
 export const utfyltNødvendigeSamværSpørsmål = (forelder: IForelder) => {
-  const {
-    avtaleOmDeltBosted,
-    harAnnenForelderSamværMedBarn,
-    harDereSkriftligSamværsavtale,
-    hvordanPraktiseresSamværet,
-  } = forelder;
-  const harIkkeAvtaleOmDeltBosted = avtaleOmDeltBosted?.svarid === ESvar.NEI;
+    const {
+        avtaleOmDeltBosted,
+        harAnnenForelderSamværMedBarn,
+        harDereSkriftligSamværsavtale,
+        hvordanPraktiseresSamværet,
+    } = forelder;
+    const harIkkeAvtaleOmDeltBosted = avtaleOmDeltBosted?.svarid === ESvar.NEI;
 
-  if (
-    harIkkeAvtaleOmDeltBosted &&
-    harForelderSamværMedBarn(harAnnenForelderSamværMedBarn?.svarid)
-  )
-    return harValgtSvar(harAnnenForelderSamværMedBarn?.verdi);
-  else if (
-    harIkkeAvtaleOmDeltBosted &&
-    måBeskriveSamværet(
-      harDereSkriftligSamværsavtale?.svarid,
-      harAnnenForelderSamværMedBarn?.svarid
+    if (
+        harIkkeAvtaleOmDeltBosted &&
+        harForelderSamværMedBarn(harAnnenForelderSamværMedBarn?.svarid)
     )
-  )
-    return harValgtSvar(hvordanPraktiseresSamværet?.verdi);
-  else return true;
+        return harValgtSvar(harAnnenForelderSamværMedBarn?.verdi);
+    else if (
+        harIkkeAvtaleOmDeltBosted &&
+        måBeskriveSamværet(
+            harDereSkriftligSamværsavtale?.svarid,
+            harAnnenForelderSamværMedBarn?.svarid
+        )
+    )
+        return harValgtSvar(hvordanPraktiseresSamværet?.verdi);
+    else return true;
 };
 
 export const utfyltNødvendigBostedSpørsmål = (forelder?: IForelder) => {
-  const utfyltBorISammeHus =
-    forelder?.borINorge?.verdi &&
-    forelder?.borAnnenForelderISammeHus?.svarid ===
-      EBorAnnenForelderISammeHus.ja
-      ? forelder?.borAnnenForelderISammeHusBeskrivelse?.verdi !== ''
-      : true;
+    const utfyltBorISammeHus =
+        forelder?.borINorge?.verdi &&
+        forelder?.borAnnenForelderISammeHus?.svarid ===
+        EBorAnnenForelderISammeHus.ja
+            ? forelder?.borAnnenForelderISammeHusBeskrivelse?.verdi !== ''
+            : true;
 
-  const harFlyttetFraDato: boolean =
-    forelder?.flyttetFra?.verdi &&
-    erDatoGyldigOgInnaforBegrensninger(
-      forelder.flyttetFra?.verdi,
-      DatoBegrensning.TidligereDatoer
-    )
-      ? true
-      : false;
+    const harFlyttetFraDato: boolean =
+        forelder?.flyttetFra?.verdi &&
+        erDatoGyldigOgInnaforBegrensninger(
+            forelder.flyttetFra?.verdi,
+            DatoBegrensning.TidligereDatoer
+        )
+            ? true
+            : false;
 
-  const utfyltBoddSammenFør =
-    forelder?.boddSammenFør?.svarid === ESvar.JA
-      ? harValgtSvar(forelder?.boddSammenFør?.verdi) && harFlyttetFraDato
-      : harValgtSvar(forelder?.boddSammenFør?.verdi);
-  const utfyltHvorMyeSammen =
-    forelder?.hvorMyeSammen?.svarid === EHvorMyeSammen.møtesUtenom
-      ? harValgtSvar(forelder.beskrivSamværUtenBarn?.verdi)
-      : harValgtSvar(forelder?.hvorMyeSammen?.verdi);
+    const utfyltBoddSammenFør =
+        forelder?.boddSammenFør?.svarid === ESvar.JA
+            ? harValgtSvar(forelder?.boddSammenFør?.verdi) && harFlyttetFraDato
+            : harValgtSvar(forelder?.boddSammenFør?.verdi);
+    const utfyltHvorMyeSammen =
+        forelder?.hvorMyeSammen?.svarid === EHvorMyeSammen.møtesUtenom
+            ? harValgtSvar(forelder.beskrivSamværUtenBarn?.verdi)
+            : harValgtSvar(forelder?.hvorMyeSammen?.verdi);
 
-  return utfyltBorISammeHus && utfyltBoddSammenFør && utfyltHvorMyeSammen;
+    return utfyltBorISammeHus && utfyltBoddSammenFør && utfyltHvorMyeSammen;
 };
 
 export const harForelderSamværMedBarn = (svarid: string | undefined) => {
-  switch (svarid) {
-    case EHarSamværMedBarn.jaIkkeMerEnnVanlig:
-      return true;
-    case EHarSamværMedBarn.jaMerEnnVanlig:
-      return true;
-    case EHarSamværMedBarn.nei:
-      return false;
+    switch (svarid) {
+        case EHarSamværMedBarn.jaIkkeMerEnnVanlig:
+            return true;
+        case EHarSamværMedBarn.jaMerEnnVanlig:
+            return true;
+        case EHarSamværMedBarn.nei:
+            return false;
 
-    default:
-      return false;
-  }
+        default:
+            return false;
+    }
 };
 export const harSkriftligSamværsavtale = (svarid: string | undefined) => {
-  switch (svarid) {
-    case EHarSkriftligSamværsavtale.jaKonkreteTidspunkter:
-      return false;
-    case EHarSkriftligSamværsavtale.jaIkkeKonkreteTidspunkter:
-      return true;
-    case EHarSkriftligSamværsavtale.nei:
-      return true;
+    switch (svarid) {
+        case EHarSkriftligSamværsavtale.jaKonkreteTidspunkter:
+            return false;
+        case EHarSkriftligSamværsavtale.jaIkkeKonkreteTidspunkter:
+            return true;
+        case EHarSkriftligSamværsavtale.nei:
+            return true;
 
-    default:
-      return false;
-  }
+        default:
+            return false;
+    }
 };
 
 export const måBeskriveSamværet = (
-  samværsavtale: string | undefined,
-  samværMedBarn: string | undefined
+    samværsavtale: string | undefined,
+    samværMedBarn: string | undefined
 ) => {
-  return (
-    samværMedBarn === EHarSamværMedBarn.jaMerEnnVanlig &&
-    (samværsavtale === EHarSkriftligSamværsavtale.jaIkkeKonkreteTidspunkter ||
-      samværsavtale === EHarSkriftligSamværsavtale.nei)
-  );
+    return (
+        samværMedBarn === EHarSamværMedBarn.jaMerEnnVanlig &&
+        (samværsavtale === EHarSkriftligSamværsavtale.jaIkkeKonkreteTidspunkter ||
+            samværsavtale === EHarSkriftligSamværsavtale.nei)
+    );
 };
 
 export const visSpørsmålHvisIkkeSammeForelder = (forelder: IForelder) => {
-  if (forelder.harAnnenForelderSamværMedBarn?.svarid === EHarSamværMedBarn.nei)
-    return true;
-  else if (
-    forelder.hvordanPraktiseresSamværet &&
-    forelder.hvordanPraktiseresSamværet?.verdi !== ''
-  )
-    return true;
-  else if (forelder.avtaleOmDeltBosted?.svarid === ESvar.JA) return true;
-  else if (forelder.harDereSkriftligSamværsavtale?.svarid)
-    return !måBeskriveSamværet(
-      forelder.harDereSkriftligSamværsavtale.svarid,
-      forelder.harAnnenForelderSamværMedBarn?.svarid
-    );
+    if (forelder.harAnnenForelderSamværMedBarn?.svarid === EHarSamværMedBarn.nei)
+        return true;
+    else if (
+        forelder.hvordanPraktiseresSamværet &&
+        forelder.hvordanPraktiseresSamværet?.verdi !== ''
+    )
+        return true;
+    else if (forelder.avtaleOmDeltBosted?.svarid === ESvar.JA) return true;
+    else if (forelder.harDereSkriftligSamværsavtale?.svarid)
+        return !måBeskriveSamværet(
+            forelder.harDereSkriftligSamværsavtale.svarid,
+            forelder.harAnnenForelderSamværMedBarn?.svarid
+        );
 
-  return false;
+    return false;
 };
 
 export const hvisEndretSvarSlettFeltHvordanPraktiseresSamværet = (
-  spørsmål: ISpørsmål,
-  svar: ISvar
+    spørsmål: ISpørsmål,
+    svar: ISvar
 ) => {
-  return (
-    (spørsmål.søknadid === EForelder.harDereSkriftligSamværsavtale &&
-      svar.id === EHarSkriftligSamværsavtale.nei) ||
-    (spørsmål.søknadid === EForelder.harAnnenForelderSamværMedBarn &&
-      svar.id === EHarSamværMedBarn.nei)
-  );
+    return (
+        (spørsmål.søknadid === EForelder.harDereSkriftligSamværsavtale &&
+            svar.id === EHarSkriftligSamværsavtale.nei) ||
+        (spørsmål.søknadid === EForelder.harAnnenForelderSamværMedBarn &&
+            svar.id === EHarSamværMedBarn.nei)
+    );
 };
 
 export const harSkriftligAvtaleOmDeltBosted = (
-  spørsmål: ISpørsmål,
-  svar: ISvar
+    spørsmål: ISpørsmål,
+    svar: ISvar
 ) => {
-  return (
-    spørsmål.søknadid === EForelder.avtaleOmDeltBosted && svar.id === ESvar.JA
-  );
+    return (
+        spørsmål.søknadid === EForelder.avtaleOmDeltBosted && svar.id === ESvar.JA
+    );
 };

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -1,330 +1,329 @@
-import React, { useEffect, useState } from 'react';
+import React, {useEffect, useState} from 'react';
 import AnnenForelderKnapper from './AnnenForelderKnapper';
 import BarneHeader from '../../../components/BarneHeader';
 import BostedOgSamvær from './bostedOgSamvær/BostedOgSamvær';
 import OmAndreForelder from './OmAndreForelder';
 import SkalBarnetBoHosSøker from './SkalBarnetBoHosSøker';
-import { IBarn } from '../../../models/steg/barn';
-import { IForelder } from '../../../models/steg/forelder';
-import { Knapp } from 'nav-frontend-knapper';
-import { useIntl } from 'react-intl';
-import { harValgtSvar } from '../../../utils/spørsmålogsvar';
-import { hentTekst } from '../../../utils/søknad';
-import {
-  erForelderUtfylt,
-  visSpørsmålHvisIkkeSammeForelder,
-} from '../../../helpers/steg/forelder';
+import {IBarn} from '../../../models/steg/barn';
+import {IForelder} from '../../../models/steg/forelder';
+import {Knapp} from 'nav-frontend-knapper';
+import {useIntl} from 'react-intl';
+import {harValgtSvar} from '../../../utils/spørsmålogsvar';
+import {hentTekst} from '../../../utils/søknad';
+import {erForelderUtfylt, visSpørsmålHvisIkkeSammeForelder,} from '../../../helpers/steg/forelder';
 import BorForelderINorge from './bostedOgSamvær/BorForelderINorge';
-import { ESvar, ISpørsmål, ISvar } from '../../../models/felles/spørsmålogsvar';
+import {ESvar, ISpørsmål, ISvar} from '../../../models/felles/spørsmålogsvar';
 import BorAnnenForelderISammeHus from './ikkesammeforelder/BorAnnenForelderISammeHus';
 import BoddSammenFør from './ikkesammeforelder/BoddSammenFør';
 import HvorMyeSammen from './ikkesammeforelder/HvorMyeSammen';
-import { hentUid } from '../../../utils/autentiseringogvalidering/uuid';
-import { erGyldigDato } from '../../../utils/dato';
-import { EBorAnnenForelderISammeHus } from '../../../models/steg/barnasbosted';
+import {hentUid} from '../../../utils/autentiseringogvalidering/uuid';
+import {erGyldigDato} from '../../../utils/dato';
+import {EBorAnnenForelderISammeHus} from '../../../models/steg/barnasbosted';
 import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
 import BarnetsAndreForelderTittel from './BarnetsAndreForelderTittel';
 import LocaleTekst from '../../../language/LocaleTekst';
-import { Element, Normaltekst } from 'nav-frontend-typografi';
+import {Element, Normaltekst} from 'nav-frontend-typografi';
 
 const lagOppdatertBarneliste = (
-  barneliste: IBarn[],
-  nåværendeBarn: IBarn,
-  forelder: IForelder
+    barneliste: IBarn[],
+    nåværendeBarn: IBarn,
+    forelder: IForelder
 ) => {
-  return barneliste.map((b) => {
-    if (b === nåværendeBarn) {
-      let nyttBarn = nåværendeBarn;
+    return barneliste.map((b) => {
+        if (b === nåværendeBarn) {
+            let nyttBarn = nåværendeBarn;
 
-      nyttBarn.forelder = forelder;
-      return nyttBarn;
-    } else {
-      return b;
-    }
-  });
+            nyttBarn.forelder = forelder;
+            return nyttBarn;
+        } else {
+            return b;
+        }
+    });
 };
 
 const visBostedOgSamværSeksjon = (
-  forelder: IForelder,
-  visesBorINorgeSpørsmål: boolean
+    forelder: IForelder,
+    visesBorINorgeSpørsmål: boolean
 ) => {
-  const borForelderINorgeSpm =
-    forelder.borINorge?.svarid === ESvar.JA ||
-    (forelder.land && forelder.land?.verdi !== '');
+    const borForelderINorgeSpm =
+        forelder.borINorge?.svarid === ESvar.JA ||
+        (forelder.land && forelder.land?.verdi !== '');
 
-  return visesBorINorgeSpørsmål
-    ? borForelderINorgeSpm
-    : erGyldigDato(forelder.fødselsdato?.verdi);
+    return visesBorINorgeSpørsmål
+        ? borForelderINorgeSpm
+        : erGyldigDato(forelder.fødselsdato?.verdi);
 };
 
 interface Props {
-  barn: IBarn;
-  settAktivIndex: Function;
-  aktivIndex: number;
-  sisteBarnUtfylt: boolean;
-  settSisteBarnUtfylt: (sisteBarnUtfylt: boolean) => void;
-  scrollTilLagtTilBarn: () => void;
-  settDokumentasjonsbehovForBarn: (
-    spørsmål: ISpørsmål,
-    valgtSvar: ISvar,
-    barneid: string,
-    barnapassid?: string
-  ) => void;
-  barneListe: IBarn[];
-  settBarneListe: (barneListe: IBarn[]) => void;
+    barn: IBarn;
+    settAktivIndex: Function;
+    aktivIndex: number;
+    sisteBarnUtfylt: boolean;
+    settSisteBarnUtfylt: (sisteBarnUtfylt: boolean) => void;
+    scrollTilLagtTilBarn: () => void;
+    settDokumentasjonsbehovForBarn: (
+        spørsmål: ISpørsmål,
+        valgtSvar: ISvar,
+        barneid: string,
+        barnapassid?: string
+    ) => void;
+    barneListe: IBarn[];
+    settBarneListe: (barneListe: IBarn[]) => void;
 }
 
 const BarnetsBostedEndre: React.FC<Props> = ({
-  barn,
-  settAktivIndex,
-  aktivIndex,
-  settSisteBarnUtfylt,
-  sisteBarnUtfylt,
-  scrollTilLagtTilBarn,
-  barneListe,
-  settBarneListe,
-  settDokumentasjonsbehovForBarn,
-}) => {
-  const intl = useIntl();
+                                                 barn,
+                                                 settAktivIndex,
+                                                 aktivIndex,
+                                                 settSisteBarnUtfylt,
+                                                 sisteBarnUtfylt,
+                                                 scrollTilLagtTilBarn,
+                                                 barneListe,
+                                                 settBarneListe,
+                                                 settDokumentasjonsbehovForBarn,
+                                             }) => {
+    const intl = useIntl();
 
-  const medforelderMedLabel = (medforelder: any) => {
-    return {
-      navn: {
-        label: hentTekst('barnasbosted.medforelder.navn', intl),
-        verdi: medforelder.verdi.navn,
-      },
-      alder: {
-        label: hentTekst('barnasbosted.medforelder.alder', intl),
-        verdi: medforelder.verdi.alder,
-      },
-      død: medforelder.død,
-      harAdressesperre: medforelder.harAdressesperre,
+    const medforelderMedLabel = (medforelder: any) => {
+        return {
+            navn: {
+                label: hentTekst('barnasbosted.medforelder.navn', intl),
+                verdi: medforelder.verdi.navn,
+            },
+            alder: {
+                label: hentTekst('barnasbosted.medforelder.alder', intl),
+                verdi: medforelder.verdi.alder,
+            },
+            død: medforelder.død,
+            harAdressesperre: medforelder.harAdressesperre,
+        };
     };
-  };
 
-  const [forelder, settForelder] = useState<IForelder>(
-    barn.forelder
-      ? barn.forelder
-      : barn.medforelder?.verdi
-      ? {
-          id: hentUid(),
-          ...medforelderMedLabel(barn.medforelder),
-        }
-      : {
-          id: hentUid(),
-        }
-  );
-
-  const [barnHarSammeForelder, settBarnHarSammeForelder] = useState<
-    boolean | undefined
-  >(undefined);
-  const [kjennerIkkeIdent, settKjennerIkkeIdent] = useState<boolean>(
-    forelder.fødselsdato?.verdi ? true : false
-  );
-
-  const {
-    borAnnenForelderISammeHus,
-    boddSammenFør,
-    flyttetFra,
-    fødselsdato,
-    ident,
-  } = forelder;
-  const jegKanIkkeOppgiLabel = hentTekst(
-    'barnasbosted.kanikkeoppgiforelder',
-    intl
-  );
-
-  useEffect(() => {
-    settForelder({
-      ...forelder,
-      kanIkkeOppgiAnnenForelderFar: {
-        label: jegKanIkkeOppgiLabel,
-        verdi: forelder.kanIkkeOppgiAnnenForelderFar?.verdi || false,
-      },
-    });
-    //eslint-disable-next-line
-  }, []);
-
-  useEffect(() => {
-    if (sisteBarnUtfylt === true && !erForelderUtfylt(forelder)) {
-      const nyBarneListe = lagOppdatertBarneliste(barneListe, barn, forelder);
-      settBarneListe(nyBarneListe);
-      settSisteBarnUtfylt(false);
-    }
-  }, [
-    sisteBarnUtfylt,
-    settSisteBarnUtfylt,
-    forelder,
-    barneListe,
-    barn,
-    settBarneListe,
-  ]);
-
-  const andreBarnMedForelder: IBarn[] = barneListe.filter((b) => {
-    return b !== barn && b.forelder;
-  });
-
-  const unikeForeldreIDer = Array.from(
-    new Set(andreBarnMedForelder.map((b) => b.forelder?.id))
-  );
-
-  const førsteBarnTilHverForelder = unikeForeldreIDer
-    .map((id) => {
-      if (!id) return null;
-      return andreBarnMedForelder.find((b) => b.forelder?.id === id);
-    })
-    .filter(Boolean) as IBarn[];
-
-  const erPåSisteBarn: boolean =
-    barneListe.length - 1 === andreBarnMedForelder.length;
-
-  const leggTilForelder = () => {
-    if (erForelderUtfylt(forelder)) settSisteBarnUtfylt(true);
-    const nyIndex = aktivIndex + 1;
-    const nyBarneListe = lagOppdatertBarneliste(barneListe, barn, forelder);
-
-    settBarneListe(nyBarneListe);
-    settAktivIndex(nyIndex);
-    scrollTilLagtTilBarn();
-  };
-
-  const visOmAndreForelder =
-    (!barn.medforelder?.verdi && førsteBarnTilHverForelder.length === 0) ||
-    (førsteBarnTilHverForelder.length > 0 && barnHarSammeForelder === false) ||
-    (barnHarSammeForelder === false &&
-      (barn.harSammeAdresse.verdi ||
-        harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi)));
-
-  const visBorAnnenForelderINorge =
-    !!barn.medforelder?.verdi ||
-    (!barnHarSammeForelder &&
-      !forelder.kanIkkeOppgiAnnenForelderFar?.verdi &&
-      harValgtSvar(forelder?.navn?.verdi) &&
-      (harValgtSvar(ident?.verdi || fødselsdato?.verdi) || kjennerIkkeIdent));
-
-  const skalFylleUtHarBoddSammenFør =
-    (harValgtSvar(borAnnenForelderISammeHus?.verdi) &&
-      borAnnenForelderISammeHus?.svarid !== EBorAnnenForelderISammeHus.ja) ||
-    harValgtSvar(forelder.borAnnenForelderISammeHusBeskrivelse?.verdi) ||
-    !forelder.borINorge?.verdi;
-
-  return (
-    <>
-      <div className="barnas-bosted">
-        <SeksjonGruppe>
-          <BarneHeader barn={barn} />
-        </SeksjonGruppe>
-        <div className="barnas-bosted__innhold">
-          {!barn.harSammeAdresse.verdi && (
-            <SkalBarnetBoHosSøker
-              barn={barn}
-              forelder={forelder}
-              settForelder={settForelder}
-              settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
-            />
-          )}
-
-          {(barn.harSammeAdresse?.verdi ||
-            harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi)) && (
-            <SeksjonGruppe>
-              <BarnetsAndreForelderTittel barn={barn} />
-
-              {førsteBarnTilHverForelder.length > 0 &&
-                !barn.medforelder?.verdi && (
-                  <AnnenForelderKnapper
-                    barn={barn}
-                    førsteBarnTilHverForelder={førsteBarnTilHverForelder}
-                    settForelder={settForelder}
-                    forelder={forelder}
-                    settBarnHarSammeForelder={settBarnHarSammeForelder}
-                  />
-                )}
-              {visOmAndreForelder && (
-                <OmAndreForelder
-                  settForelder={settForelder}
-                  forelder={forelder}
-                  kjennerIkkeIdent={kjennerIkkeIdent}
-                  settKjennerIkkeIdent={settKjennerIkkeIdent}
-                  settSisteBarnUtfylt={settSisteBarnUtfylt}
-                />
-              )}
-              {barn.medforelder?.verdi && (
-                <>
-                  <Element>Navn</Element>
-                  <Normaltekst>
-                    {barn.medforelder.verdi.navn
-                      ? barn.medforelder.verdi.navn
-                      : `${hentTekst(
-                          'barnekort.medforelder.hemmelig',
-                          intl
-                        )}, ${barn.medforelder.verdi.alder}`}
-                  </Normaltekst>
-                </>
-              )}
-            </SeksjonGruppe>
-          )}
-
-          {visBorAnnenForelderINorge && (
-            <BorForelderINorge
-              barn={barn}
-              forelder={forelder}
-              settForelder={settForelder}
-              settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
-            />
-          )}
-
-          {(visBostedOgSamværSeksjon(forelder, visBorAnnenForelderINorge) ||
-            barnHarSammeForelder) && (
-            <BostedOgSamvær
-              settForelder={settForelder}
-              forelder={forelder}
-              barn={barn}
-              settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
-            />
-          )}
-
-          {!barnHarSammeForelder && visSpørsmålHvisIkkeSammeForelder(forelder) && (
-            <>
-              {forelder.borINorge?.verdi && (
-                <BorAnnenForelderISammeHus
-                  forelder={forelder}
-                  settForelder={settForelder}
-                  barn={barn}
-                />
-              )}
-
-              {skalFylleUtHarBoddSammenFør && (
-                <BoddSammenFør
-                  forelder={forelder}
-                  barn={barn}
-                  settForelder={settForelder}
-                />
-              )}
-              {(boddSammenFør?.svarid === ESvar.NEI ||
-                erGyldigDato(flyttetFra?.verdi)) && (
-                <HvorMyeSammen
-                  forelder={forelder}
-                  barn={barn}
-                  settForelder={settForelder}
-                />
-              )}
-            </>
-          )}
-          {erForelderUtfylt(forelder) && (
-            <Knapp onClick={leggTilForelder}>
-              <LocaleTekst
-                tekst={
-                  !sisteBarnUtfylt && !erPåSisteBarn
-                    ? 'knapp.neste.barn'
-                    : 'knapp.neste'
+    const [forelder, settForelder] = useState<IForelder>(
+        barn.forelder
+            ? barn.forelder
+            : barn.medforelder?.verdi
+                ? {
+                    id: hentUid(),
+                    ...medforelderMedLabel(barn.medforelder),
                 }
-              />
-            </Knapp>
-          )}
-        </div>
-      </div>
-    </>
-  );
+                : {
+                    id: hentUid(),
+                }
+    );
+
+    const [barnHarSammeForelder, settBarnHarSammeForelder] = useState<boolean | undefined>(undefined);
+    const [kjennerIkkeIdent, settKjennerIkkeIdent] = useState<boolean>(
+        forelder.fødselsdato?.verdi ? true : false
+    );
+
+    const {
+        borAnnenForelderISammeHus,
+        boddSammenFør,
+        flyttetFra,
+        fødselsdato,
+        ident,
+    } = forelder;
+    const jegKanIkkeOppgiLabel = hentTekst(
+        'barnasbosted.kanikkeoppgiforelder',
+        intl
+    );
+
+    const erFødselsdatoUtfyltOgGyldig = (fødselsdato?: string) => (fødselsdato !== "" ? erGyldigDato(fødselsdato) : true);
+
+    useEffect(() => {
+        settForelder({
+            ...forelder,
+            kanIkkeOppgiAnnenForelderFar: {
+                label: jegKanIkkeOppgiLabel,
+                verdi: forelder.kanIkkeOppgiAnnenForelderFar?.verdi || false,
+            },
+        });
+        //eslint-disable-next-line
+    }, []);
+
+    useEffect(() => {
+        if (sisteBarnUtfylt === true && !erForelderUtfylt(forelder)) {
+            const nyBarneListe = lagOppdatertBarneliste(barneListe, barn, forelder);
+            settBarneListe(nyBarneListe);
+            settSisteBarnUtfylt(false);
+        }
+    }, [
+        sisteBarnUtfylt,
+        settSisteBarnUtfylt,
+        forelder,
+        barneListe,
+        barn,
+        settBarneListe,
+    ]);
+
+    const andreBarnMedForelder: IBarn[] = barneListe.filter((b) => {
+        return b !== barn && b.forelder;
+    });
+
+    const unikeForeldreIDer = Array.from(
+        new Set(andreBarnMedForelder.map((b) => b.forelder?.id))
+    );
+
+    const førsteBarnTilHverForelder = unikeForeldreIDer
+        .map((id) => {
+            if (!id) return null;
+            return andreBarnMedForelder.find((b) => b.forelder?.id === id);
+        })
+        .filter(Boolean) as IBarn[];
+
+    const erPåSisteBarn: boolean =
+        barneListe.length - 1 === andreBarnMedForelder.length;
+
+    const leggTilForelder = () => {
+        if (erForelderUtfylt(forelder)) settSisteBarnUtfylt(true);
+        const nyIndex = aktivIndex + 1;
+        const nyBarneListe = lagOppdatertBarneliste(barneListe, barn, forelder);
+
+        settBarneListe(nyBarneListe);
+        settAktivIndex(nyIndex);
+        scrollTilLagtTilBarn();
+    };
+
+    const visOmAndreForelder =
+        (!barn.medforelder?.verdi && førsteBarnTilHverForelder.length === 0) ||
+        (førsteBarnTilHverForelder.length > 0 && barnHarSammeForelder === false) ||
+        (barnHarSammeForelder === false &&
+            (barn.harSammeAdresse.verdi ||
+                harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi)));
+
+    const visBorAnnenForelderINorge =
+        !!barn.medforelder?.verdi ||
+        (!barnHarSammeForelder &&
+            !forelder.kanIkkeOppgiAnnenForelderFar?.verdi &&
+            harValgtSvar(forelder?.navn?.verdi) &&
+            (harValgtSvar(ident?.verdi || fødselsdato?.verdi) || kjennerIkkeIdent));
+
+    const skalFylleUtHarBoddSammenFør =
+        (harValgtSvar(borAnnenForelderISammeHus?.verdi) &&
+            borAnnenForelderISammeHus?.svarid !== EBorAnnenForelderISammeHus.ja) ||
+        harValgtSvar(forelder.borAnnenForelderISammeHusBeskrivelse?.verdi) ||
+        !forelder.borINorge?.verdi;
+
+    return (
+        <>
+            <div className="barnas-bosted">
+                <SeksjonGruppe>
+                    <BarneHeader barn={barn}/>
+                </SeksjonGruppe>
+                <div className="barnas-bosted__innhold">
+                    {!barn.harSammeAdresse.verdi && (
+                        <SkalBarnetBoHosSøker
+                            barn={barn}
+                            forelder={forelder}
+                            settForelder={settForelder}
+                            settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
+                        />
+                    )}
+
+                    {(barn.harSammeAdresse?.verdi ||
+                        harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi)) && (
+                        <SeksjonGruppe>
+                            <BarnetsAndreForelderTittel barn={barn}/>
+
+                            {førsteBarnTilHverForelder.length > 0 &&
+                            !barn.medforelder?.verdi && (
+                                <AnnenForelderKnapper
+                                    barn={barn}
+                                    førsteBarnTilHverForelder={førsteBarnTilHverForelder}
+                                    settForelder={settForelder}
+                                    forelder={forelder}
+                                    settBarnHarSammeForelder={settBarnHarSammeForelder}
+                                />
+                            )}
+                            {visOmAndreForelder && (
+                                <OmAndreForelder
+                                    settForelder={settForelder}
+                                    forelder={forelder}
+                                    kjennerIkkeIdent={kjennerIkkeIdent}
+                                    settKjennerIkkeIdent={settKjennerIkkeIdent}
+                                    settSisteBarnUtfylt={settSisteBarnUtfylt}
+                                />
+                            )}
+                            {barn.medforelder?.verdi && (
+                                <>
+                                    <Element>Navn</Element>
+                                    <Normaltekst>
+                                        {barn.medforelder.verdi.navn
+                                            ? barn.medforelder.verdi.navn
+                                            : `${hentTekst(
+                                                'barnekort.medforelder.hemmelig',
+                                                intl
+                                            )}, ${barn.medforelder.verdi.alder}`}
+                                    </Normaltekst>
+                                </>
+                            )}
+                        </SeksjonGruppe>
+                    )}
+
+                    {visBorAnnenForelderINorge && (
+                        <BorForelderINorge
+                            barn={barn}
+                            forelder={forelder}
+                            settForelder={settForelder}
+                            settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
+                        />
+                    )}
+
+                    {(visBostedOgSamværSeksjon(forelder, visBorAnnenForelderINorge) ||
+                        barnHarSammeForelder) && (
+                        <BostedOgSamvær
+                            settForelder={settForelder}
+                            forelder={forelder}
+                            barn={barn}
+                            settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
+                        />
+                    )}
+
+                    {!barnHarSammeForelder && visSpørsmålHvisIkkeSammeForelder(forelder) && (
+                        <>
+                            {forelder.borINorge?.verdi && (
+                                <BorAnnenForelderISammeHus
+                                    forelder={forelder}
+                                    settForelder={settForelder}
+                                    barn={barn}
+                                />
+                            )}
+
+                            {skalFylleUtHarBoddSammenFør && (
+                                <BoddSammenFør
+                                    forelder={forelder}
+                                    barn={barn}
+                                    settForelder={settForelder}
+                                />
+                            )}
+                            {(boddSammenFør?.svarid === ESvar.NEI ||
+                                erGyldigDato(flyttetFra?.verdi)) && (
+                                <HvorMyeSammen
+                                    forelder={forelder}
+                                    barn={barn}
+                                    settForelder={settForelder}
+                                />
+                            )}
+                        </>
+                    )}
+
+                    { console.log(erFødselsdatoUtfyltOgGyldig(forelder?.fødselsdato?.verdi), forelder, erForelderUtfylt(forelder))}
+                    {erForelderUtfylt(forelder) && erFødselsdatoUtfyltOgGyldig(forelder?.fødselsdato?.verdi) && (
+                        <Knapp onClick={leggTilForelder}>
+                            <LocaleTekst
+                                tekst={
+                                    !sisteBarnUtfylt && !erPåSisteBarn
+                                        ? 'knapp.neste.barn'
+                                        : 'knapp.neste'
+                                }
+                            />
+                        </Knapp>
+                    )}
+                </div>
+            </div>
+        </>
+    );
 };
 
 export default BarnetsBostedEndre;

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -76,16 +76,16 @@ interface Props {
 }
 
 const BarnetsBostedEndre: React.FC<Props> = ({
-                                               barn,
-                                               settAktivIndex,
-                                               aktivIndex,
-                                               settSisteBarnUtfylt,
-                                               sisteBarnUtfylt,
-                                               scrollTilLagtTilBarn,
-                                               barneListe,
-                                               settBarneListe,
-                                               settDokumentasjonsbehovForBarn,
-                                             }) => {
+   barn,
+   settAktivIndex,
+   aktivIndex,
+   settSisteBarnUtfylt,
+   sisteBarnUtfylt,
+   scrollTilLagtTilBarn,
+   barneListe,
+   settBarneListe,
+   settDokumentasjonsbehovForBarn,
+ }) => {
   const intl = useIntl();
 
   const medforelderMedLabel = (medforelder: any) => {

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -133,7 +133,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     intl,
   );
 
-  const erFødselsdatoUtfyltOgGyldigEllerTomtFelt = (fødselsdato?: string) => (erGyldigDato(fødselsdato) || fødselsdato === "");
+  const erFødselsdatoUtfyltOgGyldigEllerTomtFelt = (fødselsdato?: string) => (erGyldigDato(fødselsdato) || fødselsdato === '');
 
   useEffect(() => {
     settForelder({
@@ -264,62 +264,56 @@ const BarnetsBostedEndre: React.FC<Props> = ({
               )}
             </SeksjonGruppe>
           )}
-          {
-            erFødselsdatoUtfyltOgGyldigEllerTomtFelt(forelder?.fødselsdato?.verdi) && (<>
 
+          {visBorAnnenForelderINorge && (
+            <BorForelderINorge
+              barn={barn}
+              forelder={forelder}
+              settForelder={settForelder}
+              settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
+            />
+          )}
 
-                {visBorAnnenForelderINorge && (
-                  <BorForelderINorge
-                    barn={barn}
-                    forelder={forelder}
-                    settForelder={settForelder}
-                    settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
-                  />
-                )}
+          {(visBostedOgSamværSeksjon(forelder, visBorAnnenForelderINorge) ||
+            barnHarSammeForelder) && (
+            <BostedOgSamvær
+              settForelder={settForelder}
+              forelder={forelder}
+              barn={barn}
+              settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
+            />
+          )}
 
-                {(visBostedOgSamværSeksjon(forelder, visBorAnnenForelderINorge) ||
-                  barnHarSammeForelder) && (
-                  <BostedOgSamvær
-                    settForelder={settForelder}
-                    forelder={forelder}
-                    barn={barn}
-                    settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
-                  />
-                )}
+          {!barnHarSammeForelder && visSpørsmålHvisIkkeSammeForelder(forelder) && (
+            <>
+              {forelder.borINorge?.verdi && (
+                <BorAnnenForelderISammeHus
+                  forelder={forelder}
+                  settForelder={settForelder}
+                  barn={barn}
+                />
+              )}
 
-                {!barnHarSammeForelder && visSpørsmålHvisIkkeSammeForelder(forelder) && (
-                  <>
-                    {forelder.borINorge?.verdi && (
-                      <BorAnnenForelderISammeHus
-                        forelder={forelder}
-                        settForelder={settForelder}
-                        barn={barn}
-                      />
-                    )}
-
-                    {skalFylleUtHarBoddSammenFør && (
-                      <BoddSammenFør
-                        forelder={forelder}
-                        barn={barn}
-                        settForelder={settForelder}
-                      />
-                    )}
-                    {(boddSammenFør?.svarid === ESvar.NEI ||
-                      erGyldigDato(flyttetFra?.verdi)) && (
-                      <HvorMyeSammen
-                        forelder={forelder}
-                        barn={barn}
-                        settForelder={settForelder}
-                      />
-                    )}
-                  </>
-                )}
-              </>
-            )
-          }
+              {skalFylleUtHarBoddSammenFør && (
+                <BoddSammenFør
+                  forelder={forelder}
+                  barn={barn}
+                  settForelder={settForelder}
+                />
+              )}
+              {(boddSammenFør?.svarid === ESvar.NEI ||
+                erGyldigDato(flyttetFra?.verdi)) && (
+                <HvorMyeSammen
+                  forelder={forelder}
+                  barn={barn}
+                  settForelder={settForelder}
+                />
+              )}
+            </>
+          )}
 
           {((erForelderUtfylt(forelder) && erFødselsdatoUtfyltOgGyldigEllerTomtFelt(forelder?.fødselsdato?.verdi))
-          || utfyltNødvendigSpørsmålUtenOppgiAnnenForelder(forelder)) && (
+            || utfyltNødvendigSpørsmålUtenOppgiAnnenForelder(forelder)) && (
             <Knapp onClick={leggTilForelder}>
               <LocaleTekst
                 tekst={

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -10,7 +10,11 @@ import { Knapp } from 'nav-frontend-knapper';
 import { useIntl } from 'react-intl';
 import { harValgtSvar } from '../../../utils/spørsmålogsvar';
 import { hentTekst } from '../../../utils/søknad';
-import { erForelderUtfylt, visSpørsmålHvisIkkeSammeForelder } from '../../../helpers/steg/forelder';
+import {
+  erForelderUtfylt,
+  utfyltNødvendigSpørsmålUtenOppgiAnnenForelder,
+  visSpørsmålHvisIkkeSammeForelder,
+} from '../../../helpers/steg/forelder';
 import BorForelderINorge from './bostedOgSamvær/BorForelderINorge';
 import { ESvar, ISpørsmål, ISvar } from '../../../models/felles/spørsmålogsvar';
 import BorAnnenForelderISammeHus from './ikkesammeforelder/BorAnnenForelderISammeHus';
@@ -129,7 +133,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     intl,
   );
 
-  const erFødselsdatoUtfyltOgGyldig = (fødselsdato?: string) => (fødselsdato !== '' ? erGyldigDato(fødselsdato) : true);
+  const erFødselsdatoUtfyltOgGyldigEllerTomtFelt = (fødselsdato?: string) => (erGyldigDato(fødselsdato) || fødselsdato === "");
 
   useEffect(() => {
     settForelder({
@@ -261,7 +265,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
             </SeksjonGruppe>
           )}
           {
-            erFødselsdatoUtfyltOgGyldig(forelder?.fødselsdato?.verdi) && (<>
+            erFødselsdatoUtfyltOgGyldigEllerTomtFelt(forelder?.fødselsdato?.verdi) && (<>
 
 
                 {visBorAnnenForelderINorge && (
@@ -314,7 +318,8 @@ const BarnetsBostedEndre: React.FC<Props> = ({
             )
           }
 
-          {erForelderUtfylt(forelder) && erFødselsdatoUtfyltOgGyldig(forelder?.fødselsdato?.verdi) && (
+          {((erForelderUtfylt(forelder) && erFødselsdatoUtfyltOgGyldigEllerTomtFelt(forelder?.fødselsdato?.verdi))
+          || utfyltNødvendigSpørsmålUtenOppgiAnnenForelder(forelder)) && (
             <Knapp onClick={leggTilForelder}>
               <LocaleTekst
                 tekst={

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -260,55 +260,60 @@ const BarnetsBostedEndre: React.FC<Props> = ({
                             )}
                         </SeksjonGruppe>
                     )}
+                    {
+                        erFødselsdatoUtfyltOgGyldig(forelder?.fødselsdato?.verdi) && (<>
 
-                    {visBorAnnenForelderINorge && (
-                        <BorForelderINorge
-                            barn={barn}
-                            forelder={forelder}
-                            settForelder={settForelder}
-                            settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
-                        />
-                    )}
 
-                    {(visBostedOgSamværSeksjon(forelder, visBorAnnenForelderINorge) ||
-                        barnHarSammeForelder) && (
-                        <BostedOgSamvær
-                            settForelder={settForelder}
-                            forelder={forelder}
-                            barn={barn}
-                            settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
-                        />
-                    )}
+                                {visBorAnnenForelderINorge && (
+                                    <BorForelderINorge
+                                        barn={barn}
+                                        forelder={forelder}
+                                        settForelder={settForelder}
+                                        settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
+                                    />
+                                )}
 
-                    {!barnHarSammeForelder && visSpørsmålHvisIkkeSammeForelder(forelder) && (
-                        <>
-                            {forelder.borINorge?.verdi && (
-                                <BorAnnenForelderISammeHus
-                                    forelder={forelder}
-                                    settForelder={settForelder}
-                                    barn={barn}
-                                />
-                            )}
+                                {(visBostedOgSamværSeksjon(forelder, visBorAnnenForelderINorge) ||
+                                    barnHarSammeForelder) && (
+                                    <BostedOgSamvær
+                                        settForelder={settForelder}
+                                        forelder={forelder}
+                                        barn={barn}
+                                        settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
+                                    />
+                                )}
 
-                            {skalFylleUtHarBoddSammenFør && (
-                                <BoddSammenFør
-                                    forelder={forelder}
-                                    barn={barn}
-                                    settForelder={settForelder}
-                                />
-                            )}
-                            {(boddSammenFør?.svarid === ESvar.NEI ||
-                                erGyldigDato(flyttetFra?.verdi)) && (
-                                <HvorMyeSammen
-                                    forelder={forelder}
-                                    barn={barn}
-                                    settForelder={settForelder}
-                                />
-                            )}
-                        </>
-                    )}
+                                {!barnHarSammeForelder && visSpørsmålHvisIkkeSammeForelder(forelder) && (
+                                    <>
+                                        {forelder.borINorge?.verdi && (
+                                            <BorAnnenForelderISammeHus
+                                                forelder={forelder}
+                                                settForelder={settForelder}
+                                                barn={barn}
+                                            />
+                                        )}
 
-                    { console.log(erFødselsdatoUtfyltOgGyldig(forelder?.fødselsdato?.verdi), forelder, erForelderUtfylt(forelder))}
+                                        {skalFylleUtHarBoddSammenFør && (
+                                            <BoddSammenFør
+                                                forelder={forelder}
+                                                barn={barn}
+                                                settForelder={settForelder}
+                                            />
+                                        )}
+                                        {(boddSammenFør?.svarid === ESvar.NEI ||
+                                            erGyldigDato(flyttetFra?.verdi)) && (
+                                            <HvorMyeSammen
+                                                forelder={forelder}
+                                                barn={barn}
+                                                settForelder={settForelder}
+                                            />
+                                        )}
+                                    </>
+                                )}
+                            </>
+                        )
+                    }
+
                     {erForelderUtfylt(forelder) && erFødselsdatoUtfyltOgGyldig(forelder?.fødselsdato?.verdi) && (
                         <Knapp onClick={leggTilForelder}>
                             <LocaleTekst

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -1,334 +1,334 @@
-import React, {useEffect, useState} from 'react';
+import React, { useEffect, useState } from 'react';
 import AnnenForelderKnapper from './AnnenForelderKnapper';
 import BarneHeader from '../../../components/BarneHeader';
 import BostedOgSamvær from './bostedOgSamvær/BostedOgSamvær';
 import OmAndreForelder from './OmAndreForelder';
 import SkalBarnetBoHosSøker from './SkalBarnetBoHosSøker';
-import {IBarn} from '../../../models/steg/barn';
-import {IForelder} from '../../../models/steg/forelder';
-import {Knapp} from 'nav-frontend-knapper';
-import {useIntl} from 'react-intl';
-import {harValgtSvar} from '../../../utils/spørsmålogsvar';
-import {hentTekst} from '../../../utils/søknad';
-import {erForelderUtfylt, visSpørsmålHvisIkkeSammeForelder,} from '../../../helpers/steg/forelder';
+import { IBarn } from '../../../models/steg/barn';
+import { IForelder } from '../../../models/steg/forelder';
+import { Knapp } from 'nav-frontend-knapper';
+import { useIntl } from 'react-intl';
+import { harValgtSvar } from '../../../utils/spørsmålogsvar';
+import { hentTekst } from '../../../utils/søknad';
+import { erForelderUtfylt, visSpørsmålHvisIkkeSammeForelder } from '../../../helpers/steg/forelder';
 import BorForelderINorge from './bostedOgSamvær/BorForelderINorge';
-import {ESvar, ISpørsmål, ISvar} from '../../../models/felles/spørsmålogsvar';
+import { ESvar, ISpørsmål, ISvar } from '../../../models/felles/spørsmålogsvar';
 import BorAnnenForelderISammeHus from './ikkesammeforelder/BorAnnenForelderISammeHus';
 import BoddSammenFør from './ikkesammeforelder/BoddSammenFør';
 import HvorMyeSammen from './ikkesammeforelder/HvorMyeSammen';
-import {hentUid} from '../../../utils/autentiseringogvalidering/uuid';
-import {erGyldigDato} from '../../../utils/dato';
-import {EBorAnnenForelderISammeHus} from '../../../models/steg/barnasbosted';
+import { hentUid } from '../../../utils/autentiseringogvalidering/uuid';
+import { erGyldigDato } from '../../../utils/dato';
+import { EBorAnnenForelderISammeHus } from '../../../models/steg/barnasbosted';
 import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
 import BarnetsAndreForelderTittel from './BarnetsAndreForelderTittel';
 import LocaleTekst from '../../../language/LocaleTekst';
-import {Element, Normaltekst} from 'nav-frontend-typografi';
+import { Element, Normaltekst } from 'nav-frontend-typografi';
 
 const lagOppdatertBarneliste = (
-    barneliste: IBarn[],
-    nåværendeBarn: IBarn,
-    forelder: IForelder
+  barneliste: IBarn[],
+  nåværendeBarn: IBarn,
+  forelder: IForelder,
 ) => {
-    return barneliste.map((b) => {
-        if (b === nåværendeBarn) {
-            let nyttBarn = nåværendeBarn;
+  return barneliste.map((b) => {
+    if (b === nåværendeBarn) {
+      let nyttBarn = nåværendeBarn;
 
-            nyttBarn.forelder = forelder;
-            return nyttBarn;
-        } else {
-            return b;
-        }
-    });
+      nyttBarn.forelder = forelder;
+      return nyttBarn;
+    } else {
+      return b;
+    }
+  });
 };
 
 const visBostedOgSamværSeksjon = (
-    forelder: IForelder,
-    visesBorINorgeSpørsmål: boolean
+  forelder: IForelder,
+  visesBorINorgeSpørsmål: boolean,
 ) => {
-    const borForelderINorgeSpm =
-        forelder.borINorge?.svarid === ESvar.JA ||
-        (forelder.land && forelder.land?.verdi !== '');
+  const borForelderINorgeSpm =
+    forelder.borINorge?.svarid === ESvar.JA ||
+    (forelder.land && forelder.land?.verdi !== '');
 
-    return visesBorINorgeSpørsmål
-        ? borForelderINorgeSpm
-        : erGyldigDato(forelder.fødselsdato?.verdi);
+  return visesBorINorgeSpørsmål
+    ? borForelderINorgeSpm
+    : erGyldigDato(forelder.fødselsdato?.verdi);
 };
 
 interface Props {
-    barn: IBarn;
-    settAktivIndex: Function;
-    aktivIndex: number;
-    sisteBarnUtfylt: boolean;
-    settSisteBarnUtfylt: (sisteBarnUtfylt: boolean) => void;
-    scrollTilLagtTilBarn: () => void;
-    settDokumentasjonsbehovForBarn: (
-        spørsmål: ISpørsmål,
-        valgtSvar: ISvar,
-        barneid: string,
-        barnapassid?: string
-    ) => void;
-    barneListe: IBarn[];
-    settBarneListe: (barneListe: IBarn[]) => void;
+  barn: IBarn;
+  settAktivIndex: Function;
+  aktivIndex: number;
+  sisteBarnUtfylt: boolean;
+  settSisteBarnUtfylt: (sisteBarnUtfylt: boolean) => void;
+  scrollTilLagtTilBarn: () => void;
+  settDokumentasjonsbehovForBarn: (
+    spørsmål: ISpørsmål,
+    valgtSvar: ISvar,
+    barneid: string,
+    barnapassid?: string,
+  ) => void;
+  barneListe: IBarn[];
+  settBarneListe: (barneListe: IBarn[]) => void;
 }
 
 const BarnetsBostedEndre: React.FC<Props> = ({
-                                                 barn,
-                                                 settAktivIndex,
-                                                 aktivIndex,
-                                                 settSisteBarnUtfylt,
-                                                 sisteBarnUtfylt,
-                                                 scrollTilLagtTilBarn,
-                                                 barneListe,
-                                                 settBarneListe,
-                                                 settDokumentasjonsbehovForBarn,
+                                               barn,
+                                               settAktivIndex,
+                                               aktivIndex,
+                                               settSisteBarnUtfylt,
+                                               sisteBarnUtfylt,
+                                               scrollTilLagtTilBarn,
+                                               barneListe,
+                                               settBarneListe,
+                                               settDokumentasjonsbehovForBarn,
                                              }) => {
-    const intl = useIntl();
+  const intl = useIntl();
 
-    const medforelderMedLabel = (medforelder: any) => {
-        return {
-            navn: {
-                label: hentTekst('barnasbosted.medforelder.navn', intl),
-                verdi: medforelder.verdi.navn,
-            },
-            alder: {
-                label: hentTekst('barnasbosted.medforelder.alder', intl),
-                verdi: medforelder.verdi.alder,
-            },
-            død: medforelder.død,
-            harAdressesperre: medforelder.harAdressesperre,
-        };
+  const medforelderMedLabel = (medforelder: any) => {
+    return {
+      navn: {
+        label: hentTekst('barnasbosted.medforelder.navn', intl),
+        verdi: medforelder.verdi.navn,
+      },
+      alder: {
+        label: hentTekst('barnasbosted.medforelder.alder', intl),
+        verdi: medforelder.verdi.alder,
+      },
+      død: medforelder.død,
+      harAdressesperre: medforelder.harAdressesperre,
     };
+  };
 
-    const [forelder, settForelder] = useState<IForelder>(
-        barn.forelder
-            ? barn.forelder
-            : barn.medforelder?.verdi
-                ? {
-                    id: hentUid(),
-                    ...medforelderMedLabel(barn.medforelder),
-                }
-                : {
-                    id: hentUid(),
-                }
-    );
-
-    const [barnHarSammeForelder, settBarnHarSammeForelder] = useState<boolean | undefined>(undefined);
-    const [kjennerIkkeIdent, settKjennerIkkeIdent] = useState<boolean>(
-        forelder.fødselsdato?.verdi ? true : false
-    );
-
-    const {
-        borAnnenForelderISammeHus,
-        boddSammenFør,
-        flyttetFra,
-        fødselsdato,
-        ident,
-    } = forelder;
-    const jegKanIkkeOppgiLabel = hentTekst(
-        'barnasbosted.kanikkeoppgiforelder',
-        intl
-    );
-
-    const erFødselsdatoUtfyltOgGyldig = (fødselsdato?: string) => (fødselsdato !== "" ? erGyldigDato(fødselsdato) : true);
-
-    useEffect(() => {
-        settForelder({
-            ...forelder,
-            kanIkkeOppgiAnnenForelderFar: {
-                label: jegKanIkkeOppgiLabel,
-                verdi: forelder.kanIkkeOppgiAnnenForelderFar?.verdi || false,
-            },
-        });
-        //eslint-disable-next-line
-    }, []);
-
-    useEffect(() => {
-        if (sisteBarnUtfylt === true && !erForelderUtfylt(forelder)) {
-            const nyBarneListe = lagOppdatertBarneliste(barneListe, barn, forelder);
-            settBarneListe(nyBarneListe);
-            settSisteBarnUtfylt(false);
+  const [forelder, settForelder] = useState<IForelder>(
+    barn.forelder
+      ? barn.forelder
+      : barn.medforelder?.verdi
+        ? {
+          id: hentUid(),
+          ...medforelderMedLabel(barn.medforelder),
         }
-    }, [
-        sisteBarnUtfylt,
-        settSisteBarnUtfylt,
-        forelder,
-        barneListe,
-        barn,
-        settBarneListe,
-    ]);
+        : {
+          id: hentUid(),
+        },
+  );
 
-    const andreBarnMedForelder: IBarn[] = barneListe.filter((b) => {
-        return b !== barn && b.forelder;
+  const [barnHarSammeForelder, settBarnHarSammeForelder] = useState<boolean | undefined>(undefined);
+  const [kjennerIkkeIdent, settKjennerIkkeIdent] = useState<boolean>(
+    forelder.fødselsdato?.verdi ? true : false,
+  );
+
+  const {
+    borAnnenForelderISammeHus,
+    boddSammenFør,
+    flyttetFra,
+    fødselsdato,
+    ident,
+  } = forelder;
+  const jegKanIkkeOppgiLabel = hentTekst(
+    'barnasbosted.kanikkeoppgiforelder',
+    intl,
+  );
+
+  const erFødselsdatoUtfyltOgGyldig = (fødselsdato?: string) => (fødselsdato !== '' ? erGyldigDato(fødselsdato) : true);
+
+  useEffect(() => {
+    settForelder({
+      ...forelder,
+      kanIkkeOppgiAnnenForelderFar: {
+        label: jegKanIkkeOppgiLabel,
+        verdi: forelder.kanIkkeOppgiAnnenForelderFar?.verdi || false,
+      },
     });
+    //eslint-disable-next-line
+  }, []);
 
-    const unikeForeldreIDer = Array.from(
-        new Set(andreBarnMedForelder.map((b) => b.forelder?.id))
-    );
+  useEffect(() => {
+    if (sisteBarnUtfylt === true && !erForelderUtfylt(forelder)) {
+      const nyBarneListe = lagOppdatertBarneliste(barneListe, barn, forelder);
+      settBarneListe(nyBarneListe);
+      settSisteBarnUtfylt(false);
+    }
+  }, [
+    sisteBarnUtfylt,
+    settSisteBarnUtfylt,
+    forelder,
+    barneListe,
+    barn,
+    settBarneListe,
+  ]);
 
-    const førsteBarnTilHverForelder = unikeForeldreIDer
-        .map((id) => {
-            if (!id) return null;
-            return andreBarnMedForelder.find((b) => b.forelder?.id === id);
-        })
-        .filter(Boolean) as IBarn[];
+  const andreBarnMedForelder: IBarn[] = barneListe.filter((b) => {
+    return b !== barn && b.forelder;
+  });
 
-    const erPåSisteBarn: boolean =
-        barneListe.length - 1 === andreBarnMedForelder.length;
+  const unikeForeldreIDer = Array.from(
+    new Set(andreBarnMedForelder.map((b) => b.forelder?.id)),
+  );
 
-    const leggTilForelder = () => {
-        if (erForelderUtfylt(forelder)) settSisteBarnUtfylt(true);
-        const nyIndex = aktivIndex + 1;
-        const nyBarneListe = lagOppdatertBarneliste(barneListe, barn, forelder);
+  const førsteBarnTilHverForelder = unikeForeldreIDer
+    .map((id) => {
+      if (!id) return null;
+      return andreBarnMedForelder.find((b) => b.forelder?.id === id);
+    })
+    .filter(Boolean) as IBarn[];
 
-        settBarneListe(nyBarneListe);
-        settAktivIndex(nyIndex);
-        scrollTilLagtTilBarn();
-    };
+  const erPåSisteBarn: boolean =
+    barneListe.length - 1 === andreBarnMedForelder.length;
 
-    const visOmAndreForelder =
-        (!barn.medforelder?.verdi && førsteBarnTilHverForelder.length === 0) ||
-        (førsteBarnTilHverForelder.length > 0 && barnHarSammeForelder === false) ||
-        (barnHarSammeForelder === false &&
-            (barn.harSammeAdresse.verdi ||
-                harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi)));
+  const leggTilForelder = () => {
+    if (erForelderUtfylt(forelder)) settSisteBarnUtfylt(true);
+    const nyIndex = aktivIndex + 1;
+    const nyBarneListe = lagOppdatertBarneliste(barneListe, barn, forelder);
 
-    const visBorAnnenForelderINorge =
-        !!barn.medforelder?.verdi ||
-        (!barnHarSammeForelder &&
-            !forelder.kanIkkeOppgiAnnenForelderFar?.verdi &&
-            harValgtSvar(forelder?.navn?.verdi) &&
-            (harValgtSvar(ident?.verdi || fødselsdato?.verdi) || kjennerIkkeIdent));
+    settBarneListe(nyBarneListe);
+    settAktivIndex(nyIndex);
+    scrollTilLagtTilBarn();
+  };
 
-    const skalFylleUtHarBoddSammenFør =
-        (harValgtSvar(borAnnenForelderISammeHus?.verdi) &&
-            borAnnenForelderISammeHus?.svarid !== EBorAnnenForelderISammeHus.ja) ||
-        harValgtSvar(forelder.borAnnenForelderISammeHusBeskrivelse?.verdi) ||
-        !forelder.borINorge?.verdi;
+  const visOmAndreForelder =
+    (!barn.medforelder?.verdi && førsteBarnTilHverForelder.length === 0) ||
+    (førsteBarnTilHverForelder.length > 0 && barnHarSammeForelder === false) ||
+    (barnHarSammeForelder === false &&
+      (barn.harSammeAdresse.verdi ||
+        harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi)));
 
-    return (
-        <>
-            <div className="barnas-bosted">
-                <SeksjonGruppe>
-                    <BarneHeader barn={barn}/>
-                </SeksjonGruppe>
-                <div className="barnas-bosted__innhold">
-                    {!barn.harSammeAdresse.verdi && (
-                        <SkalBarnetBoHosSøker
-                            barn={barn}
-                            forelder={forelder}
-                            settForelder={settForelder}
-                            settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
-                        />
+  const visBorAnnenForelderINorge =
+    !!barn.medforelder?.verdi ||
+    (!barnHarSammeForelder &&
+      !forelder.kanIkkeOppgiAnnenForelderFar?.verdi &&
+      harValgtSvar(forelder?.navn?.verdi) &&
+      (harValgtSvar(ident?.verdi || fødselsdato?.verdi) || kjennerIkkeIdent));
+
+  const skalFylleUtHarBoddSammenFør =
+    (harValgtSvar(borAnnenForelderISammeHus?.verdi) &&
+      borAnnenForelderISammeHus?.svarid !== EBorAnnenForelderISammeHus.ja) ||
+    harValgtSvar(forelder.borAnnenForelderISammeHusBeskrivelse?.verdi) ||
+    !forelder.borINorge?.verdi;
+
+  return (
+    <>
+      <div className='barnas-bosted'>
+        <SeksjonGruppe>
+          <BarneHeader barn={barn} />
+        </SeksjonGruppe>
+        <div className='barnas-bosted__innhold'>
+          {!barn.harSammeAdresse.verdi && (
+            <SkalBarnetBoHosSøker
+              barn={barn}
+              forelder={forelder}
+              settForelder={settForelder}
+              settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
+            />
+          )}
+
+          {(barn.harSammeAdresse?.verdi ||
+            harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi)) && (
+            <SeksjonGruppe>
+              <BarnetsAndreForelderTittel barn={barn} />
+
+              {førsteBarnTilHverForelder.length > 0 &&
+              !barn.medforelder?.verdi && (
+                <AnnenForelderKnapper
+                  barn={barn}
+                  førsteBarnTilHverForelder={førsteBarnTilHverForelder}
+                  settForelder={settForelder}
+                  forelder={forelder}
+                  settBarnHarSammeForelder={settBarnHarSammeForelder}
+                />
+              )}
+              {visOmAndreForelder && (
+                <OmAndreForelder
+                  settForelder={settForelder}
+                  forelder={forelder}
+                  kjennerIkkeIdent={kjennerIkkeIdent}
+                  settKjennerIkkeIdent={settKjennerIkkeIdent}
+                  settSisteBarnUtfylt={settSisteBarnUtfylt}
+                />
+              )}
+              {barn.medforelder?.verdi && (
+                <>
+                  <Element>Navn</Element>
+                  <Normaltekst>
+                    {barn.medforelder.verdi.navn
+                      ? barn.medforelder.verdi.navn
+                      : `${hentTekst(
+                        'barnekort.medforelder.hemmelig',
+                        intl,
+                      )}, ${barn.medforelder.verdi.alder}`}
+                  </Normaltekst>
+                </>
+              )}
+            </SeksjonGruppe>
+          )}
+          {
+            erFødselsdatoUtfyltOgGyldig(forelder?.fødselsdato?.verdi) && (<>
+
+
+                {visBorAnnenForelderINorge && (
+                  <BorForelderINorge
+                    barn={barn}
+                    forelder={forelder}
+                    settForelder={settForelder}
+                    settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
+                  />
+                )}
+
+                {(visBostedOgSamværSeksjon(forelder, visBorAnnenForelderINorge) ||
+                  barnHarSammeForelder) && (
+                  <BostedOgSamvær
+                    settForelder={settForelder}
+                    forelder={forelder}
+                    barn={barn}
+                    settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
+                  />
+                )}
+
+                {!barnHarSammeForelder && visSpørsmålHvisIkkeSammeForelder(forelder) && (
+                  <>
+                    {forelder.borINorge?.verdi && (
+                      <BorAnnenForelderISammeHus
+                        forelder={forelder}
+                        settForelder={settForelder}
+                        barn={barn}
+                      />
                     )}
 
-                    {(barn.harSammeAdresse?.verdi ||
-                        harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi)) && (
-                        <SeksjonGruppe>
-                            <BarnetsAndreForelderTittel barn={barn}/>
-
-                            {førsteBarnTilHverForelder.length > 0 &&
-                            !barn.medforelder?.verdi && (
-                                <AnnenForelderKnapper
-                                    barn={barn}
-                                    førsteBarnTilHverForelder={førsteBarnTilHverForelder}
-                                    settForelder={settForelder}
-                                    forelder={forelder}
-                                    settBarnHarSammeForelder={settBarnHarSammeForelder}
-                                />
-                            )}
-                            {visOmAndreForelder && (
-                                <OmAndreForelder
-                                    settForelder={settForelder}
-                                    forelder={forelder}
-                                    kjennerIkkeIdent={kjennerIkkeIdent}
-                                    settKjennerIkkeIdent={settKjennerIkkeIdent}
-                                    settSisteBarnUtfylt={settSisteBarnUtfylt}
-                                />
-                            )}
-                            {barn.medforelder?.verdi && (
-                                <>
-                                    <Element>Navn</Element>
-                                    <Normaltekst>
-                                        {barn.medforelder.verdi.navn
-                                            ? barn.medforelder.verdi.navn
-                                            : `${hentTekst(
-                                                'barnekort.medforelder.hemmelig',
-                                                intl
-                                            )}, ${barn.medforelder.verdi.alder}`}
-                                    </Normaltekst>
-                                </>
-                            )}
-                        </SeksjonGruppe>
+                    {skalFylleUtHarBoddSammenFør && (
+                      <BoddSammenFør
+                        forelder={forelder}
+                        barn={barn}
+                        settForelder={settForelder}
+                      />
                     )}
-                    {
-                        erFødselsdatoUtfyltOgGyldig(forelder?.fødselsdato?.verdi) && (<>
-
-
-                                {visBorAnnenForelderINorge && (
-                                    <BorForelderINorge
-                                        barn={barn}
-                                        forelder={forelder}
-                                        settForelder={settForelder}
-                                        settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
-                                    />
-                                )}
-
-                                {(visBostedOgSamværSeksjon(forelder, visBorAnnenForelderINorge) ||
-                                    barnHarSammeForelder) && (
-                                    <BostedOgSamvær
-                                        settForelder={settForelder}
-                                        forelder={forelder}
-                                        barn={barn}
-                                        settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
-                                    />
-                                )}
-
-                                {!barnHarSammeForelder && visSpørsmålHvisIkkeSammeForelder(forelder) && (
-                                    <>
-                                        {forelder.borINorge?.verdi && (
-                                            <BorAnnenForelderISammeHus
-                                                forelder={forelder}
-                                                settForelder={settForelder}
-                                                barn={barn}
-                                            />
-                                        )}
-
-                                        {skalFylleUtHarBoddSammenFør && (
-                                            <BoddSammenFør
-                                                forelder={forelder}
-                                                barn={barn}
-                                                settForelder={settForelder}
-                                            />
-                                        )}
-                                        {(boddSammenFør?.svarid === ESvar.NEI ||
-                                            erGyldigDato(flyttetFra?.verdi)) && (
-                                            <HvorMyeSammen
-                                                forelder={forelder}
-                                                barn={barn}
-                                                settForelder={settForelder}
-                                            />
-                                        )}
-                                    </>
-                                )}
-                            </>
-                        )
-                    }
-
-                    {erForelderUtfylt(forelder) && erFødselsdatoUtfyltOgGyldig(forelder?.fødselsdato?.verdi) && (
-                        <Knapp onClick={leggTilForelder}>
-                            <LocaleTekst
-                                tekst={
-                                    !sisteBarnUtfylt && !erPåSisteBarn
-                                        ? 'knapp.neste.barn'
-                                        : 'knapp.neste'
-                                }
-                            />
-                        </Knapp>
+                    {(boddSammenFør?.svarid === ESvar.NEI ||
+                      erGyldigDato(flyttetFra?.verdi)) && (
+                      <HvorMyeSammen
+                        forelder={forelder}
+                        barn={barn}
+                        settForelder={settForelder}
+                      />
                     )}
-                </div>
-            </div>
-        </>
-    );
+                  </>
+                )}
+              </>
+            )
+          }
+
+          {erForelderUtfylt(forelder) && erFødselsdatoUtfyltOgGyldig(forelder?.fødselsdato?.verdi) && (
+            <Knapp onClick={leggTilForelder}>
+              <LocaleTekst
+                tekst={
+                  !sisteBarnUtfylt && !erPåSisteBarn
+                    ? 'knapp.neste.barn'
+                    : 'knapp.neste'
+                }
+              />
+            </Knapp>
+          )}
+        </div>
+      </div>
+    </>
+  );
 };
 
 export default BarnetsBostedEndre;


### PR DESCRIPTION
**Innhold:**
- Filtrer bort/Ikke vis neste seksjoner (utfylt eller ikke) dersom man har feil fdato. Vil også skje dersom bruker går opp og tilbake for å endre fdato. Skal ikke gå an å fylle ut kun et årstall. 
- Ikke vis Neste knapp (Neste barn) hvis man har feil format på fdato
- Legg til rette for at bruker kan fjerne dato i etterkant (dvs. at feltet blir en tom streng) og fremdeles gå videre (siden fdato er optional).

Note to self: Vurder å endre "Neste" (barn) til noe annet mtp UU. Er forvirrende for bruker å "høre" to Neste knapper. 
Forslag til erstatningstekst? 
- "Lagre informasjon" 
- "Gå videre til neste barn" / "Gå videre" *lagre infoen, vis neste knapp nederst*
..? 

**Favro-kort med screenshots:** https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-5617
