### PR TITLE
Foreløpig fiks

### DIFF
--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -15,7 +15,7 @@ export const erAlleForeldreUtfylt = (foreldre: IForelder[]) =>
   foreldre.every((forelder) => erForelderUtfylt(forelder));
 
 export const erForelderUtfylt = (forelder: IForelder): boolean | undefined => {
-  const { borINorge, land, avtaleOmDeltBosted, fraFolkeregister } = forelder;
+  const { borINorge, land, avtaleOmDeltBosted } = forelder;
   const utfyltBorINorge =
     borINorge?.verdi || (borINorge?.verdi === false && land?.verdi !== '');
 

--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -21,10 +21,10 @@ export const erForelderUtfylt = (forelder: IForelder): boolean | undefined => {
 
   const utfyltAvtaleDeltBosted = harValgtSvar(avtaleOmDeltBosted?.verdi);
   const forelderInfoOgSpørsmålBesvart: boolean | undefined =
-    (utfyltBorINorge || fraFolkeregister) &&
+    utfyltBorINorge &&
     utfyltAvtaleDeltBosted &&
     utfyltNødvendigeSamværSpørsmål(forelder) &&
-    (utfyltNødvendigBostedSpørsmål(forelder) || fraFolkeregister);
+    utfyltNødvendigBostedSpørsmål(forelder);
 
   const kanIkkeOppgiAnnenForelderRuteUtfylt = utfyltNødvendigSpørsmålUtenOppgiAnnenForelder(
     forelder


### PR DESCRIPTION
Denne fikser feilen som gjør at man kan sende inn med manglende felter, men etterlater en mindre alvorlig bug (brukeren får flere "Annen forelder"-knapper enn nødvendig i tilfeller der flere barn har samme forelder).