### PR TITLE
Skal ikke nulle ut samboerdetaljer dersom det er gyldig ident ELLER g…

### DIFF
--- a/src/søknad/steg/1-omdeg/sivilstatus/begrunnelse/SøknadsBegrunnelse.tsx
+++ b/src/søknad/steg/1-omdeg/sivilstatus/begrunnelse/SøknadsBegrunnelse.tsx
@@ -91,7 +91,12 @@ const Søknadsbegrunnelse: FC<Props> = ({
         },
       });
 
-    if (!erGyldigIdent && samlivsbruddAndre) {
+    const harGyldigSamboerInfo =
+      erGyldigIdent ||
+      (samboerInfo.kjennerIkkeIdent && samboerInfo.fødselsdato);
+
+    if (!harGyldigSamboerInfo && samlivsbruddAndre) {
+      console.log('sletter tidligere samboerdetaljer2');
       const nySamboerInfo = { ...samboerInfo };
       const nySivilstatus = { ...sivilstatus };
       delete nySamboerInfo.ident;

--- a/src/søknad/steg/1-omdeg/sivilstatus/begrunnelse/SøknadsBegrunnelse.tsx
+++ b/src/søknad/steg/1-omdeg/sivilstatus/begrunnelse/SøknadsBegrunnelse.tsx
@@ -96,7 +96,6 @@ const Søknadsbegrunnelse: FC<Props> = ({
       (samboerInfo.kjennerIkkeIdent && samboerInfo.fødselsdato);
 
     if (!harGyldigSamboerInfo && samlivsbruddAndre) {
-      console.log('sletter tidligere samboerdetaljer2');
       const nySamboerInfo = { ...samboerInfo };
       const nySivilstatus = { ...sivilstatus };
       delete nySamboerInfo.ident;


### PR DESCRIPTION
…yldig fødselsdato for tidligere samboer. Tidligere bug: Ble nullet ut hvis dato var fylt inn og man fortsatte på en søknad