### PR TITLE
Ikke vis "Lagt til"-barn før man har svart på spørsmål om forelder

### DIFF
--- a/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
+++ b/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
@@ -26,10 +26,8 @@ const AnnenForelderKnapper: React.FC<Props> = ({
 }) => {
   const intl = useIntl();
 
-  const [
-    andreForelderRadioVerdi,
-    settAndreForelderRadioVerdi,
-  ] = useState<string>('');
+  const [andreForelderRadioVerdi, settAndreForelderRadioVerdi] =
+    useState<string>('');
 
   const leggTilSammeForelder = (
     e: SyntheticEvent<EventTarget, Event>,
@@ -83,7 +81,11 @@ const AnnenForelderKnapper: React.FC<Props> = ({
     <KomponentGruppe>
       <div className="andre-forelder-valg">
         {førsteBarnTilHverForelder.map((b) => {
-          if (!b) return null;
+          if (
+            !b.forelder?.borINorge &&
+            !b.forelder?.kanIkkeOppgiAnnenForelderFar
+          )
+            return null;
 
           return (
             <RadioPanel

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedLagtTil.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedLagtTil.tsx
@@ -32,7 +32,8 @@ const BarnetsBostedLagtTil: React.FC<Props> = ({
     barn.navn && barn.navn.verdi !== ''
       ? barn.navn.verdi
       : hentTekst('barnet.storForBokstav', intl);
-  if (!forelder) return null;
+
+  if (!forelder || !barn.forelder?.borINorge) return null;
 
   const endreInformasjon = () => {
     settAktivIndex(index);

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedLagtTil.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedLagtTil.tsx
@@ -33,7 +33,11 @@ const BarnetsBostedLagtTil: React.FC<Props> = ({
       ? barn.navn.verdi
       : hentTekst('barnet.storForBokstav', intl);
 
-  if (!forelder || !barn.forelder?.borINorge) return null;
+  if (
+    !forelder ||
+    (!barn.forelder?.borINorge && !barn.forelder?.kanIkkeOppgiAnnenForelderFar)
+  )
+    return null;
 
   const endreInformasjon = () => {
     settAktivIndex(index);


### PR DESCRIPTION
Løser [denne](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-6154) oppgaven. Man fikk muligheten til å klikke "Endre informasjon" på det neste barnet før man hadde fylt ut nåværende. Denne feilen oppsto etter at vi gjorde en endring på barnekortene slik at vi fyller ut forelder-objektet med en gang, og kan derfor ikke lenger sjekke om forelder er fylt ut ved å bare sjekke om forelder ikke er null.

Løses ved at man bare viser kortet om også det obligatoriske spørsmålet "Bor Xs andre forelder i Norge" er besvart.