### PR TITLE
Skal sette størrelse på inputfelt utgifter til skolepenger

### DIFF
--- a/src/søknad/steg/5-aktivitet/underUtdanning/Studiekostnader.tsx
+++ b/src/søknad/steg/5-aktivitet/underUtdanning/Studiekostnader.tsx
@@ -55,6 +55,7 @@ const Studiekostnader: React.FC<Props> = ({ utdanning, oppdaterUtdanning }) => {
           label={semesteravgiftLabel}
           nøkkel={EUtdanning.semesteravgift}
           type={'number'}
+          bredde={'XS'}
           settInputFelt={(e) =>
             settInputFelt(EUtdanning.semesteravgift, semesteravgiftLabel, e)
           }
@@ -71,6 +72,7 @@ const Studiekostnader: React.FC<Props> = ({ utdanning, oppdaterUtdanning }) => {
           label={studieavgiftLabel}
           nøkkel={EUtdanning.studieavgift}
           type={'number'}
+          bredde={'XS'}
           settInputFelt={(e) =>
             settInputFelt(EUtdanning.studieavgift, studieavgiftLabel, e)
           }
@@ -85,6 +87,7 @@ const Studiekostnader: React.FC<Props> = ({ utdanning, oppdaterUtdanning }) => {
           label={eksamensgebyrLabel}
           nøkkel={EUtdanning.eksamensgebyr}
           type={'number'}
+          bredde={'XS'}
           settInputFelt={(e) =>
             settInputFelt(EUtdanning.eksamensgebyr, eksamensgebyrLabel, e)
           }


### PR DESCRIPTION
`type={'number'}` er visst dårlig på håndtering av størrelser hvis ikke denne settes eksplisitt. 

**Før:**
![image](https://user-images.githubusercontent.com/21220467/203573782-a376fbc9-12be-4b3d-b99c-cf9ec6d473c4.png)


**Etter:**
![image](https://user-images.githubusercontent.com/21220467/203573480-248984ff-eed5-48e5-9765-221107285b35.png)
