### PR TITLE
Setter consumer-id på global nivå

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,9 +19,12 @@ import { logAdressesperre } from './utils/amplitude';
 import { ESkjemanavn } from './utils/skjemanavn';
 import { useLokalIntlContext } from './context/LokalIntlContext';
 import { Alert, Loader, Modal } from '@navikt/ds-react';
+import axios from 'axios';
 
 // @ts-ignore
 Modal.setAppElement(document.getElementById('modal-a11y-wrapper'));
+
+axios.defaults.headers.common['Nav-Consumer-Id'] = 'familie-ef-soknad';
 
 const App = () => {
   const [autentisert, settAutentisering] = useState<boolean>(false);

--- a/src/components/filopplaster/Filopplaster.tsx
+++ b/src/components/filopplaster/Filopplaster.tsx
@@ -13,10 +13,6 @@ import axios from 'axios';
 import { skjemanavnTilId, urlTilSkjemanavn } from '../../utils/skjemanavn';
 import { IDokumentasjon } from '../../models/steg/dokumentasjon';
 import { dagensDatoMedTidspunktStreng } from '../../utils/dato';
-import {
-  HEADER_NAV_CONSUMER_ID,
-  HEADER_NAV_CONSUMER_ID_VALUE,
-} from '../../utils/apiutil';
 import { logFeilFilopplasting } from '../../utils/amplitude';
 import { getFeilmelding } from '../../utils/feil';
 import FormData from 'form-data';
@@ -122,7 +118,6 @@ const Filopplaster: React.FC<Props> = ({
               headers: {
                 'Content-Type': 'multipart/form-data',
                 accept: 'application/json',
-                [HEADER_NAV_CONSUMER_ID]: HEADER_NAV_CONSUMER_ID_VALUE,
               },
               transformRequest: (data, headers) => {
                 return requestData;

--- a/src/utils/apiutil.ts
+++ b/src/utils/apiutil.ts
@@ -1,2 +1,0 @@
-export const HEADER_NAV_CONSUMER_ID = 'Nav-Consumer-Id';
-export const HEADER_NAV_CONSUMER_ID_VALUE = 'familie-ef-soknad';

--- a/src/utils/søknad.ts
+++ b/src/utils/søknad.ts
@@ -10,10 +10,6 @@ import {
   standardLabelsBarn,
 } from '../helpers/labels';
 import { IBarn } from '../models/steg/barn';
-import {
-  HEADER_NAV_CONSUMER_ID,
-  HEADER_NAV_CONSUMER_ID_VALUE,
-} from './apiutil';
 import { LokalIntlShape } from '../language/typer';
 
 export const hentPersonData = () => {
@@ -51,7 +47,6 @@ export const hentMellomlagretSøknadFraDokument = <T>(
       headers: {
         'Content-Type': 'application/json',
         accept: 'application/json',
-        [HEADER_NAV_CONSUMER_ID]: HEADER_NAV_CONSUMER_ID_VALUE,
       },
     })
     .then((response: { data?: T }) => {
@@ -63,14 +58,17 @@ export const mellomlagreSøknadTilDokument = <T>(
   søknad: T,
   stønadstype: MellomlagredeStønadstyper
 ): Promise<T> => {
-  return axios.post(`${Environment().mellomlagerProxyUrl + stønadstype}`, søknad, {
-    withCredentials: true,
-    headers: {
-      'Content-Type': 'application/json',
-      accept: 'application/json',
-      [HEADER_NAV_CONSUMER_ID]: HEADER_NAV_CONSUMER_ID_VALUE,
-    },
-  });
+  return axios.post(
+    `${Environment().mellomlagerProxyUrl + stønadstype}`,
+    søknad,
+    {
+      withCredentials: true,
+      headers: {
+        'Content-Type': 'application/json',
+        accept: 'application/json',
+      },
+    }
+  );
 };
 
 export const nullstillMellomlagretSøknadTilDokument = (
@@ -81,7 +79,6 @@ export const nullstillMellomlagretSøknadTilDokument = (
     headers: {
       'Content-Type': 'application/json',
       accept: 'application/json',
-      [HEADER_NAV_CONSUMER_ID]: HEADER_NAV_CONSUMER_ID_VALUE,
     },
   });
 };


### PR DESCRIPTION
Den var ikke satt på alle requester så enklere å sette på global nivå? 