### PR TITLE
Barn som ikke er valgt i søknad fjernes ikke fra liste, men filtreres…

### DIFF
--- a/src/barnetilsyn/steg/6-barnepass/Barnepass.tsx
+++ b/src/barnetilsyn/steg/6-barnepass/Barnepass.tsx
@@ -79,7 +79,7 @@ const Barnepass: FC<Props> = () => {
   useMount(() => logSidevisningBarnetilsyn('Barnepass'));
 
   const settBarnepass = (barnepass: IBarnepass, barnid: string) => {
-    const endretBarn = barnSomSkalHaBarnepass.map((barn: IBarn) => {
+    const endretBarn = søknad.person.barn.map((barn: IBarn) => {
       if (barn.id === barnid) {
         return {
           ...barn,

--- a/src/søknad/steg/7-oppsummering/OppsummeringBarnaDine.tsx
+++ b/src/søknad/steg/7-oppsummering/OppsummeringBarnaDine.tsx
@@ -44,7 +44,7 @@ const OppsummeringBarnaDine: React.FC<Props> = ({
     }
     return nyttBarn;
   };
-  const oppsummeringBarnaDine = barnaDine.map((barn) => {
+  const oppsummeringBarnaDine = barnaDine.filter((barn) => barn.skalHaBarnepass?.verdi).map((barn) => {
     const endretBarn = hentEndretBarn(barn);
 
     return (


### PR DESCRIPTION
… bare ut i visningen i oppsummering. Backend får ansvaret for å filtrere vekk barn som det ikke søkes for.

Hvorfor gjøres dette?
Barn som ikke er valgt i barnetilsyn-søknaden blir borte fra søknaden i steget hvor valgte barn blir oppdatert. Konsekvensen av det er at når man kommer til oppsummering, og skal ende informasjon på barna, er det kun barn som er valgt som er synlig, og det er ingen mulighet til å legge til et av de andre barna. Dette skal nå bli fikset ved at lista med barn ikke oppdateres, og at backend skal filtrere vekk barn som ikke ble valgt i søknaden.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-9559)