### PR TITLE
My og Tor fikser bugs - søktSeparasjon datovelger årstall

### DIFF
--- a/src/helpers/steg/omdeg.ts
+++ b/src/helpers/steg/omdeg.ts
@@ -122,7 +122,11 @@ export const erStegFerdigUtfylt = (
   sivilstatus: ISivilstatus,
   medlemskap: IMedlemskap
 ): boolean => {
-  const { harSøktSeparasjon, datoFlyttetFraHverandre } = sivilstatus;
+  const {
+    harSøktSeparasjon,
+    datoSøktSeparasjon,
+    datoFlyttetFraHverandre,
+  } = sivilstatus;
 
   const datoFlyttetfraHverandreErUtfyltOgGyldig =
     datoFlyttetFraHverandre?.verdi &&
@@ -131,8 +135,16 @@ export const erStegFerdigUtfylt = (
       DatoBegrensning.TidligereDatoer
     );
 
+  const datoSøktSeparasjonerUtfyltOgGyldig =
+    datoSøktSeparasjon?.verdi &&
+    erDatoGyldigOgInnaforBegrensninger(
+      datoSøktSeparasjon?.verdi,
+      DatoBegrensning.TidligereDatoer
+    );
+
   return ((harSøkerTlfnr(person) &&
     harSøktSeparasjon?.verdi &&
+    datoSøktSeparasjonerUtfyltOgGyldig &&
     datoFlyttetfraHverandreErUtfyltOgGyldig) ||
     harSøktSeparasjon?.verdi === false ||
     erSøknadsBegrunnelseBesvart(sivilstatus)) &&

--- a/src/mock/mockPersonUtenBarn.json
+++ b/src/mock/mockPersonUtenBarn.json
@@ -12,7 +12,7 @@
     "innvandretDato": "1991-12-28",
     "utvandretDato": "",
     "oppholdstillatelse": "",
-    "sivilstand": "UGIF",
+    "sivilstand": "GIFT",
     "språk": "NB",
     "statsborgerskap": "NOR",
     "privattelefon": "",


### PR DESCRIPTION
Fikser en bug der man kan gå videre i søknadsdialogen på steg 1 dersom man er gift og skriver inn et årstall under "datoSøktSeparasjon".