### PR TITLE
Sjekk medforelder

### DIFF
--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -20,14 +20,8 @@ export const erForelderUtfylt = (forelder: IForelder): boolean | undefined => {
   const utfyltBorINorge =
     borINorge?.verdi || (borINorge?.verdi === false && land?.verdi !== '');
 
-  const erFeltTomtEllerUtfyltMedGyldigFødselsdato = (
-    erGyldigDato(fødselsdato?.verdi) || fødselsdato?.verdi === ""
-  );
-  const utfyltForelderInfo = navn?.verdi !== '' && (ident?.verdi !== '' || erFeltTomtEllerUtfyltMedGyldigFødselsdato);
-
   const utfyltAvtaleDeltBosted = harValgtSvar(avtaleOmDeltBosted?.verdi);
   const forelderInfoOgSpørsmålBesvart: boolean | undefined =
-    utfyltForelderInfo &&
     utfyltBorINorge &&
     utfyltAvtaleDeltBosted &&
     utfyltNødvendigeSamværSpørsmål(forelder) &&

--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -10,13 +10,12 @@ import { ESvar, ISpørsmål, ISvar } from '../../models/felles/spørsmålogsvar'
 import { harValgtSvar } from '../../utils/spørsmålogsvar';
 import { erDatoGyldigOgInnaforBegrensninger } from '../../components/dato/utils';
 import { DatoBegrensning } from '../../components/dato/Datovelger';
-import { erGyldigDato } from '../../utils/dato';
 
 export const erAlleForeldreUtfylt = (foreldre: IForelder[]) =>
   foreldre.every((forelder) => erForelderUtfylt(forelder));
 
 export const erForelderUtfylt = (forelder: IForelder): boolean | undefined => {
-  const { navn, fødselsdato, ident, borINorge, land, avtaleOmDeltBosted } = forelder;
+  const { borINorge, land, avtaleOmDeltBosted } = forelder;
   const utfyltBorINorge =
     borINorge?.verdi || (borINorge?.verdi === false && land?.verdi !== '');
 

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -133,7 +133,9 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     intl,
   );
 
-  const erFødselsdatoUtfyltOgGyldigEllerTomtFelt = (fødselsdato?: string) => (erGyldigDato(fødselsdato) || fødselsdato === '');
+  const erFødselsdatoUtfyltOgGyldigEllerTomtFelt =
+    (fødselsdato?: string) => (erGyldigDato(fødselsdato) || fødselsdato === '');
+  const harForelderFraPdl = (barn?.medforelder?.verdi.navn || false);
 
   useEffect(() => {
     settForelder({
@@ -208,6 +210,9 @@ const BarnetsBostedEndre: React.FC<Props> = ({
       borAnnenForelderISammeHus?.svarid !== EBorAnnenForelderISammeHus.ja) ||
     harValgtSvar(forelder.borAnnenForelderISammeHusBeskrivelse?.verdi) ||
     !forelder.borINorge?.verdi;
+
+  console.log(forelder);
+  console.log(barn?.medforelder?.verdi);
 
   return (
     <>
@@ -312,8 +317,12 @@ const BarnetsBostedEndre: React.FC<Props> = ({
             </>
           )}
 
-          {((erForelderUtfylt(forelder) && erFødselsdatoUtfyltOgGyldigEllerTomtFelt(forelder?.fødselsdato?.verdi))
-            || utfyltNødvendigSpørsmålUtenOppgiAnnenForelder(forelder)) && (
+          {((erForelderUtfylt(forelder) &&
+            (
+              erFødselsdatoUtfyltOgGyldigEllerTomtFelt(forelder?.fødselsdato?.verdi) ||
+              utfyltNødvendigSpørsmålUtenOppgiAnnenForelder(forelder)  ||
+              harForelderFraPdl)
+          ) && (
             <Knapp onClick={leggTilForelder}>
               <LocaleTekst
                 tekst={

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -332,7 +332,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
                 }
               />
             </Knapp>
-          )}
+          ))}
         </div>
       </div>
     </>


### PR DESCRIPTION
Fiksen der vi prøvde å være strenge slik at bruker måtte fylle ut årstall (dersom annen forelder ikke fantes i folkeregisteret) sjekket bare `forelder` som er objektet for når man svarer på spm og fyller inn forelder info i søknadsdialogen. Når man henter forelder fra pdl lagres den i `medforelder`, så her har det endt med en glipp der bruker ikke kan gå videre hvis de har forelder hentet fra pdl. 
![image](https://user-images.githubusercontent.com/8249453/125930121-83f0f468-4b0a-4d79-a789-e61082900e91.png)


Denne PRen skal fikse dette ved å sjekke medforelder i tillegg. 😎 

