### PR TITLE
Slett Fnr-state dersom den blir ugyldig

### DIFF
--- a/src/models/søknad/toggles.ts
+++ b/src/models/søknad/toggles.ts
@@ -4,4 +4,5 @@ export interface Toggles {
 
 export enum ToggleName {
   feilsituasjon = 'familie.ef.soknad.feilsituasjon',
+  slettFnrState = 'familie.ef.soknad.slett-ugyldig-fnr-fra-state',
 }

--- a/src/søknad/steg/1-omdeg/sivilstatus/begrunnelse/SøknadsBegrunnelse.tsx
+++ b/src/søknad/steg/1-omdeg/sivilstatus/begrunnelse/SøknadsBegrunnelse.tsx
@@ -115,6 +115,10 @@ const Søknadsbegrunnelse: FC<Props> = ({
           verdi: ident,
         },
       });
+
+    if (!erGyldig) {
+      delete samboerInfo.ident;
+    }
   };
 
   const settChecked = (checked: boolean) => {

--- a/src/søknad/steg/1-omdeg/sivilstatus/begrunnelse/SøknadsBegrunnelse.tsx
+++ b/src/søknad/steg/1-omdeg/sivilstatus/begrunnelse/SøknadsBegrunnelse.tsx
@@ -25,8 +25,10 @@ import {
   EPersonDetaljer,
   IPersonDetaljer,
 } from '../../../../../models/søknad/person';
+import { useToggles } from '../../../../../context/TogglesContext';
 import LocaleTekst from '../../../../../language/LocaleTekst';
 import { harFyltUtSamboerDetaljer } from '../../../../../utils/person';
+import { ToggleName } from '../../../../../models/søknad/toggles';
 
 interface Props {
   sivilstatus: ISivilstatus;
@@ -47,6 +49,7 @@ const Søknadsbegrunnelse: FC<Props> = ({
 }) => {
   const intl = useIntl();
   const spørsmål: ISpørsmål = BegrunnelseSpørsmål(intl);
+  const { toggles } = useToggles();
 
   const {
     årsakEnslig,
@@ -116,7 +119,7 @@ const Søknadsbegrunnelse: FC<Props> = ({
         },
       });
 
-    if (!erGyldig) {
+    if (toggles[ToggleName.slettFnrState] && !erGyldig) {
       delete samboerInfo.ident;
     }
   };

--- a/src/søknad/steg/2-bosituasjon/OmSamboerenDin.tsx
+++ b/src/søknad/steg/2-bosituasjon/OmSamboerenDin.tsx
@@ -12,6 +12,8 @@ import {
   EPersonDetaljer,
   IPersonDetaljer,
 } from '../../../models/søknad/person';
+import { ToggleName } from '../../../models/søknad/toggles';
+import { useToggles } from '../../../context/TogglesContext';
 
 interface Props {
   tittel: string;
@@ -32,6 +34,7 @@ const OmSamboerenDin: FC<Props> = ({
 }) => {
   const intl = useIntl();
   const samboerDetaljer = bosituasjon[samboerDetaljerType];
+  const { toggles } = useToggles();
   const [samboerInfo, settSamboerInfo] = useState<IPersonDetaljer>(
     samboerDetaljer ? samboerDetaljer : { kjennerIkkeIdent: false }
   );
@@ -52,7 +55,7 @@ const OmSamboerenDin: FC<Props> = ({
         },
       });
 
-    if (!erGyldigIdent) {
+    if (toggles[ToggleName.slettFnrState] && !erGyldigIdent) {
       let nySamboerInfo = { ...samboerInfo };
       delete nySamboerInfo.ident;
 

--- a/src/søknad/steg/2-bosituasjon/OmSamboerenDin.tsx
+++ b/src/søknad/steg/2-bosituasjon/OmSamboerenDin.tsx
@@ -51,6 +51,14 @@ const OmSamboerenDin: FC<Props> = ({
           verdi: ident,
         },
       });
+
+    if (!erGyldigIdent) {
+      let nySamboerInfo = { ...samboerInfo };
+      delete nySamboerInfo.ident;
+
+      settSamboerInfo(nySamboerInfo);
+    }
+
     // eslint-disable-next-line
   }, [erGyldigIdent, ident]);
 

--- a/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
+++ b/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
@@ -51,6 +51,15 @@ const OmAndreForelder: React.FC<Props> = ({
         ...forelder,
         ident: { label: hentTekst('person.ident', intl), verdi: identFelt },
       });
+
+    if (!erGyldigIdent) {
+      const nyForelder = { ...forelder };
+
+      delete nyForelder.ident;
+
+      settForelder(nyForelder);
+    }
+
     // eslint-disable-next-line
   }, [erGyldigIdent, identFelt]);
 

--- a/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
+++ b/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
@@ -13,6 +13,8 @@ import { hentUid } from '../../../utils/autentiseringogvalidering/uuid';
 import { useIntl } from 'react-intl';
 import IdentEllerFødselsdatoGruppe from '../../../components/gruppe/IdentEllerFødselsdatoGruppe';
 import { Feilmelding } from 'nav-frontend-typografi';
+import { useToggles } from '../../../context/TogglesContext';
+import { ToggleName } from '../../../models/søknad/toggles';
 
 interface Props {
   settForelder: (verdi: IForelder) => void;
@@ -44,6 +46,7 @@ const OmAndreForelder: React.FC<Props> = ({
   const [identFelt, settIdentFelt] = useState<string>(
     ident?.verdi ? ident.verdi : ''
   );
+  const { toggles } = useToggles();
 
   useEffect(() => {
     erGyldigIdent &&
@@ -52,7 +55,7 @@ const OmAndreForelder: React.FC<Props> = ({
         ident: { label: hentTekst('person.ident', intl), verdi: identFelt },
       });
 
-    if (!erGyldigIdent) {
+    if (toggles[ToggleName.slettFnrState] && !erGyldigIdent) {
       const nyForelder = { ...forelder };
 
       delete nyForelder.ident;


### PR DESCRIPTION
Sletter ident dersom den blir ugyldig etter å ha vært gyldig. Se disse Favro-oppgavene: [Skriv om Fnr/navn-komponenten](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8010) og [Samboerdetaljer - Validering feiler hvis man går tilbake og sletter Fnr/ident slik at det sendes som null til backend](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-3281).