### PR TITLE
Fjernet BlockContent i favør for PortableText for sanity-tekster då B…

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -63,7 +63,19 @@ module.exports = {
       },
     ],
   },
-  webpack: {},
+  webpack: {
+    configure: {
+      module: {
+        rules: [
+          {
+            type: 'javascript/auto',
+            test: /\.mjs$/,
+            use: [],
+          },
+        ],
+      },
+    },
+  },
   eslint: {
     enable: true,
     mode: 'extends',

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@navikt/ds-icons": "^1.3.21",
         "@navikt/ds-react": "^1.3.21",
         "@navikt/fnrvalidator": "^1.3.3",
-        "@sanity/block-content-to-react": "^3.0.0",
+        "@portabletext/react": "^1.0.6",
         "@sanity/client": "^3.4.1",
         "@sentry/browser": "^7.15.0",
         "@types/amplitude-js": "^8.16.2",
@@ -3535,6 +3535,34 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@portabletext/react": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@portabletext/react/-/react-1.0.6.tgz",
+      "integrity": "sha512-j6BprLiwFz3zr1Lo6BxM2sQ1b3g1JIjGwePeuxqSfbBiEYbGXn2izEckMJ02hSa1f7+RCEUJ+Bojvtzz6BBUaw==",
+      "dependencies": {
+        "@portabletext/toolkit": "^1.0.5",
+        "@portabletext/types": "^1.0.3"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18"
+      }
+    },
+    "node_modules/@portabletext/toolkit": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@portabletext/toolkit/-/toolkit-1.0.6.tgz",
+      "integrity": "sha512-u48kRSOyxbOmy0J//bLg1odTcL5dvPDmobSbiTgR11J/k9eIKCdWRiJtddpEyId/aWGP2bkX4ol2RMPCmAPCIg==",
+      "dependencies": {
+        "@portabletext/types": "^1.0.3"
+      }
+    },
+    "node_modules/@portabletext/types": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@portabletext/types/-/types-1.0.3.tgz",
+      "integrity": "sha512-SDDsdury2SaTI2D5Ea6o+Y39SSZMYHRMWJHxkxYl3yzFP0n/0EknOhoXcoaV+bxGr2dTTqZi2TOEj+uWYuavSw==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
@@ -3830,29 +3858,6 @@
         }
       }
     },
-    "node_modules/@sanity/block-content-to-hyperscript": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sanity/block-content-to-hyperscript/-/block-content-to-hyperscript-3.0.0.tgz",
-      "integrity": "sha512-uoXWLdFY5LqO8A9sFJqnZWWDCBC+0r3Egeh0bwKQ2EK2Vil5L40iJGNXMZhDB8BnvH+6B4155SU8Q3vY59T6pA==",
-      "dependencies": {
-        "@sanity/generate-help-url": "^0.140.0",
-        "@sanity/image-url": "^0.140.15",
-        "hyperscript": "^2.0.2",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/@sanity/block-content-to-react": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sanity/block-content-to-react/-/block-content-to-react-3.0.0.tgz",
-      "integrity": "sha512-oHPLlIsulsnL3ITs93RIvUPBI6nAeoSFOUf16vX4T7z4wWywxP39N1DF9mAx2tV6Kjr1fJAx5GF7zfiMXYLaqA==",
-      "dependencies": {
-        "@sanity/block-content-to-hyperscript": "^3.0.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=15.0.0"
-      }
-    },
     "node_modules/@sanity/client": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@sanity/client/-/client-3.4.1.tgz",
@@ -3875,19 +3880,6 @@
       "dependencies": {
         "event-source-polyfill": "1.0.25",
         "eventsource": "^2.0.2"
-      }
-    },
-    "node_modules/@sanity/generate-help-url": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-0.140.0.tgz",
-      "integrity": "sha512-H/G/WA9S22TXcXST52CIiTsHx3S2hH0gvK7LnI5w76vfKS0obnDPh8jrPg4xeNRYGPuV9MHYRlyERGpRGoo4Qw=="
-    },
-    "node_modules/@sanity/image-url": {
-      "version": "0.140.22",
-      "resolved": "https://registry.npmjs.org/@sanity/image-url/-/image-url-0.140.22.tgz",
-      "integrity": "sha512-CAmQZnj+KM7FSEYiWlIGDit072syicYuAw0w7R2ctMzHiZ4p9mE/g6dBnYqrqFUrw2J+GpJgPt+RVspKP8vdqA==",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@sanity/timed-out": {
@@ -6357,11 +6349,6 @@
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
-    "node_modules/browser-split": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.0.tgz",
-      "integrity": "sha512-CNXO3AXAS1H/kOGQkPjucm1161/XoF3aVkMfujqwk85XN/D/MkQMvoB81lXyX/2rerZS+hPAYYRR3mAW05awjQ=="
-    },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -6998,14 +6985,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
       "integrity": "sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw=="
-    },
-    "node_modules/class-list": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/class-list/-/class-list-0.1.1.tgz",
-      "integrity": "sha512-zqR0uW+VsLtyQhixBhkdQ+z6B8+Y8HTh28kdSVjJ4zTTKM7Xz2asAQSya9VI6m/34F6N6Ktm0mrchKB+E5a8Xw==",
-      "dependencies": {
-        "indexof": "0.0.1"
-      }
     },
     "node_modules/class-utils": {
       "version": "0.3.6",
@@ -11590,17 +11569,6 @@
       "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
       "integrity": "sha512-7Wn5GMLuHBjZCb2bTmnDOycho0p/7UVaAeqXZGbHrBCl6Yd/xDhQJAXe6Ga9AXJH2I5zY1dEdYw2u1UptnSBJA=="
     },
-    "node_modules/html-element": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/html-element/-/html-element-2.3.1.tgz",
-      "integrity": "sha512-xnFt2ZkbFcjc+JoAtg3Hl89VeEZDjododu4VCPkRvFmBTHHA9U1Nt6hLUWfW2O+6Sl/rT1hHK/PivleX3PdBJQ==",
-      "dependencies": {
-        "class-list": "~0.1.1"
-      },
-      "engines": {
-        "node": ">=4.2"
-      }
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -11874,16 +11842,6 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
-    "node_modules/hyperscript": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hyperscript/-/hyperscript-2.0.2.tgz",
-      "integrity": "sha512-uggBAYfHFC5WyZQXlJ61BNZbPmJbschcvfYNhYdZWCp+0J8KYb5Du8nQuk8Ru+ThoCNb01B0tPtnTRqnrFBkVg==",
-      "dependencies": {
-        "browser-split": "0.0.0",
-        "class-list": "~0.1.0",
-        "html-element": "^2.0.0"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -12073,11 +12031,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha512-bup+4tap3Hympa+JBJUG7XuOsdNQ6fxt0MHyXMKuLBKn0OqsTfvUxkUrroEX1+B2VsSHvCjiIcZVxRtYa4nllA=="
-    },
-    "node_modules/indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg=="
     },
     "node_modules/infer-owner": {
       "version": "1.0.4",
@@ -32467,6 +32420,28 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
       "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
     },
+    "@portabletext/react": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@portabletext/react/-/react-1.0.6.tgz",
+      "integrity": "sha512-j6BprLiwFz3zr1Lo6BxM2sQ1b3g1JIjGwePeuxqSfbBiEYbGXn2izEckMJ02hSa1f7+RCEUJ+Bojvtzz6BBUaw==",
+      "requires": {
+        "@portabletext/toolkit": "^1.0.5",
+        "@portabletext/types": "^1.0.3"
+      }
+    },
+    "@portabletext/toolkit": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@portabletext/toolkit/-/toolkit-1.0.6.tgz",
+      "integrity": "sha512-u48kRSOyxbOmy0J//bLg1odTcL5dvPDmobSbiTgR11J/k9eIKCdWRiJtddpEyId/aWGP2bkX4ol2RMPCmAPCIg==",
+      "requires": {
+        "@portabletext/types": "^1.0.3"
+      }
+    },
+    "@portabletext/types": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@portabletext/types/-/types-1.0.3.tgz",
+      "integrity": "sha512-SDDsdury2SaTI2D5Ea6o+Y39SSZMYHRMWJHxkxYl3yzFP0n/0EknOhoXcoaV+bxGr2dTTqZi2TOEj+uWYuavSw=="
+    },
     "@radix-ui/primitive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
@@ -32683,26 +32658,6 @@
         "any-observable": "^0.3.0"
       }
     },
-    "@sanity/block-content-to-hyperscript": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sanity/block-content-to-hyperscript/-/block-content-to-hyperscript-3.0.0.tgz",
-      "integrity": "sha512-uoXWLdFY5LqO8A9sFJqnZWWDCBC+0r3Egeh0bwKQ2EK2Vil5L40iJGNXMZhDB8BnvH+6B4155SU8Q3vY59T6pA==",
-      "requires": {
-        "@sanity/generate-help-url": "^0.140.0",
-        "@sanity/image-url": "^0.140.15",
-        "hyperscript": "^2.0.2",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "@sanity/block-content-to-react": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sanity/block-content-to-react/-/block-content-to-react-3.0.0.tgz",
-      "integrity": "sha512-oHPLlIsulsnL3ITs93RIvUPBI6nAeoSFOUf16vX4T7z4wWywxP39N1DF9mAx2tV6Kjr1fJAx5GF7zfiMXYLaqA==",
-      "requires": {
-        "@sanity/block-content-to-hyperscript": "^3.0.0",
-        "prop-types": "^15.6.2"
-      }
-    },
     "@sanity/client": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@sanity/client/-/client-3.4.1.tgz",
@@ -32723,16 +32678,6 @@
         "event-source-polyfill": "1.0.25",
         "eventsource": "^2.0.2"
       }
-    },
-    "@sanity/generate-help-url": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-0.140.0.tgz",
-      "integrity": "sha512-H/G/WA9S22TXcXST52CIiTsHx3S2hH0gvK7LnI5w76vfKS0obnDPh8jrPg4xeNRYGPuV9MHYRlyERGpRGoo4Qw=="
-    },
-    "@sanity/image-url": {
-      "version": "0.140.22",
-      "resolved": "https://registry.npmjs.org/@sanity/image-url/-/image-url-0.140.22.tgz",
-      "integrity": "sha512-CAmQZnj+KM7FSEYiWlIGDit072syicYuAw0w7R2ctMzHiZ4p9mE/g6dBnYqrqFUrw2J+GpJgPt+RVspKP8vdqA=="
     },
     "@sanity/timed-out": {
       "version": "4.0.2",
@@ -34705,11 +34650,6 @@
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
-    "browser-split": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.0.tgz",
-      "integrity": "sha512-CNXO3AXAS1H/kOGQkPjucm1161/XoF3aVkMfujqwk85XN/D/MkQMvoB81lXyX/2rerZS+hPAYYRR3mAW05awjQ=="
-    },
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -35205,14 +35145,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
       "integrity": "sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw=="
-    },
-    "class-list": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/class-list/-/class-list-0.1.1.tgz",
-      "integrity": "sha512-zqR0uW+VsLtyQhixBhkdQ+z6B8+Y8HTh28kdSVjJ4zTTKM7Xz2asAQSya9VI6m/34F6N6Ktm0mrchKB+E5a8Xw==",
-      "requires": {
-        "indexof": "0.0.1"
-      }
     },
     "class-utils": {
       "version": "0.3.6",
@@ -38698,14 +38630,6 @@
       "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
       "integrity": "sha512-7Wn5GMLuHBjZCb2bTmnDOycho0p/7UVaAeqXZGbHrBCl6Yd/xDhQJAXe6Ga9AXJH2I5zY1dEdYw2u1UptnSBJA=="
     },
-    "html-element": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/html-element/-/html-element-2.3.1.tgz",
-      "integrity": "sha512-xnFt2ZkbFcjc+JoAtg3Hl89VeEZDjododu4VCPkRvFmBTHHA9U1Nt6hLUWfW2O+6Sl/rT1hHK/PivleX3PdBJQ==",
-      "requires": {
-        "class-list": "~0.1.1"
-      }
-    },
     "html-encoding-sniffer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -38906,16 +38830,6 @@
       "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
       "dev": true
     },
-    "hyperscript": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hyperscript/-/hyperscript-2.0.2.tgz",
-      "integrity": "sha512-uggBAYfHFC5WyZQXlJ61BNZbPmJbschcvfYNhYdZWCp+0J8KYb5Du8nQuk8Ru+ThoCNb01B0tPtnTRqnrFBkVg==",
-      "requires": {
-        "browser-split": "0.0.0",
-        "class-list": "~0.1.0",
-        "html-element": "^2.0.0"
-      }
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -39037,11 +38951,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha512-bup+4tap3Hympa+JBJUG7XuOsdNQ6fxt0MHyXMKuLBKn0OqsTfvUxkUrroEX1+B2VsSHvCjiIcZVxRtYa4nllA=="
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg=="
     },
     "infer-owner": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   "dependencies": {
     "@craco/craco": "^6.4.5",
     "@navikt/ds-css": "^1.3.21",
-    "@navikt/ds-react": "^1.3.21",
     "@navikt/ds-icons": "^1.3.21",
+    "@navikt/ds-react": "^1.3.21",
     "@navikt/fnrvalidator": "^1.3.3",
-    "@sanity/block-content-to-react": "^3.0.0",
+    "@portabletext/react": "^1.0.6",
     "@sanity/client": "^3.4.1",
     "@sentry/browser": "^7.15.0",
     "@types/amplitude-js": "^8.16.2",

--- a/src/arbeidssøkerskjema/Forside.tsx
+++ b/src/arbeidssøkerskjema/Forside.tsx
@@ -11,19 +11,19 @@ import {
 } from './routes/routesArbeidssokerskjema';
 import VeilederSnakkeboble from './VeilederSnakkeboble';
 import { useSkjema } from './SkjemaContext';
-import { useForsideInnhold } from '../utils/hooks';
+import { useForsideInnhold, useMount } from '../utils/hooks';
 import { ForsideType } from '../models/søknad/stønadstyper';
 import { hentPath } from '../utils/routing';
 import Språkvelger from '../components/språkvelger/Språkvelger';
 import { logSidevisningArbeidssokerskjema } from '../utils/amplitude';
-import { useMount } from '../utils/hooks';
 import { useLokalIntlContext } from '../context/LokalIntlContext';
 import {
-  Panel,
-  Heading,
-  ConfirmationPanel,
-  Button,
   Accordion,
+  BodyShort,
+  Button,
+  ConfirmationPanel,
+  Heading,
+  Panel,
 } from '@navikt/ds-react';
 import styled from 'styled-components';
 import { PortableText } from '@portabletext/react';
@@ -82,9 +82,9 @@ const Forside: React.FC<any> = ({ visningsnavn }) => {
                     <Accordion.Item>
                       <Accordion.Header>{blokk.tittel}</Accordion.Header>
                       <Accordion.Content>
-                        <div className={'navds-body-short navds-body-long'}>
+                        <BodyShort>
                           <PortableText value={blokk.innhold} />
-                        </div>
+                        </BodyShort>
                       </Accordion.Content>
                     </Accordion.Item>
                   </Accordion>
@@ -96,9 +96,9 @@ const Forside: React.FC<any> = ({ visningsnavn }) => {
                       {blokk.tittel}
                     </Heading>
                   )}
-                  <div className={'navds-body-short navds-body-long'}>
+                  <BodyShort>
                     <PortableText value={blokk.innhold} />
-                  </div>
+                  </BodyShort>
                 </div>
               );
             })}
@@ -116,9 +116,9 @@ const Forside: React.FC<any> = ({ visningsnavn }) => {
                 )}
                 onChange={() => settBekreftelse(!skjema.harBekreftet)}
               >
-                <div className={'navds-body-short navds-body-long'}>
+                <BodyShort>
                   <PortableText value={disclaimer} />
-                </div>
+                </BodyShort>
               </StyledConfirmationPanel>
             </>
           )}

--- a/src/arbeidssøkerskjema/Forside.tsx
+++ b/src/arbeidssøkerskjema/Forside.tsx
@@ -26,8 +26,7 @@ import {
   Accordion,
 } from '@navikt/ds-react';
 import styled from 'styled-components';
-
-const BlockContent = require('@sanity/block-content-to-react');
+import { PortableText } from '@portabletext/react';
 
 const DisclaimerTittel = styled(Heading)`
   margin-bottom: 1rem;
@@ -53,26 +52,6 @@ const Forside: React.FC<any> = ({ visningsnavn }) => {
     });
   };
   const forside = useForsideInnhold(ForsideType.arbeidssøker);
-
-  const BlockRenderer = (props: any) => {
-    const { style = 'normal' } = props.node;
-
-    if (/^h\d/.test(style)) {
-      const level = style.replace(/[^\d]/g, '');
-      return React.createElement(
-        style,
-        { className: `heading-${level}` },
-        props.children
-      );
-    }
-
-    if (style === 'blockquote') {
-      return <blockquote>- {props.children}</blockquote>;
-    }
-
-    // Fall back to default handling
-    return BlockContent.defaultSerializers.types.block(props);
-  };
 
   const disclaimer = forside['disclaimer_' + locale];
   const seksjon = forside['seksjon_' + locale];
@@ -103,11 +82,9 @@ const Forside: React.FC<any> = ({ visningsnavn }) => {
                     <Accordion.Item>
                       <Accordion.Header>{blokk.tittel}</Accordion.Header>
                       <Accordion.Content>
-                        <BlockContent
-                          className="navds-body-short navds-body-long"
-                          blocks={blokk.innhold}
-                          serializers={{ types: { block: BlockRenderer } }}
-                        />
+                        <div className={'navds-body-short navds-body-long'}>
+                          <PortableText value={blokk.innhold} />
+                        </div>
                       </Accordion.Content>
                     </Accordion.Item>
                   </Accordion>
@@ -119,11 +96,9 @@ const Forside: React.FC<any> = ({ visningsnavn }) => {
                       {blokk.tittel}
                     </Heading>
                   )}
-                  <BlockContent
-                    className="navds-body-short navds-body-long"
-                    blocks={blokk.innhold}
-                    serializers={{ types: { block: BlockRenderer } }}
-                  />
+                  <div className={'navds-body-short navds-body-long'}>
+                    <PortableText value={blokk.innhold} />
+                  </div>
                 </div>
               );
             })}
@@ -141,10 +116,9 @@ const Forside: React.FC<any> = ({ visningsnavn }) => {
                 )}
                 onChange={() => settBekreftelse(!skjema.harBekreftet)}
               >
-                <BlockContent
-                  blocks={disclaimer}
-                  serializers={{ types: { block: BlockRenderer } }}
-                />
+                <div className={'navds-body-short navds-body-long'}>
+                  <PortableText value={disclaimer} />
+                </div>
               </StyledConfirmationPanel>
             </>
           )}

--- a/src/søknad/forside/Forsideinformasjon.tsx
+++ b/src/søknad/forside/Forsideinformasjon.tsx
@@ -10,11 +10,13 @@ import { useSpråkContext } from '../../context/SpråkContext';
 import { useNavigate } from 'react-router-dom';
 import { LokalIntlShape } from '../../language/typer';
 import {
+  Accordion,
   Alert,
-  Heading,
+  BodyLong,
+  BodyShort,
   Button,
   ConfirmationPanel,
-  Accordion,
+  Heading,
 } from '@navikt/ds-react';
 import styled from 'styled-components';
 import { PortableText } from '@portabletext/react';
@@ -81,12 +83,12 @@ const Forsideinformasjon: React.FC<InnholdProps> = ({
                 <Accordion.Item>
                   <Accordion.Header>{blokk.tittel}</Accordion.Header>
                   <Accordion.Content>
-                    <div className={'navds-body-short navds-body-long'}>
+                    <BodyShort>
                       <PortableText
                         value={blokk.innhold}
                         components={components}
                       />
-                    </div>
+                    </BodyShort>
                   </Accordion.Content>
                 </Accordion.Item>
               </Accordion>
@@ -98,9 +100,9 @@ const Forsideinformasjon: React.FC<InnholdProps> = ({
                   {blokk.tittel}
                 </Heading>
               )}
-              <div className={'navds-body-short navds-body-long'}>
+              <BodyShort>
                 <PortableText value={blokk.innhold} components={components} />
-              </div>
+              </BodyShort>
             </div>
           );
         })}
@@ -117,9 +119,9 @@ const Forsideinformasjon: React.FC<InnholdProps> = ({
             )}
             onChange={() => settBekreftelse(!harBekreftet)}
           >
-            <div className={'navds-body-short navds-body-long'}>
+            <BodyShort>
               <PortableText value={disclaimer} components={components} />
-            </div>
+            </BodyShort>
           </StyledConfirmationPanel>
         </>
       )}

--- a/src/søknad/forside/Forsideinformasjon.tsx
+++ b/src/søknad/forside/Forsideinformasjon.tsx
@@ -12,7 +12,6 @@ import { LokalIntlShape } from '../../language/typer';
 import {
   Accordion,
   Alert,
-  BodyLong,
   BodyShort,
   Button,
   ConfirmationPanel,

--- a/src/søknad/forside/Forsideinformasjon.tsx
+++ b/src/søknad/forside/Forsideinformasjon.tsx
@@ -45,7 +45,7 @@ const components: Partial<PortableTextReactComponents> = {
     link: ({ children, value }) => {
       return (
         <span className="lenke-tekst">
-          <a href={value}>{children}</a>
+          <a href={value.href}>{children}</a>
         </span>
       );
     },

--- a/src/søknad/forside/Forsideinformasjon.tsx
+++ b/src/søknad/forside/Forsideinformasjon.tsx
@@ -17,6 +17,8 @@ import {
   Accordion,
 } from '@navikt/ds-react';
 import styled from 'styled-components';
+import { PortableText } from '@portabletext/react';
+import { PortableTextReactComponents } from '@portabletext/react/src/types';
 
 const StyledConfirmationPanel = styled(ConfirmationPanel)`
   margin-bottom: 2rem;
@@ -25,8 +27,6 @@ const StyledConfirmationPanel = styled(ConfirmationPanel)`
 const DisclaimerTittel = styled(Heading)`
   margin-bottom: 1rem;
 `;
-
-const BlockContent = require('@sanity/block-content-to-react');
 
 interface InnholdProps {
   seksjon?: any;
@@ -37,6 +37,18 @@ interface InnholdProps {
   settBekreftelse: (bekreftet: boolean) => void;
   nesteSide: string;
 }
+
+const components: Partial<PortableTextReactComponents> = {
+  marks: {
+    link: ({ children, value }) => {
+      return (
+        <span className="lenke-tekst">
+          <a href={value}>{children}</a>
+        </span>
+      );
+    },
+  },
+};
 
 const Forsideinformasjon: React.FC<InnholdProps> = ({
   seksjon,
@@ -49,40 +61,6 @@ const Forsideinformasjon: React.FC<InnholdProps> = ({
 }) => {
   const navigate = useNavigate();
   const [locale] = useSpråkContext();
-
-  const BlockRenderer = (props: any) => {
-    const { style = 'normal' } = props.node;
-
-    if (/^h\d/.test(style)) {
-      const level = style.replace(/[^\d]/g, '');
-      return React.createElement(
-        style,
-        { className: `heading-${level}` },
-        props.children
-      );
-    }
-
-    if (props.node.markDefs.length > 0) {
-      return props.node.markDefs.map((mark: any, index: number) => {
-        let { _type = '' } = mark;
-        if (_type === 'link') {
-          return (
-            <span className="lenke-tekst" key={index}>
-              {props.children}
-            </span>
-          );
-        }
-        return props.children;
-      });
-    }
-
-    if (style === 'blockquote') {
-      return <blockquote>- {props.children}</blockquote>;
-    }
-
-    // Fall back to default handling
-    return BlockContent.defaultSerializers.types.block(props);
-  };
 
   return (
     <>
@@ -103,11 +81,12 @@ const Forsideinformasjon: React.FC<InnholdProps> = ({
                 <Accordion.Item>
                   <Accordion.Header>{blokk.tittel}</Accordion.Header>
                   <Accordion.Content>
-                    <BlockContent
-                      className="navds-body-short navds-body-long"
-                      blocks={blokk.innhold}
-                      serializers={{ types: { block: BlockRenderer } }}
-                    />
+                    <div className={'navds-body-short navds-body-long'}>
+                      <PortableText
+                        value={blokk.innhold}
+                        components={components}
+                      />
+                    </div>
                   </Accordion.Content>
                 </Accordion.Item>
               </Accordion>
@@ -120,16 +99,11 @@ const Forsideinformasjon: React.FC<InnholdProps> = ({
                 </Heading>
               )}
               <div className={'navds-body-short navds-body-long'}>
-                <BlockContent
-                  className="navds-body-short navds-body-long"
-                  blocks={blokk.innhold}
-                  serializers={{ types: { block: BlockRenderer } }}
-                />
+                <PortableText value={blokk.innhold} components={components} />
               </div>
             </div>
           );
         })}
-
       {disclaimer && !isIE && (
         <>
           <DisclaimerTittel level="2" size="small">
@@ -143,10 +117,9 @@ const Forsideinformasjon: React.FC<InnholdProps> = ({
             )}
             onChange={() => settBekreftelse(!harBekreftet)}
           >
-            <BlockContent
-              blocks={disclaimer}
-              serializers={{ types: { block: BlockRenderer } }}
-            />
+            <div className={'navds-body-short navds-body-long'}>
+              <PortableText value={disclaimer} components={components} />
+            </div>
           </StyledConfirmationPanel>
         </>
       )}


### PR DESCRIPTION
…lockContent er deprecated

* https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8702
* https://github.com/portabletext/react-portabletext/blob/main/MIGRATING.md
* https://github.com/navikt/familie-felles-frontend/pull/668 liknende

Det ble litt mindre spacing på noen stedet fordi tidligere var det 2 div's som wrappet content, nå er det kun en
Dvs tidligere var det dette:
```html
<div class="seksjon">
  <h2 class="navds-heading navds-heading--small">Vi vil hente informasjon om deg</h2>
  <div class="navds-body-short navds-body-long">
     <div class="navds-body-short navds-body-long">
        <p>
```

Men nå slettes en av divene med navds

### Arbeidssøkerskjema
Før
![image](https://user-images.githubusercontent.com/937168/197543113-65337859-75a2-4cb3-815f-ab58ef36cc5a.png)

Etter
![image](https://user-images.githubusercontent.com/937168/197543082-d03ca8d6-5864-492e-9bdb-2576a3755491.png)


### Søknad
Før
![image](https://user-images.githubusercontent.com/937168/197543212-e8e989ff-fdc9-4b8d-8527-f17ac7b57001.png)

Etter
![image](https://user-images.githubusercontent.com/937168/197543231-e1a0bc95-1e06-448b-8809-050f98fc3c3d.png)

