### PR TITLE
Egen environment-config for mock og api

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ Frontend - søknad for enslig forsørger.
 
 1. `npm install`
 2. `npm start`
-3. `node mock/mock-server.js` 
+
+* Hvis man ønsker å kjøre med mock-api
+1. Endre `REACT_APP_BRUK_API_I_DEV=false` i `.env`
+2.`node mock/mock-server.js` 
 
 Kjør uten redirect til autentisering lokalt: 
 sett .env variabel: 

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -1,3 +1,5 @@
+import { erLokaltMedMock } from './utils/miljø';
+
 interface EnvironmentProps {
   veiviserUrl: string;
   apiUrl: string;
@@ -41,13 +43,23 @@ const Environment = (): EnvironmentProps => {
       miljø: 'production',
       modellVersjon: modellVersjon,
     };
-  } else {
+  } else if (erLokaltMedMock()) {
     return {
       veiviserUrl: '',
       apiUrl: '',
       loginService: `http://localhost:8091/local/cookie?subject=21057822284&issuerId=selvbetjening&audience=aud-localhost`, // forventet i api ved innsending (local) - syntetisk fnr
       dokumentUrl: `/api/dokument`,
       mellomlagerUrl: `/api/mellomlager/`,
+      miljø: 'local',
+      modellVersjon: modellVersjon,
+    };
+  } else {
+    return {
+      veiviserUrl: '',
+      apiUrl: 'http://localhost:8091',
+      loginService: `http://localhost:8091/local/cookie?subject=21057822284&issuerId=selvbetjening&audience=aud-localhost`, // forventet i api ved innsending (local) - syntetisk fnr
+      dokumentUrl: `http://localhost:8082/api/mapper/ANYTTHING`,
+      mellomlagerUrl: `http://localhost:8082/api/soknad/`,
       miljø: 'local',
       modellVersjon: modellVersjon,
     };


### PR DESCRIPTION
Stoppet mulighet for å bruke soknad-api og familie-dokument i https://github.com/navikt/familie-ef-soknad/pull/1007