### PR TITLE
Fiks sjekk av tomt objekt

### DIFF
--- a/src/components/dato/ÅrMånedvelger.tsx
+++ b/src/components/dato/ÅrMånedvelger.tsx
@@ -109,7 +109,7 @@ const ÅrMånedVelger: React.FC<Props> = ({
             disabled={disabled}
           />
           {datobegrensning === DatoBegrensning.AlleDatoer &&
-          begrensninger === {} ? (
+          Object.entries(begrensninger).length === 0 ? (
             <DatePicker
               name="dateInput"
               ariaLabelledBy={'Datepicker - format (MM.yyyy)'}


### PR DESCRIPTION
Denne sjekken har alltid blitt false før, da objektene aldri vil være de samme (siden javascript sammenligner objektet ved referanse og ikke verdi). Dette har likevel gått bra til nå, siden 'begrensninger'-objektet aldri har vært tomt til nå.

Det var den nye versjonen av [TypeScript som fanget dette opp](https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/).