### PR TITLE
Ikke vis ident fra folkeregister når vi viser fram annen forelder/med…

### DIFF
--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedLagtTil.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedLagtTil.tsx
@@ -86,7 +86,7 @@ const BarnetsBostedLagtTil: React.FC<Props> = ({
             </BodyShort>
           </div>
         )}
-        {forelder.ident && (
+        {!forelder.fraFolkeregister && forelder.ident && (
           <div className="spørsmål-og-svar">
             <Label>{intl.formatMessage({ id: 'person.ident.visning' })}</Label>
             <BodyShort>{forelder.ident.verdi}</BodyShort>

--- a/src/søknad/steg/7-oppsummering/OppsummeringBarnasBosituasjon.tsx
+++ b/src/søknad/steg/7-oppsummering/OppsummeringBarnasBosituasjon.tsx
@@ -30,12 +30,15 @@ const OppsummeringBarnasBosituasjon: FC<Props> = ({
     .map((barn) => {
       if (!barn.forelder) return null;
 
+      const visningsIdent = barn.forelder.fraFolkeregister ? undefined : barn.forelder.ident
+
       let nyForelder = {
         ...barn.forelder,
         navn: {
           label: hentTekst('barnasbosted.oppsummering.navn.label', intl),
           verdi: barn.forelder?.navn?.verdi,
         },
+        ident: visningsIdent
       };
 
       delete nyForelder.hvorforIkkeOppgi;


### PR DESCRIPTION
Ikke vis ident fra folkeregister når vi viser fram annen forelder/medforelder på barnekort og i oppsummering. Skal kun vise fram identer bruker har skrevet inn. 

Tar gjerne en prat om måter å løse dette på - skille mellom immutable register-ident(fra pdl) og registrerte identer osv. 
Ikke lett å navigere i barnekortkoden slik det er nå. 
