### PR TITLE
Dersom annen forelder har adressebeskyttelse blir feilmeldingen litt …

### DIFF
--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -369,7 +369,7 @@ export default {
   'barnasbosted.kanGåVidere':
     'We have all the information we need. Please proceed with the next step.',
   'barnasbosted.feilmelding.adressebeskyttelse':
-    'One or several of your children are registered with address protection and applying electronically is therefore not available. You have to use this <a href="https://www.nav.no/soknader/nb/person/familie/enslig-mor-eller-far/NAV%2015-00.01/brev">application</a> to apply.',
+    'One or several of your children, or other parent, are registered with address protection and applying electronically is therefore not available. You have to use this <a href="https://www.nav.no/soknader/nb/person/familie/enslig-mor-eller-far/NAV%2015-00.01/brev">application</a> to apply.',
   'barnasbosted.oppsummering.navn.label': 'Name of the other parent',
   'barnasbosted.medforelder.navn': 'Navn',
   'barnasbosted.medforelder.alder': 'Alder',

--- a/src/language/tekster_nb.ts
+++ b/src/language/tekster_nb.ts
@@ -358,7 +358,7 @@ export default {
   'barnasbosted.kanGåVidere':
     'Vi har opplysningene vi trenger. Du kan gå videre til neste steg.',
   'barnasbosted.feilmelding.adressebeskyttelse':
-    'Et eller flere av barna dine er registrert med adressebeskyttelse og digital søknad er ikke tilgjengelig. Du må bruke dette <a href="https://www.nav.no/soknader/nb/person/familie/enslig-mor-eller-far/NAV%2015-00.01/brev">skjemaet</a> for å søke.',
+    'Et eller flere av barna dine, eller annen forelder, er registrert med adressebeskyttelse og digital søknad er ikke tilgjengelig. Du må bruke dette <a href="https://www.nav.no/soknader/nb/person/familie/enslig-mor-eller-far/NAV%2015-00.01/brev">skjemaet</a> for å søke.',
   'barnasbosted.oppsummering.navn.label': 'Navn på annen forelder',
   'barnasbosted.medforelder.navn': 'Navn',
   'barnasbosted.medforelder.alder': 'Alder',


### PR DESCRIPTION
…rar. Legger derfor til "annen forelder har adressebeskyttelse" som mulig grunn for at søker ikke kan sende inn digital søknad.

Løser: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-6037


Har også oppdatert: https://navno.sharepoint.com/:x:/s/TeamFamilie426/EQuWOrev2kBBksUp23G-59YBgsZ6gyHMwDSy0Zi4DC_1Cg?e=21vAGl