### PR TITLE
Fjern advarsel opphold

### DIFF
--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -175,8 +175,6 @@ export default {
     'We ask about this to work out what information we need from you.',
   'medlemskap.spm.opphold':
     'Are you and the child/children currently present in Norway?',
-  'medlemskap.alert-advarsel.opphold':
-    'If you are not living in Norway, you are generally not entitled to benefit for single parents. However, you can receive benefit if you are living overseas because you work for a Norwegian employer. You can also spend up to six weeks outside Norway during a 12 month period.',
   'medlemskap.spm.bosatt': 'Have you lived in Norway for the past five years?',
   'medlemskap.periodeBoddIUtlandet.utenlandsopphold': 'Period spent abroad ',
   'medlemskap.periodeBoddIUtlandet.slett': 'Remove period spent abroad',

--- a/src/language/tekster_nb.ts
+++ b/src/language/tekster_nb.ts
@@ -171,8 +171,6 @@ export default {
   'sivilstatus.hjelpetekst-innhold.begrunnelse':
     'Vi spør om dette for å vite hvilken informasjon vi trenger fra deg.',
   'medlemskap.spm.opphold': 'Oppholder du og barnet/barna dere i Norge?',
-  'medlemskap.alert-advarsel.opphold':
-    'Når du ikke oppholder deg i Norge, har du som hovedregel ikke rett på stønad til enslig mor eller far. Du kan likevel få stønad dersom du oppholder deg i utlandet fordi du arbeider for en norsk arbeidsgiver. Du kan også være i utlandet i inntil 6 uker i løpet av en 12 måneders periode.',
   'medlemskap.spm.bosatt': 'Har du oppholdt deg i Norge de siste 5 årene?',
   'medlemskap.periodeBoddIUtlandet.utenlandsopphold': 'Utenlandsperiode',
   'medlemskap.periodeBoddIUtlandet.slett': 'Fjern utenlandsperiode',

--- a/src/language/tekster_nn.ts
+++ b/src/language/tekster_nn.ts
@@ -257,10 +257,6 @@ export default {
 
   // --- MEDLEMSKAP
   'medlemskap.spm.opphold': 'Oppheld du deg i Noreg?',
-  'medlemskap.alert-advarsel.opphold':
-    'If you are not living in Norway, you are generally not entitled to benefit for single parents. ' +
-    'However, you can receive benefit if you are living overseas because you work for a Norwegian employer. ' +
-    'You can also spend up to six weeks outside Norway during a 12 month period.',
   'medlemskap.spm.bosatt': 'Have you lived in Norway for the past five years?',
 
   'medlemskap.periodeBoddIUtlandet.utenlandsopphold': 'Period spent abroad ',

--- a/src/søknad/steg/1-omdeg/medlemskap/Medlemskap.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/Medlemskap.tsx
@@ -73,11 +73,6 @@ const Medlemskap: React.FC<Props> = ({ medlemskap, settMedlemskap }) => {
           valgtSvar={valgtSvarOppholderSegINorge}
           onChange={settMedlemskapBooleanFelt}
         />
-        {valgtSvarOppholderSegINorge === false && (
-          <Alert size="small" variant="warning" inline>
-            <LocaleTekst tekst={'medlemskap.alert-advarsel.opphold'} />
-          </Alert>
-        )}
       </KomponentGruppe>
 
       {søkerOppholderSegINorge?.hasOwnProperty('verdi') && (


### PR DESCRIPTION
**Hvorfor:** 
Vil ikke vise fram varsel med feil info hvis dette er eøs-opphold. 

**Dette er steg 1:** 
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12182
https://nav-it.slack.com/archives/G0104QDKZJQ/p1678981141770259

**Neste steg:** 
Analysere behov - trenger vi mer info? Eller kan vi fjerne hele spørsmålet, eller er det greit slik? Bedre infotekst? 

**Endring i ui:** 
![image](https://user-images.githubusercontent.com/53942238/227155681-7dd5f54f-761b-4974-aa03-9cd21ef29060.png)
