### PR TITLE
Endret lenke med link fra nytt designsystem

### DIFF
--- a/src/arbeidssøkerskjema/steg/3-Kvittering.tsx
+++ b/src/arbeidssøkerskjema/steg/3-Kvittering.tsx
@@ -68,12 +68,9 @@ const Kvittering: React.FC = () => {
             </BodyShort>
           </Link>
         </FeltGruppe>
-        <a
-          className={'knapp knapp--standard kvittering'}
-          href={'https://arbeidssokerregistrering.nav.no/'}
-        >
+        <Link href={'https://arbeidssokerregistrering.nav.no/'}>
           <LocaleTekst tekst={'arbeidssøker.knapp.tilleggstønad'} />
-        </a>
+        </Link>
       </KomponentGruppe>
     </Side>
   ) : (

--- a/src/søknad/steg/1-omdeg/personopplysninger/SøkerBorIkkePåAdresse.tsx
+++ b/src/søknad/steg/1-omdeg/personopplysninger/SøkerBorIkkePåAdresse.tsx
@@ -2,9 +2,8 @@ import { FC } from 'react';
 import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
 import LocaleTekst from '../../../../language/LocaleTekst';
 import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
-import Lenke from 'nav-frontend-lenker';
 import { Stønadstype } from '../../../../models/søknad/stønadstyper';
-import { Label, BodyShort, Alert } from '@navikt/ds-react';
+import { Label, BodyShort, Alert, Link } from '@navikt/ds-react';
 
 interface Props {
   stønadstype: Stønadstype;
@@ -35,9 +34,9 @@ const SøkerBorIkkePåAdresse: FC<Props> = ({ stønadstype }) => {
         </FeltGruppe>
         <FeltGruppe>
           <BodyShort>
-            <Lenke href={lenkerPDFSøknad[stønadstype]}>
+            <Link href={lenkerPDFSøknad[stønadstype]}>
               <LocaleTekst tekst={'personopplysninger.lenke.pdfskjema'} />
-            </Lenke>
+            </Link>
           </BodyShort>
         </FeltGruppe>
         <BodyShort>

--- a/src/søknad/steg/9-kvittering/ErklæringSamlivsbrudd.tsx
+++ b/src/søknad/steg/9-kvittering/ErklæringSamlivsbrudd.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react';
 import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
-import Lenke from 'nav-frontend-lenker';
 import download from '../../../assets/download.svg';
 import styled from 'styled-components/macro';
 import { StyledUndertittel } from '../../../components/gruppe/Spacing';
@@ -8,7 +7,7 @@ import LocaleTekst from '../../../language/LocaleTekst';
 import { useLokalIntlContext } from '../../../context/LokalIntlContext';
 import { hentFilePath } from '../../../utils/språk';
 import { useSpråkContext } from '../../../context/SpråkContext';
-import { BodyShort, Label } from '@navikt/ds-react';
+import { BodyShort, Label, Link } from '@navikt/ds-react';
 
 const StyledLenke = styled.div`
   margin-top: 1rem;
@@ -37,7 +36,7 @@ const ErklæringSamlivsbrudd: FC = () => {
       </BodyShort>
 
       <StyledLenke>
-        <Lenke
+        <Link
           href={hentFilePath(locale, {
             nb: '/familie/alene-med-barn/soknad/filer/Erklaering_om_samlivsbrudd.pdf',
             en: '/familie/alene-med-barn/soknad/filer/Declaration_on_end_of_relationship_EN.pdf',
@@ -49,7 +48,7 @@ const ErklæringSamlivsbrudd: FC = () => {
           <Label>
             {intl.formatMessage({ id: 'kvittering.knapp.samlivsbrudd' })}
           </Label>
-        </Lenke>
+        </Link>
       </StyledLenke>
     </SeksjonGruppe>
   );

--- a/src/søknad/steg/9-kvittering/RegistrerDegSomArbeidssøker.tsx
+++ b/src/søknad/steg/9-kvittering/RegistrerDegSomArbeidssøker.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import FeltGruppe from '../../../components/gruppe/FeltGruppe';
 import LocaleTekst from '../../../language/LocaleTekst';
 import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
-import { BodyShort } from '@navikt/ds-react';
+import { BodyShort, Link } from '@navikt/ds-react';
 
 const RegistrerDegSomArbeidssøker: FC = () => {
   return (
@@ -12,12 +12,9 @@ const RegistrerDegSomArbeidssøker: FC = () => {
           <LocaleTekst tekst={'kvittering.tekst.arbeidssøker'} />
         </BodyShort>
       </FeltGruppe>
-      <a
-        className={'knapp knapp--standard kvittering'}
-        href={'https://arbeidssokerregistrering.nav.no/'}
-      >
+      <Link href={'https://arbeidssokerregistrering.nav.no/'}>
         <LocaleTekst tekst={'kvittering.knapp.arbeidssøker'} />
-      </a>
+      </Link>
     </SeksjonGruppe>
   );
 };

--- a/src/søknad/steg/9-kvittering/SykSøker.tsx
+++ b/src/søknad/steg/9-kvittering/SykSøker.tsx
@@ -1,12 +1,11 @@
 import { FC } from 'react';
 import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
-import Lenke from 'nav-frontend-lenker';
 import download from '../../../assets/download.svg';
 import { StyledUndertittel } from '../../../components/gruppe/Spacing';
 import styled from 'styled-components/macro';
 import LocaleTekst from '../../../language/LocaleTekst';
 import { useLokalIntlContext } from '../../../context/LokalIntlContext';
-import { BodyShort, Label } from '@navikt/ds-react';
+import { BodyShort, Label, Link } from '@navikt/ds-react';
 
 const StyledLenke = styled.div`
   margin-top: 1rem;
@@ -33,12 +32,12 @@ const SykSøker: FC<{ filPath: string }> = ({ filPath }) => {
         <LocaleTekst tekst={'kvittering.beskrivelse.huskeliste.erSyk'} />
       </BodyShort>
       <StyledLenke>
-        <Lenke href={filPath} download>
+        <Link href={filPath} download>
           <img alt="Nedlastingsikon" src={download} />
           <Label>
             {intl.formatMessage({ id: 'kvittering.knapp.huskeliste.erSyk' })}
           </Label>
-        </Lenke>
+        </Link>
       </StyledLenke>
     </SeksjonGruppe>
   );

--- a/src/søknad/steg/9-kvittering/SyktBarn.tsx
+++ b/src/søknad/steg/9-kvittering/SyktBarn.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react';
 import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
-import Lenke from 'nav-frontend-lenker';
 import download from '../../../assets/download.svg';
 import { StyledUndertittel } from '../../../components/gruppe/Spacing';
 import styled from 'styled-components/macro';
@@ -8,7 +7,7 @@ import LocaleTekst from '../../../language/LocaleTekst';
 import { useLokalIntlContext } from '../../../context/LokalIntlContext';
 import { hentFilePath } from '../../../utils/språk';
 import { useSpråkContext } from '../../../context/SpråkContext';
-import { BodyShort, Label } from '@navikt/ds-react';
+import { BodyShort, Label, Link } from '@navikt/ds-react';
 
 const StyledLenke = styled.div`
   margin-top: 1rem;
@@ -35,7 +34,7 @@ const SyktBarn: FC = () => {
         <LocaleTekst tekst={'kvittering.beskrivelse.huskeliste.syktBarn'} />
       </BodyShort>
       <StyledLenke>
-        <Lenke
+        <Link
           href={hentFilePath(locale, {
             nb: '/familie/alene-med-barn/soknad/filer/Huskeliste_lege_sykt_barn_OS.pdf',
             en: '/familie/alene-med-barn/soknad/filer/Checklist_for_your_doctors_appointment_child_OS_EN.pdf',
@@ -47,7 +46,7 @@ const SyktBarn: FC = () => {
           <Label>
             {intl.formatMessage({ id: 'kvittering.knapp.huskeliste.syktBarn' })}
           </Label>
-        </Lenke>
+        </Link>
       </StyledLenke>
     </SeksjonGruppe>
   );

--- a/src/søknad/steg/9-kvittering/TilleggsstønaderArbeidssøker.tsx
+++ b/src/søknad/steg/9-kvittering/TilleggsstønaderArbeidssøker.tsx
@@ -2,10 +2,8 @@ import { FC } from 'react';
 import FeltGruppe from '../../../components/gruppe/FeltGruppe';
 import LocaleTekst from '../../../language/LocaleTekst';
 import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
-import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
-import Lenke from 'nav-frontend-lenker';
 import styled from 'styled-components/macro';
-import { BodyShort, Heading } from '@navikt/ds-react';
+import { BodyShort, Heading, Link } from '@navikt/ds-react';
 
 const StyledBeskrivelse = styled.div`
   .navds-body-short {
@@ -34,25 +32,22 @@ const TilleggsstønaderArbeidssøker: FC = () => {
           </BodyShort>
         </StyledBeskrivelse>
       </FeltGruppe>
-      <KomponentGruppe>
-        <Lenke href={'https://www.nav.no/familie/alene-med-barn/skolepenger'}>
-          <BodyShort>
-            <LocaleTekst
-              tekst={'kvittering.lenke.tilleggsstønader.arbeidssøker'}
-            />
-          </BodyShort>
-        </Lenke>
-      </KomponentGruppe>
-      <KomponentGruppe>
-        <a
-          className={'knapp knapp--standard kvittering'}
+      <BodyShort>
+        <Link href={'https://www.nav.no/familie/alene-med-barn/skolepenger'}>
+          <LocaleTekst
+            tekst={'kvittering.lenke.tilleggsstønader.arbeidssøker'}
+          />
+        </Link>
+      </BodyShort>
+      <BodyShort>
+        <Link
           href={'https://www.nav.no/soknader/nb/person/arbeid/tilleggsstonader'}
         >
           <LocaleTekst
             tekst={'kvittering.knapp.tilleggsstønader.arbeidssøker'}
           />
-        </a>
-      </KomponentGruppe>
+        </Link>
+      </BodyShort>
     </SeksjonGruppe>
   );
 };

--- a/src/søknad/steg/9-kvittering/TilleggsstønaderHarAktivitet.tsx
+++ b/src/søknad/steg/9-kvittering/TilleggsstønaderHarAktivitet.tsx
@@ -2,10 +2,8 @@ import { FC } from 'react';
 import FeltGruppe from '../../../components/gruppe/FeltGruppe';
 import LocaleTekst from '../../../language/LocaleTekst';
 import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
-import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
-import Lenke from 'nav-frontend-lenker';
 import styled from 'styled-components/macro';
-import { BodyShort, Heading } from '@navikt/ds-react';
+import { BodyShort, Heading, Link } from '@navikt/ds-react';
 
 const StyledBeskrivelse = styled.div`
   .navds-body-short {
@@ -34,18 +32,15 @@ const TilleggsstønaderHarAktivitet: FC = () => {
           </BodyShort>
         </StyledBeskrivelse>
       </FeltGruppe>
-      <KomponentGruppe>
-        <Lenke href={'https://www.nav.no/familie/alene-med-barn/barnetilsyn'}>
-          <BodyShort>
-            <LocaleTekst
-              tekst={'kvittering.lenke.tilleggsstønader.aktivitetskrav'}
-            />
-          </BodyShort>
-        </Lenke>
-      </KomponentGruppe>
-      <KomponentGruppe>
-        <a
-          className={'knapp knapp--standard kvittering'}
+      <BodyShort>
+        <Link href={'https://www.nav.no/familie/alene-med-barn/barnetilsyn'}>
+          <LocaleTekst
+            tekst={'kvittering.lenke.tilleggsstønader.aktivitetskrav'}
+          />
+        </Link>
+      </BodyShort>
+      <BodyShort>
+        <Link
           href={
             'https://www.nav.no/soknader/nb/person/familie/enslig-mor-eller-far#NAV150002'
           }
@@ -53,8 +48,8 @@ const TilleggsstønaderHarAktivitet: FC = () => {
           <LocaleTekst
             tekst={'kvittering.knapp.tilleggsstønader.aktivitetskrav'}
           />
-        </a>
-      </KomponentGruppe>
+        </Link>
+      </BodyShort>
     </SeksjonGruppe>
   );
 };

--- a/src/søknad/steg/9-kvittering/TilleggsstønaderUnderUtdanning.tsx
+++ b/src/søknad/steg/9-kvittering/TilleggsstønaderUnderUtdanning.tsx
@@ -2,13 +2,12 @@ import { FC } from 'react';
 import FeltGruppe from '../../../components/gruppe/FeltGruppe';
 import LocaleTekst from '../../../language/LocaleTekst';
 import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
-import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
-import Lenke from 'nav-frontend-lenker';
 import styled from 'styled-components/macro';
 import { hentTekst } from '../../../utils/søknad';
 import { useLokalIntlContext } from '../../../context/LokalIntlContext';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
-import { BodyShort, Heading } from '@navikt/ds-react';
+import { BodyShort, Heading, Link } from '@navikt/ds-react';
+import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
 
 const StyledBeskrivelse = styled.div`
   .navds-body-short {
@@ -25,7 +24,7 @@ const RegistrerDegSomArbeidssøker: FC<{ stønadstype: Stønadstype }> = ({
   return (
     <SeksjonGruppe>
       {stønadstype === Stønadstype.overgangsstønad && (
-        <>
+        <KomponentGruppe>
           <FeltGruppe>
             <Heading size="small">
               <LocaleTekst tekst={'kvittering.tittel.skolepenger'} />
@@ -36,26 +35,25 @@ const RegistrerDegSomArbeidssøker: FC<{ stønadstype: Stønadstype }> = ({
               {hentTekst('kvittering.tekst.skolepenger', intl)}
             </BodyShort>
           </FeltGruppe>
-          <KomponentGruppe>
-            <BodyShort>
-              <Lenke
-                href={'https://www.nav.no/familie/alene-med-barn/skolepenger'}
-              >
+          <div>
+            <Link
+              href={'https://www.nav.no/familie/alene-med-barn/skolepenger'}
+            >
+              <BodyShort>
                 {hentTekst('kvittering.lenke.skolepenger', intl)}
-              </Lenke>
-            </BodyShort>
-          </KomponentGruppe>
+              </BodyShort>
+            </Link>
+          </div>
           <KomponentGruppe>
-            <a
-              className={'knapp knapp--standard kvittering'}
+            <Link
               href={
                 'https://www.nav.no/soknader/nb/person/familie/enslig-mor-eller-far/NAV%2015-00.04/dokumentinnsending'
               }
             >
               <LocaleTekst tekst={'kvittering.knapp.skolepenger'} />
-            </a>
+            </Link>
           </KomponentGruppe>
-        </>
+        </KomponentGruppe>
       )}
       <FeltGruppe>
         <Heading size="small">
@@ -71,24 +69,20 @@ const RegistrerDegSomArbeidssøker: FC<{ stønadstype: Stønadstype }> = ({
         </StyledBeskrivelse>
       </FeltGruppe>
 
-      <KomponentGruppe>
-        <Lenke
+      <BodyShort>
+        <Link
           href={'https://www.nav.no/familie/alene-med-barn/tilleggsstonader'}
         >
-          <BodyShort>
-            <LocaleTekst tekst={'kvittering.lenke.tilleggsstønader'} />
-          </BodyShort>
-        </Lenke>
-      </KomponentGruppe>
-
-      <KomponentGruppe>
-        <a
-          className={'knapp knapp--standard kvittering'}
+          <LocaleTekst tekst={'kvittering.lenke.tilleggsstønader'} />
+        </Link>
+      </BodyShort>
+      <BodyShort>
+        <Link
           href={'https://www.nav.no/soknader/nb/person/arbeid/tilleggsstonader'}
         >
           <LocaleTekst tekst={'kvittering.knapp.tilleggsstønader'} />
-        </a>
-      </KomponentGruppe>
+        </Link>
+      </BodyShort>
     </SeksjonGruppe>
   );
 };


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10353

Fjerner wrap av KomponentGruppe då den legger til padding-bottom som ikke trengs for lenkene 

<img width="461" alt="image" src="https://user-images.githubusercontent.com/937168/200861367-554cb5fc-495f-4601-8786-f691b13cf44c.png">

Før:
![image](https://user-images.githubusercontent.com/937168/200865794-36468caf-a7ac-437b-832d-ac9a7b5dfb0d.png)

Etter:
![image](https://user-images.githubusercontent.com/937168/200865911-6255a559-1015-4763-9cf0-da7f756fdb8b.png)

