### PR TITLE
Strengere sjekk for fødselsdatofelt - riktig format eller tom for opt…

### DIFF
--- a/src/utils/person.ts
+++ b/src/utils/person.ts
@@ -17,8 +17,22 @@ export const harFyltUtSamboerDetaljer = (
 
   return valgfriIdentEllerFødselsdato
     ? samboerDetaljer?.navn?.verdi !== '' &&
-        samboerDetaljer?.navn?.verdi !== undefined
+        samboerDetaljer?.navn?.verdi !== undefined &&
+        erFødselsdatoUtfyltOgGyldigEllerTomtFelt(
+          samboerDetaljer.fødselsdato?.verdi,
+          DatoBegrensning.TidligereDatoer
+        )
     : harFyltUtFødselsdatoEllerIdent &&
         samboerDetaljer?.navn?.verdi !== '' &&
         samboerDetaljer?.navn?.verdi !== undefined;
+};
+
+export const erFødselsdatoUtfyltOgGyldigEllerTomtFelt = (
+  dato: string | undefined,
+  begrensning: DatoBegrensning
+) => {
+  return (
+    (dato && erDatoGyldigOgInnaforBegrensninger(dato, begrensning)) ||
+    dato === ''
+  );
 };


### PR DESCRIPTION
**Bug**:
- Hvis fødselsdato er optional, så kommer bruker seg gjennom med kun årstall. 
- Mangler validering for akkurat dette. 

**Løsning:**
- Legger til en ekstra sjekk for samboer info og fødselsdato (der fødselsdato er optional)
- Gjenbruker tidligere funksjon som sjekker om dato er i riktig format. 
- Lar bruker gå videre kun hvis de har fødselsdato i riktig format eller har latt feltet stå helt tomt (hvis datoen er optional)

**Relatert til denne:** 
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-5617
