### PR TITLE
Vis "Samme som"-knapper for barn/foreldre som kommer fra folkeregister.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,7 +76,7 @@ const App = () => {
   };
 
   const oppdaterSøknadMedBarn = (person: IPerson, barneliste: any[]) => {
-    const barnMedLabels = oppdaterBarnMedLabel(barneliste);
+    const barnMedLabels = oppdaterBarnMedLabel(barneliste, intl);
 
     settSøknad({ ...søknad, person: { ...person, barn: barnMedLabels } });
   };

--- a/src/barnetilsyn/BarnetilsynApp.tsx
+++ b/src/barnetilsyn/BarnetilsynApp.tsx
@@ -77,7 +77,7 @@ const BarnetilsynApp = () => {
   };
 
   const oppdaterSøknadMedBarn = (person: IPerson, barneliste: any[]) => {
-    const barnMedLabels = oppdaterBarnMedLabel(barneliste);
+    const barnMedLabels = oppdaterBarnMedLabel(barneliste, intl);
     settSøknad &&
       settSøknad({ ...søknad, person: { ...person, barn: barnMedLabels } });
   };

--- a/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
+++ b/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
@@ -91,6 +91,7 @@ const BarnaDine: React.FC = () => {
   const harValgtMinstEttBarn = søknad.person.barn.some(
     (b: IBarn) => b.skalHaBarnepass?.verdi
   );
+
   return (
     <>
       <Side

--- a/src/barnetilsyn/steg/9-kvittering/Kvittering.tsx
+++ b/src/barnetilsyn/steg/9-kvittering/Kvittering.tsx
@@ -42,7 +42,7 @@ const Kvittering: React.FC = () => {
   useEffect(() => {
     nullstillMellomlagretBarnetilsyn();
     return () => {
-      const barnelisteMedLabels = oppdaterBarnMedLabel(person.barn);
+      const barnelisteMedLabels = oppdaterBarnMedLabel(person.barn, intl);
       nullstillSøknadBarnetilsyn(person, barnelisteMedLabels);
     };
   }, [nullstillMellomlagretBarnetilsyn, nullstillSøknadBarnetilsyn, person]);

--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -15,27 +15,26 @@ export const erAlleForeldreUtfylt = (foreldre: IForelder[]) =>
   foreldre.every((forelder) => erForelderUtfylt(forelder));
 
 export const erForelderUtfylt = (forelder: IForelder): boolean | undefined => {
-  const { borINorge, land, avtaleOmDeltBosted } = forelder;
+  const { borINorge, land, avtaleOmDeltBosted, fraFolkeregister } = forelder;
   const utfyltBorINorge =
     borINorge?.verdi || (borINorge?.verdi === false && land?.verdi !== '');
 
   const utfyltAvtaleDeltBosted = harValgtSvar(avtaleOmDeltBosted?.verdi);
   const forelderInfoOgSpørsmålBesvart: boolean | undefined =
-    utfyltBorINorge &&
+    (utfyltBorINorge || fraFolkeregister) &&
     utfyltAvtaleDeltBosted &&
     utfyltNødvendigeSamværSpørsmål(forelder) &&
-    utfyltNødvendigBostedSpørsmål(forelder);
+    (utfyltNødvendigBostedSpørsmål(forelder) || fraFolkeregister);
 
   const kanIkkeOppgiAnnenForelderRuteUtfylt = utfyltNødvendigSpørsmålUtenOppgiAnnenForelder(
-    forelder,
+    forelder
   );
 
   return forelderInfoOgSpørsmålBesvart || kanIkkeOppgiAnnenForelderRuteUtfylt;
 };
 
-
 export const utfyltNødvendigSpørsmålUtenOppgiAnnenForelder = (
-  forelder: IForelder,
+  forelder: IForelder
 ) => {
   const {
     hvorforIkkeOppgi,
@@ -70,7 +69,7 @@ export const utfyltNødvendigeSamværSpørsmål = (forelder: IForelder) => {
     harIkkeAvtaleOmDeltBosted &&
     måBeskriveSamværet(
       harDereSkriftligSamværsavtale?.svarid,
-      harAnnenForelderSamværMedBarn?.svarid,
+      harAnnenForelderSamværMedBarn?.svarid
     )
   )
     return harValgtSvar(hvordanPraktiseresSamværet?.verdi);
@@ -81,7 +80,7 @@ export const utfyltNødvendigBostedSpørsmål = (forelder?: IForelder) => {
   const utfyltBorISammeHus =
     forelder?.borINorge?.verdi &&
     forelder?.borAnnenForelderISammeHus?.svarid ===
-    EBorAnnenForelderISammeHus.ja
+      EBorAnnenForelderISammeHus.ja
       ? forelder?.borAnnenForelderISammeHusBeskrivelse?.verdi !== ''
       : true;
 
@@ -89,7 +88,7 @@ export const utfyltNødvendigBostedSpørsmål = (forelder?: IForelder) => {
     forelder?.flyttetFra?.verdi &&
     erDatoGyldigOgInnaforBegrensninger(
       forelder.flyttetFra?.verdi,
-      DatoBegrensning.TidligereDatoer,
+      DatoBegrensning.TidligereDatoer
     )
       ? true
       : false;
@@ -135,7 +134,7 @@ export const harSkriftligSamværsavtale = (svarid: string | undefined) => {
 
 export const måBeskriveSamværet = (
   samværsavtale: string | undefined,
-  samværMedBarn: string | undefined,
+  samværMedBarn: string | undefined
 ) => {
   return (
     samværMedBarn === EHarSamværMedBarn.jaMerEnnVanlig &&
@@ -156,7 +155,7 @@ export const visSpørsmålHvisIkkeSammeForelder = (forelder: IForelder) => {
   else if (forelder.harDereSkriftligSamværsavtale?.svarid)
     return !måBeskriveSamværet(
       forelder.harDereSkriftligSamværsavtale.svarid,
-      forelder.harAnnenForelderSamværMedBarn?.svarid,
+      forelder.harAnnenForelderSamværMedBarn?.svarid
     );
 
   return false;
@@ -164,7 +163,7 @@ export const visSpørsmålHvisIkkeSammeForelder = (forelder: IForelder) => {
 
 export const hvisEndretSvarSlettFeltHvordanPraktiseresSamværet = (
   spørsmål: ISpørsmål,
-  svar: ISvar,
+  svar: ISvar
 ) => {
   return (
     (spørsmål.søknadid === EForelder.harDereSkriftligSamværsavtale &&
@@ -176,7 +175,7 @@ export const hvisEndretSvarSlettFeltHvordanPraktiseresSamværet = (
 
 export const harSkriftligAvtaleOmDeltBosted = (
   spørsmål: ISpørsmål,
-  svar: ISvar,
+  svar: ISvar
 ) => {
   return (
     spørsmål.søknadid === EForelder.avtaleOmDeltBosted && svar.id === ESvar.JA

--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -30,8 +30,6 @@ export const erForelderUtfylt = (forelder: IForelder): boolean | undefined => {
     forelder
   );
 
-  console.log('BESVART', forelderInfoOgSpørsmålBesvart);
-
   return forelderInfoOgSpørsmålBesvart || kanIkkeOppgiAnnenForelderRuteUtfylt;
 };
 

--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -30,6 +30,8 @@ export const erForelderUtfylt = (forelder: IForelder): boolean | undefined => {
     forelder
   );
 
+  console.log('BESVART', forelderInfoOgSpørsmålBesvart);
+
   return forelderInfoOgSpørsmålBesvart || kanIkkeOppgiAnnenForelderRuteUtfylt;
 };
 

--- a/src/models/steg/forelder.ts
+++ b/src/models/steg/forelder.ts
@@ -27,6 +27,7 @@ export interface IForelder {
   flyttetFra?: IDatoFelt;
   hvorMyeSammen?: ISpørsmålFelt;
   beskrivSamværUtenBarn?: ITekstFelt;
+  fraFolkeregister?: boolean;
 }
 
 export enum EForelder {

--- a/src/overgangsstønad/steg/8-dokumentasjon/SendSøknad.tsx
+++ b/src/overgangsstønad/steg/8-dokumentasjon/SendSøknad.tsx
@@ -109,8 +109,6 @@ const SendSøknadKnapper: FC = () => {
       locale: locale,
     };
 
-    console.log('SØKNAD KLAR FOR', søknadKlarForSending);
-
     settinnsendingState({ ...innsendingState, venter: true });
     sendInnSøknad(søknadKlarForSending)
       .then((kvittering) => {

--- a/src/overgangsstønad/steg/8-dokumentasjon/SendSøknad.tsx
+++ b/src/overgangsstønad/steg/8-dokumentasjon/SendSøknad.tsx
@@ -109,6 +109,8 @@ const SendSøknadKnapper: FC = () => {
       locale: locale,
     };
 
+    console.log('SØKNAD KLAR FOR', søknadKlarForSending);
+
     settinnsendingState({ ...innsendingState, venter: true });
     sendInnSøknad(søknadKlarForSending)
       .then((kvittering) => {

--- a/src/overgangsstønad/steg/9-kvittering/Kvittering.tsx
+++ b/src/overgangsstønad/steg/9-kvittering/Kvittering.tsx
@@ -53,7 +53,7 @@ const Kvittering: React.FC = () => {
   useEffect(() => {
     nullstillMellomlagretOvergangsstønad();
     return () => {
-      const barnelisteMedLabels = oppdaterBarnMedLabel(person.barn);
+      const barnelisteMedLabels = oppdaterBarnMedLabel(person.barn, intl);
       nullstillSøknadOvergangsstønad(person, barnelisteMedLabels);
     };
   }, [

--- a/src/skolepenger/SkolepengerApp.tsx
+++ b/src/skolepenger/SkolepengerApp.tsx
@@ -80,7 +80,7 @@ const SkolepengerApp = () => {
   };
 
   const oppdaterSøknadMedBarn = (person: IPerson, barneliste: any[]) => {
-    const barnMedLabels = oppdaterBarnMedLabel(barneliste);
+    const barnMedLabels = oppdaterBarnMedLabel(barneliste, intl);
 
     settSøknad &&
       settSøknad({ ...søknad, person: { ...person, barn: barnMedLabels } });

--- a/src/skolepenger/steg/8-kvittering/Kvittering.tsx
+++ b/src/skolepenger/steg/8-kvittering/Kvittering.tsx
@@ -34,7 +34,7 @@ const Kvittering: React.FC = () => {
   useEffect(() => {
     nullstillMellomlagretSkolepenger();
     return () => {
-      const barnelisteMedLabels = oppdaterBarnMedLabel(person.barn);
+      const barnelisteMedLabels = oppdaterBarnMedLabel(person.barn, intl);
       nullstillSøknadSkolepenger(person, barnelisteMedLabels);
     };
   }, [nullstillMellomlagretSkolepenger, nullstillSøknadSkolepenger, person]);

--- a/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
+++ b/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
@@ -56,6 +56,7 @@ const AnnenForelderKnapper: React.FC<Props> = ({
       hvorMyeSammen: denAndreForelderen?.hvorMyeSammen,
       beskrivSamværUtenBarn: denAndreForelderen?.beskrivSamværUtenBarn,
       land: denAndreForelderen?.land,
+      fraFolkeregister: denAndreForelderen?.fraFolkeregister,
     });
   };
 

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -152,15 +152,9 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     return b !== barn && b.forelder;
   });
 
-  console.log('ANDRE BARN MED FORELDER', andreBarnMedForelder);
-
   const unikeForeldreIDer = Array.from(
     new Set(andreBarnMedForelder.map((b) => b.forelder?.id))
   );
-
-  console.log('UNIKE', unikeForeldreIDer);
-
-  // må også lage ID til nye foreldre generert av medforelder.
 
   const førsteBarnTilHverForelder = unikeForeldreIDer
     .map((id) => {

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -197,14 +197,6 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     harValgtSvar(forelder.borAnnenForelderISammeHusBeskrivelse?.verdi) ||
     !forelder.borINorge?.verdi;
 
-  console.log('ER UTdFYLT', erForelderUtfylt(forelder));
-
-  console.log('forelder', forelder);
-
-  console.log('barnHar', barnHarSammeForelder);
-
-  // HVORDAN REGISTRERE "BOR I NORGE" NÅR MAN HAR TRYKKET "SAMME SOM MEDFORELDER"
-
   return (
     <>
       <div className="barnas-bosted">

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -89,29 +89,9 @@ const BarnetsBostedEndre: React.FC<Props> = ({
 }) => {
   const intl = useIntl();
 
-  const medforelderMedLabel = (medforelder: any) => {
-    return {
-      navn: {
-        label: hentTekst('barnasbosted.medforelder.navn', intl),
-        verdi: medforelder.verdi.navn,
-      },
-      alder: {
-        label: hentTekst('barnasbosted.medforelder.alder', intl),
-        verdi: medforelder.verdi.alder,
-      },
-      død: medforelder.død,
-      harAdressesperre: medforelder.harAdressesperre,
-    };
-  };
-
   const [forelder, settForelder] = useState<IForelder>(
     barn.forelder
       ? barn.forelder
-      : barn.medforelder?.verdi
-      ? {
-          id: hentUid(),
-          ...medforelderMedLabel(barn.medforelder),
-        }
       : {
           id: hentUid(),
         }
@@ -172,9 +152,15 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     return b !== barn && b.forelder;
   });
 
+  console.log('ANDRE BARN MED FORELDER', andreBarnMedForelder);
+
   const unikeForeldreIDer = Array.from(
     new Set(andreBarnMedForelder.map((b) => b.forelder?.id))
   );
+
+  console.log('UNIKE', unikeForeldreIDer);
+
+  // må også lage ID til nye foreldre generert av medforelder.
 
   const førsteBarnTilHverForelder = unikeForeldreIDer
     .map((id) => {

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -100,6 +100,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   const [barnHarSammeForelder, settBarnHarSammeForelder] = useState<
     boolean | undefined
   >(undefined);
+
   const [kjennerIkkeIdent, settKjennerIkkeIdent] = useState<boolean>(
     forelder.fødselsdato?.verdi ? true : false
   );
@@ -195,6 +196,14 @@ const BarnetsBostedEndre: React.FC<Props> = ({
       borAnnenForelderISammeHus?.svarid !== EBorAnnenForelderISammeHus.ja) ||
     harValgtSvar(forelder.borAnnenForelderISammeHusBeskrivelse?.verdi) ||
     !forelder.borINorge?.verdi;
+
+  console.log('ER UTdFYLT', erForelderUtfylt(forelder));
+
+  console.log('forelder', forelder);
+
+  console.log('barnHar', barnHarSammeForelder);
+
+  // HVORDAN REGISTRERE "BOR I NORGE" NÅR MAN HAR TRYKKET "SAMME SOM MEDFORELDER"
 
   return (
     <>

--- a/src/utils/søknad.ts
+++ b/src/utils/søknad.ts
@@ -173,6 +173,10 @@ const medforelderMedLabel = (medforelder: any, intl: IntlShape) => {
       label: hentTekst('barnasbosted.medforelder.navn', intl),
       verdi: medforelder.verdi.navn,
     },
+    ident: {
+      label: hentTekst('barnasbosted.medforelder.navn', intl),
+      verdi: medforelder.verdi.ident,
+    },
     alder: {
       label: hentTekst('barnasbosted.medforelder.alder', intl),
       verdi: medforelder.verdi.alder,
@@ -180,6 +184,7 @@ const medforelderMedLabel = (medforelder: any, intl: IntlShape) => {
     død: medforelder.død,
     harAdressesperre: medforelder.harAdressesperre,
     id: hentUid(),
+    fraFolkeregister: true,
   };
 };
 

--- a/src/utils/søknad.ts
+++ b/src/utils/søknad.ts
@@ -185,7 +185,6 @@ const medforelderMedLabel = (medforelder: any, intl: IntlShape) => {
 
 export const oppdaterBarnMedLabel = (barneliste: IBarn[], intl: IntlShape) =>
   barneliste.map((barn: any) => {
-    console.log('BARN', barn);
     const barnMedLabel = settBarnMedLabelOgVerdi(barn);
     barnMedLabel['ident'] = barnMedLabel['fnr'];
     delete barnMedLabel.fnr;

--- a/src/utils/søknad.ts
+++ b/src/utils/søknad.ts
@@ -12,6 +12,7 @@ import {
   standardLabelsBarn,
 } from '../helpers/labels';
 import { IBarn } from '../models/steg/barn';
+import { useIntl } from 'react-intl';
 
 export const hentPersonData = () => {
   return axios
@@ -166,10 +167,35 @@ export const unikeDokumentasjonsbehov = (
   return alle.findIndex((item) => item.id === behov.id) === index;
 };
 
-export const oppdaterBarnMedLabel = (barneliste: IBarn[]) =>
+const medforelderMedLabel = (medforelder: any, intl: IntlShape) => {
+  return {
+    navn: {
+      label: hentTekst('barnasbosted.medforelder.navn', intl),
+      verdi: medforelder.verdi.navn,
+    },
+    alder: {
+      label: hentTekst('barnasbosted.medforelder.alder', intl),
+      verdi: medforelder.verdi.alder,
+    },
+    død: medforelder.død,
+    harAdressesperre: medforelder.harAdressesperre,
+    id: hentUid(),
+  };
+};
+
+export const oppdaterBarnMedLabel = (barneliste: IBarn[], intl: IntlShape) =>
   barneliste.map((barn: any) => {
+    console.log('BARN', barn);
     const barnMedLabel = settBarnMedLabelOgVerdi(barn);
     barnMedLabel['ident'] = barnMedLabel['fnr'];
     delete barnMedLabel.fnr;
+
+    if (barnMedLabel.medforelder) {
+      barnMedLabel['forelder'] = medforelderMedLabel(
+        barnMedLabel.medforelder,
+        intl
+      );
+    }
+
     return barnMedLabel;
   });


### PR DESCRIPTION
Løser denne Favro-oppgaven: [Får ikke lenger opp knapper for å velge at et barn har samme forelder som et barn som kommer fra folkeregister](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-5762).

Knappene for å indikere at et barn har samme forelder som et allerede eksisterende barn forsvant for barn/foreldre-par som kom fra folkeregister. Dette skjedde etter at vi fjernet muligheten til å svare på spørsmål om disse foreldrene, da "medforelder"-objektet ikke lenger ble kopiert over til "forelder", og det er "forelder"-objektet som brukes for å sjekke om man skal få opp disse knappene.

Løser problemet ved å flytte kopieringen av medforelder til forelder til den initielle hentingen av barna.