### PR TITLE
Fjern svar på neste spørsmål dersom svar på 'Hvor mye jobber du?' fjernes

### DIFF
--- a/src/søknad/steg/5-aktivitet/arbeidsforhold/Arbeidsgiver.tsx
+++ b/src/søknad/steg/5-aktivitet/arbeidsforhold/Arbeidsgiver.tsx
@@ -102,6 +102,10 @@ const Arbeidsgiver: React.FC<Props> = ({
     nøkkel: EArbeidsgiver,
     label: string
   ) => {
+    if (!e.currentTarget.value) {
+      delete arbeidsgiver.ansettelsesforhold;
+    }
+
     arbeidsgiver &&
       settArbeidsgiver({
         ...arbeidsgiver,


### PR DESCRIPTION
Dette gjør at man ikke kommer videre i søknaden dersom man har fjerna svar på "Hvor mye jobber du?" etter at man har svart på spørsmålet om ansettelsesforhold. [Favro-oppgave](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-2777).