### PR TITLE
Ta i bruk farger fra ds-tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "mustache-express": "^1.3.2",
         "nav-datovelger": "^12.6.0",
         "nav-faker": "^3.2.4",
+        "nav-frontend-core": "^6.0.1",
         "nav-frontend-ikoner-assets": "^3.0.1",
         "nav-frontend-js-utils": "^1.0.20",
         "nav-frontend-knapper-style": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@navikt/ds-css": "^2.1.6",
         "@navikt/ds-icons": "^2.1.6",
         "@navikt/ds-react": "^2.1.6",
+        "@navikt/ds-tokens": "^2.8.4",
         "@navikt/fnrvalidator": "^1.3.3",
         "@portabletext/react": "^2.0.1",
         "@sanity/client": "^4.0.1",
@@ -3620,6 +3621,12 @@
         "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18",
         "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18"
       }
+    },
+    "node_modules/@navikt/ds-tokens": {
+      "version": "2.8.4",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/2.8.4/8b8e1591406738c119e086b07460e29ea4634872",
+      "integrity": "sha512-EaRMNLOosnYoZ9FOvYck63qXWlZxGnnjDCZa288fOdjWpPlLF3M1fSDkR0RKTf+xxI7UNn/3NEMGmz+DPGM5sQ==",
+      "license": "MIT"
     },
     "node_modules/@navikt/fnrvalidator": {
       "version": "1.3.3",
@@ -28133,6 +28140,11 @@
           }
         }
       }
+    },
+    "@navikt/ds-tokens": {
+      "version": "2.8.4",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/2.8.4/8b8e1591406738c119e086b07460e29ea4634872",
+      "integrity": "sha512-EaRMNLOosnYoZ9FOvYck63qXWlZxGnnjDCZa288fOdjWpPlLF3M1fSDkR0RKTf+xxI7UNn/3NEMGmz+DPGM5sQ=="
     },
     "@navikt/fnrvalidator": {
       "version": "1.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "mustache-express": "^1.3.2",
         "nav-datovelger": "^12.6.0",
         "nav-faker": "^3.2.4",
-        "nav-frontend-core": "^6.0.1",
         "nav-frontend-ikoner-assets": "^3.0.1",
         "nav-frontend-js-utils": "^1.0.20",
         "nav-frontend-knapper-style": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "mustache-express": "^1.3.2",
     "nav-datovelger": "^12.6.0",
     "nav-faker": "^3.2.4",
+    "nav-frontend-core": "^6.0.1",
     "nav-frontend-ikoner-assets": "^3.0.1",
     "nav-frontend-js-utils": "^1.0.20",
     "nav-frontend-knapper-style": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@navikt/ds-css": "^2.1.6",
     "@navikt/ds-icons": "^2.1.6",
     "@navikt/ds-react": "^2.1.6",
+    "@navikt/ds-tokens": "^2.8.4",
     "@navikt/fnrvalidator": "^1.3.3",
     "@portabletext/react": "^2.0.1",
     "@sanity/client": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "mustache-express": "^1.3.2",
     "nav-datovelger": "^12.6.0",
     "nav-faker": "^3.2.4",
-    "nav-frontend-core": "^6.0.1",
     "nav-frontend-ikoner-assets": "^3.0.1",
     "nav-frontend-js-utils": "^1.0.20",
     "nav-frontend-knapper-style": "^2.1.2",

--- a/src/assets/KalenderIkonSVG.tsx
+++ b/src/assets/KalenderIkonSVG.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import navFarger from 'nav-frontend-core';
+import { ABlue500 } from '@navikt/ds-tokens/dist/tokens';
 interface Props {
   height?: number;
   width?: number;
@@ -10,7 +10,7 @@ const KalenderIkonSVG: React.FC<Props> = ({ height, width }) => (
     height={height || 24}
     version="1.1"
     aria-labelledby="Kalender"
-    color={navFarger.navBla}
+    color={ABlue500}
     viewBox="0 0 18 18"
     role="presentation"
     focusable={false}

--- a/src/components/språkvelger/SpråkSelectMenu.tsx
+++ b/src/components/språkvelger/SpråkSelectMenu.tsx
@@ -6,7 +6,7 @@ import NorskFlaggSVG from '../../assets/NorskFlaggSVG';
 import { FC } from 'react';
 import styled from 'styled-components/macro';
 import { StyledTekst, SVGFlagg } from './Språkvelger';
-import navFarger from 'nav-frontend-core';
+import { AGray400, AOrange300 } from '@navikt/ds-tokens/dist/tokens';
 
 const StyledSpråkMeny = styled(Menu)`
   width: 100%;
@@ -26,12 +26,12 @@ const StyledListe = styled.ul`
 
   &:hover {
     outline: none;
-    box-shadow: 0 0 0 3px ${navFarger.navOransjeLighten40};
+    box-shadow: 0 0 0 3px ${AOrange300};
   }
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 3px ${navFarger.navOransjeLighten40};
+    box-shadow: 0 0 0 3px ${AOrange300};
   }
 
   ul {
@@ -59,19 +59,19 @@ const StyledMenuItem = styled(MenuItem)`
   padding: 0.5rem 1rem 0.5rem 1rem;
   outline: none;
   background-color: #ffffff;
-  border-bottom: 1px solid ${navFarger.navGra40};
-  border-left: 1px solid ${navFarger.navGra40};
-  border-right: 1px solid ${navFarger.navGra40};
+  border-bottom: 1px solid ${AGray400};
+  border-left: 1px solid ${AGray400};
+  border-right: 1px solid ${AGray400};
 
   &:hover {
     outline: none;
     cursor: pointer;
-    box-shadow: 0 0 0 3px ${navFarger.navOransjeLighten40};
+    box-shadow: 0 0 0 3px ${AOrange300};
   }
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 3px ${navFarger.navOransjeLighten40};
+    box-shadow: 0 0 0 3px ${AOrange300};
   }
 `;
 

--- a/src/components/språkvelger/Språkvelger.tsx
+++ b/src/components/språkvelger/Språkvelger.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/macro';
 import { SpråkSelectMenu } from './SpråkSelectMenu';
 import { Button as AriaButton, Wrapper } from 'react-aria-menubutton';
 import { useSpråkContext } from '../../context/SpråkContext';
-import navFarger from 'nav-frontend-core';
+import { AGray400, AOrange300 } from '@navikt/ds-tokens/dist/tokens';
 import {
   hentListeMedSpråk,
   hentListeMedSpråkUtenNynorsk,
@@ -24,7 +24,7 @@ const StyledSpråkvelger = styled.div`
 
 const StyledWrapper = styled(Wrapper)`
   width: 170px;
-  border: 3px solid ${navFarger.navGra40};
+  border: 3px solid ${AGray400};
   border-radius: 0.25rem;
   position: relative;
   outline: none;
@@ -39,7 +39,7 @@ const StyledButton = styled(AriaButton)`
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 3px ${navFarger.navOransjeLighten40};
+    box-shadow: 0 0 0 3px ${AOrange300};
     border-color: transparent;
   }
 `;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import './App.css';
 
 import '@navikt/ds-css';
+import 'nav-frontend-core';
 import './overgangsstønad/Forside.css';
 import './overgangsstønad/Søknadsdialog.css';
 import './components/feil/Feilside.css';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import './App.css';
 
 import '@navikt/ds-css';
-import 'nav-frontend-core';
+import 'nav-frontend-core'; // Må importeres fordi eldre nav-frontend komponenter avhenger av styling fra den
 import './overgangsstønad/Forside.css';
 import './overgangsstønad/Søknadsdialog.css';
 import './components/feil/Feilside.css';

--- a/src/language/LocaleTekst.tsx
+++ b/src/language/LocaleTekst.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { LocaleString } from '../models/felles/språk';
 import { useSpråkContext } from '../context/SpråkContext';
 import styled from 'styled-components/macro';
-import navFarger from 'nav-frontend-core';
+import { ABlue500 } from '@navikt/ds-tokens/dist/tokens';
 import FormattedHtmlMessage from './FormattedHtmlMessage';
 import FormattedMessage from './FormattedMessage';
 
@@ -13,7 +13,7 @@ interface Props {
 
 const StyledLocaleTekst = styled.div`
   a {
-    color: ${navFarger.navBla};
+    color: ${ABlue500};
   }
 `;
 


### PR DESCRIPTION
Ting ser "helt likt" ut som tidligere. Oransje og blåfargen som er tatt i bruk er akk samme fargekode. Fant ikke den grå, men er såpass lite forskjell på den nye og den tidligere at jeg ikke tror noen ser forskjell😅

`nav-frontend-core` kan ikke slettes fordi den påvirker veldig mye av css-en. La den derfor til i index.tsx så flere skal slippe å slette den ved en feil🙃