### PR TITLE
Fjern oppdatering av state fra validering

### DIFF
--- a/src/søknad/steg/2-bosituasjon/OmSamboerenDin.tsx
+++ b/src/søknad/steg/2-bosituasjon/OmSamboerenDin.tsx
@@ -86,14 +86,6 @@ const OmSamboerenDin: FC<Props> = ({
 
   const hvisGyldigIdentSettIdentISamboerDetaljer = (erGyldig: boolean) => {
     settGyldigIdent(erGyldig);
-    erGyldig &&
-      settSamboerInfo({
-        ...samboerInfo,
-        [EPersonDetaljer.ident]: {
-          label: hentTekst('person.ident', intl),
-          verdi: ident,
-        },
-      });
   };
 
   const oppdaterIdent = (e: React.FormEvent<HTMLInputElement>) => {

--- a/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
+++ b/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
@@ -56,11 +56,6 @@ const OmAndreForelder: React.FC<Props> = ({
 
   const hvisGyldigIdentSettIdent = (erGyldig: boolean) => {
     settGyldigIdent(erGyldig);
-    erGyldig &&
-      settForelder({
-        ...forelder,
-        ident: { label: hentTekst('person.ident', intl), verdi: identFelt },
-      });
   };
 
   const oppdaterIdent = (e: React.FormEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Siden identen ikke er oppdatert i valideringsfunksjonen, gjorde dette at feil fødselsnummer ble satt. Løser [denne oppgaven](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-5866).