### PR TITLE
Rydding i toggles:

### DIFF
--- a/src/arbeidssøkerskjema/Forside.tsx
+++ b/src/arbeidssøkerskjema/Forside.tsx
@@ -22,8 +22,6 @@ import { useForsideInnhold } from '../utils/hooks';
 import { ForsideType } from '../models/søknad/stønadstyper';
 import { hentPath } from '../utils/routing';
 import Språkvelger from '../components/språkvelger/Språkvelger';
-import { ToggleName } from '../models/søknad/toggles';
-import { useToggles } from '../context/TogglesContext';
 import { logSidevisningArbeidssokerskjema } from '../utils/amplitude';
 import { useMount } from '../utils/hooks';
 
@@ -32,7 +30,6 @@ const BlockContent = require('@sanity/block-content-to-react');
 const Forside: React.FC<any> = ({ visningsnavn, intl }) => {
   const [locale] = useSpråkContext();
   const navigate = useNavigate();
-  const { toggles } = useToggles();
 
   const { skjema, settSkjema } = useSkjema();
 
@@ -58,7 +55,7 @@ const Forside: React.FC<any> = ({ visningsnavn, intl }) => {
       return React.createElement(
         style,
         { className: `heading-${level}` },
-        props.children
+        props.children,
       );
     }
 
@@ -81,41 +78,39 @@ const Forside: React.FC<any> = ({ visningsnavn, intl }) => {
             <VeilederSnakkeboble
               tekst={hentBeskjedMedNavn(
                 visningsnavn,
-                intl.formatMessage({ id: 'skjema.hei' })
+                intl.formatMessage({ id: 'skjema.hei' }),
               )}
             />
           </div>
-          {toggles[ToggleName.vis_språkvelger] && (
-            <FeltGruppe>
-              <Språkvelger />
-            </FeltGruppe>
-          )}
+          <FeltGruppe>
+            <Språkvelger/>
+          </FeltGruppe>
           <Sidetittel>
-            <LocaleTekst tekst={'skjema.sidetittel'} />
+            <LocaleTekst tekst={'skjema.sidetittel'}/>
           </Sidetittel>
           {seksjon &&
-            seksjon.map((blokk: any, index: number) => {
-              return blokk._type === 'dokumentasjonskrav' ? (
-                <div className="seksjon" key={index}>
-                  <Ekspanderbartpanel tittel={blokk.tittel}>
-                    <BlockContent
-                      className="typo-normal"
-                      blocks={blokk.innhold}
-                      serializers={{ types: { block: BlockRenderer } }}
-                    />
-                  </Ekspanderbartpanel>
-                </div>
-              ) : (
-                <div className="seksjon" key={index}>
-                  {blokk.tittel && <Element>{blokk.tittel}</Element>}
+          seksjon.map((blokk: any, index: number) => {
+            return blokk._type === 'dokumentasjonskrav' ? (
+              <div className="seksjon" key={index}>
+                <Ekspanderbartpanel tittel={blokk.tittel}>
                   <BlockContent
                     className="typo-normal"
                     blocks={blokk.innhold}
                     serializers={{ types: { block: BlockRenderer } }}
                   />
-                </div>
-              );
-            })}
+                </Ekspanderbartpanel>
+              </div>
+            ) : (
+              <div className="seksjon" key={index}>
+                {blokk.tittel && <Element>{blokk.tittel}</Element>}
+                <BlockContent
+                  className="typo-normal"
+                  blocks={blokk.innhold}
+                  serializers={{ types: { block: BlockRenderer } }}
+                />
+              </div>
+            );
+          })}
 
           {disclaimer && (
             <div className="seksjon">
@@ -131,7 +126,7 @@ const Forside: React.FC<any> = ({ visningsnavn, intl }) => {
                   checked={skjema.harBekreftet}
                   label={hentBeskjedMedNavn(
                     visningsnavn,
-                    intl.formatMessage({ id: 'side.bekreftelse' })
+                    intl.formatMessage({ id: 'side.bekreftelse' }),
                   )}
                 />
               </AlertStripeAdvarsel>
@@ -145,13 +140,13 @@ const Forside: React.FC<any> = ({ visningsnavn, intl }) => {
                   navigate({
                     pathname: hentPath(
                       RoutesArbeidssokerskjema,
-                      ERouteArbeidssøkerskjema.Spørsmål
+                      ERouteArbeidssøkerskjema.Spørsmål,
                     ),
                   })
                 }
                 type={'hoved'}
               >
-                <LocaleTekst tekst={'skjema.knapp.start'} />
+                <LocaleTekst tekst={'skjema.knapp.start'}/>
               </KnappBase>
             </FeltGruppe>
           ) : null}

--- a/src/mock/mockToggles.json
+++ b/src/mock/mockToggles.json
@@ -1,5 +1,3 @@
 {
-  "familie.ef.soknad.feilsituasjon": false,
-  "familie.ef.soknad.sprakvelger": true,
-  "familie.ef.soknad.visSkalBehandlesINySaksbehandling": true
+  "familie.ef.soknad.feilsituasjon": false
 }

--- a/src/models/søknad/toggles.ts
+++ b/src/models/søknad/toggles.ts
@@ -4,6 +4,4 @@ export interface Toggles {
 
 export enum ToggleName {
   feilsituasjon = 'familie.ef.soknad.feilsituasjon',
-  vis_språkvelger = 'familie.ef.soknad.sprakvelger',
-  visSkalBehandlesINySaksbehandling = "familie.ef.soknad.visSkalBehandlesINySaksbehandling"
 }

--- a/src/søknad/forside/Forsideinformasjon.tsx
+++ b/src/søknad/forside/Forsideinformasjon.tsx
@@ -12,8 +12,6 @@ import { hentTekst } from '../../utils/søknad';
 import { isIE } from 'react-device-detect';
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
 import Språkvelger from '../../components/språkvelger/Språkvelger';
-import { useToggles } from '../../context/TogglesContext';
-import { ToggleName } from '../../models/søknad/toggles';
 import { useSpråkContext } from '../../context/SpråkContext';
 import { useNavigate } from 'react-router-dom';
 
@@ -40,7 +38,6 @@ const Forsideinformasjon: React.FC<InnholdProps> = ({
 }) => {
   const navigate = useNavigate();
   const [locale] = useSpråkContext();
-  const { toggles } = useToggles();
 
   const BlockRenderer = (props: any) => {
     const { style = 'normal' } = props.node;
@@ -78,11 +75,9 @@ const Forsideinformasjon: React.FC<InnholdProps> = ({
 
   return (
     <>
-      {toggles[ToggleName.vis_språkvelger] && (
-        <FeltGruppe>
-          <Språkvelger />
-        </FeltGruppe>
-      )}
+      <FeltGruppe>
+        <Språkvelger/>
+      </FeltGruppe>
       {locale === 'en' && (
         <AlertStripeAdvarsel>
           We are in the process of translating this application. The few missing


### PR DESCRIPTION
 Fjern toggle som ikke er i bruk:
visSkalBehandlesINySaksbehandling = "familie.ef.soknad.visSkalBehandlesINySaksbehandling"
Fjern toggle som har vært skrudd på i prod lenge:
vis_språkvelger = 'familie.ef.soknad.sprakvelger'