### PR TITLE
Bare nullstill medlemskap når ident til tidligere samboer er ugyldig og man har valgt samlivsbrudd med noen andre.

### DIFF
--- a/src/søknad/steg/1-omdeg/sivilstatus/begrunnelse/SøknadsBegrunnelse.tsx
+++ b/src/søknad/steg/1-omdeg/sivilstatus/begrunnelse/SøknadsBegrunnelse.tsx
@@ -94,7 +94,11 @@ const Søknadsbegrunnelse: FC<Props> = ({
         },
       });
 
-    if (toggles[ToggleName.slettFnrState] && !erGyldigIdent) {
+    if (
+      toggles[ToggleName.slettFnrState] &&
+      !erGyldigIdent &&
+      samlivsbruddAndre
+    ) {
       const nySamboerInfo = { ...samboerInfo };
       const nySivilstatus = { ...sivilstatus };
       delete nySamboerInfo.ident;


### PR DESCRIPTION
Dersom noe annet er valgt så vil ident aldri være gyldig, og da nullstiller man medlemskap når det ikke trengs.