### PR TITLE
Landvelger i søknad 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@navikt/ds-react": "^2.8.11",
         "@navikt/ds-tokens": "^2.8.11",
         "@navikt/fnrvalidator": "^1.3.3",
+        "@navikt/land-verktoy": "3.2.10",
         "@portabletext/react": "^2.0.2",
         "@sanity/client": "^4.0.1",
         "@sentry/browser": "^7.47.0",
@@ -3668,6 +3669,38 @@
       "integrity": "sha512-GsLa9ioYPGsDMBHcgKUNoYbZor09KyFIqSaWy8jy1I7f06q6DgUhdpZuRTHLVRCPjWqF2aLzKtvAfrw5dSeakg==",
       "license": "MIT"
     },
+    "node_modules/@navikt/hoykontrast": {
+      "version": "3.1.3",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/hoykontrast/3.1.3/43802c32f4977c987c0b25191741694ec1027fd8",
+      "integrity": "sha512-SymfAjW4K+gXTbMcP1rSeahkSlNM2K0l2np8U4Dkd3njKXD3AD53zW+zpVUiVyOmOCrpFbIPYUnbO3r8bqPIQQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "styled-components": "^5.3.5"
+      }
+    },
+    "node_modules/@navikt/land-verktoy": {
+      "version": "3.2.10",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/land-verktoy/3.2.10/e77121939d18b82cb96a4eca7f208e4a37d714b5",
+      "integrity": "sha512-NsWuQLO0FxpMH6ElOx+SU9szWA2aA1twxmhry6oUttItuY4t4tC7XKzBll0fVuB/+5Rmv8h50adcLjWPUywPZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@piotrgorecki/i18n-currency-name": "^1.3.0",
+        "country-data-list": "^1.2.2",
+        "i18n-iso-countries": "^7.5.0"
+      },
+      "peerDependencies": {
+        "@navikt/ds-css": "^1.x",
+        "@navikt/ds-icons": "^1.x",
+        "@navikt/ds-react": "^1.x",
+        "@navikt/hoykontrast": "^3.1.3",
+        "lodash": "^4.17.21",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -3707,6 +3740,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@piotrgorecki/i18n-currency-name": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@piotrgorecki/i18n-currency-name/-/i18n-currency-name-1.3.0.tgz",
+      "integrity": "sha512-Txbw0UmGgyvkZEFzjycmh7hEwYeRftILvx4G72PrMBHoS18PGnPODWbZvw7bi+KoV+buMezEHy8ezojc0f7YvQ=="
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.10",
@@ -7472,6 +7510,14 @@
         "typescript": ">=3"
       }
     },
+    "node_modules/country-data-list": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/country-data-list/-/country-data-list-1.2.3.tgz",
+      "integrity": "sha512-suiYKZupOpEc/Ly/fuy/EScHGnUcgnXmlimO6Tk+W5w9nXeY6TQmplQ66Pn3qNwp9jvCGAAc7XsctLuFXpp/iw==",
+      "dependencies": {
+        "currency-symbol-map": "~5"
+      }
+    },
     "node_modules/craco-less": {
       "version": "2.1.0-alpha.0",
       "resolved": "https://registry.npmjs.org/craco-less/-/craco-less-2.1.0-alpha.0.tgz",
@@ -7934,6 +7980,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
       "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
     },
+    "node_modules/currency-symbol-map": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/currency-symbol-map/-/currency-symbol-map-5.1.0.tgz",
+      "integrity": "sha512-LO/lzYRw134LMDVnLyAf1dHE5tyO6axEFkR3TXjQIOmMkAM9YL6QsiUwuXzZAmFnuDJcs4hayOgyIYtViXFrLw=="
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -8246,6 +8297,11 @@
       "resolved": "https://registry.npmjs.org/device-specs/-/device-specs-1.0.0.tgz",
       "integrity": "sha512-fYXbFSeilT7bnKWFi4OERSPHdtaEoDGn4aUhV5Nly6/I+Tp6JZ/6Icmd7LVIF5euyodGpxz2e/bfUmDnIdSIDw==",
       "dev": true
+    },
+    "node_modules/diacritics": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/diacritics/-/diacritics-1.3.0.tgz",
+      "integrity": "sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA=="
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -10967,6 +11023,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/i18n-iso-countries": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/i18n-iso-countries/-/i18n-iso-countries-7.6.0.tgz",
+      "integrity": "sha512-HPKjOUKS0BkjiY4ayrsuFbu7Ock++pXLs+FAOYl4WfTL5L0ploEH68fiRAP6Zev5g/jvMFt54KcPGJcb942wbg==",
+      "dependencies": {
+        "diacritics": "1.3.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/iconv-lite": {
@@ -28382,6 +28449,23 @@
       "resolved": "https://npm.pkg.github.com/download/@navikt/fnrvalidator/1.3.3/8414963a30e59e3056c9befea7bb022498a2a742",
       "integrity": "sha512-GsLa9ioYPGsDMBHcgKUNoYbZor09KyFIqSaWy8jy1I7f06q6DgUhdpZuRTHLVRCPjWqF2aLzKtvAfrw5dSeakg=="
     },
+    "@navikt/hoykontrast": {
+      "version": "3.1.3",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/hoykontrast/3.1.3/43802c32f4977c987c0b25191741694ec1027fd8",
+      "integrity": "sha512-SymfAjW4K+gXTbMcP1rSeahkSlNM2K0l2np8U4Dkd3njKXD3AD53zW+zpVUiVyOmOCrpFbIPYUnbO3r8bqPIQQ==",
+      "peer": true,
+      "requires": {}
+    },
+    "@navikt/land-verktoy": {
+      "version": "3.2.10",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/land-verktoy/3.2.10/e77121939d18b82cb96a4eca7f208e4a37d714b5",
+      "integrity": "sha512-NsWuQLO0FxpMH6ElOx+SU9szWA2aA1twxmhry6oUttItuY4t4tC7XKzBll0fVuB/+5Rmv8h50adcLjWPUywPZQ==",
+      "requires": {
+        "@piotrgorecki/i18n-currency-name": "^1.3.0",
+        "country-data-list": "^1.2.2",
+        "i18n-iso-countries": "^7.5.0"
+      }
+    },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -28412,6 +28496,11 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@piotrgorecki/i18n-currency-name": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@piotrgorecki/i18n-currency-name/-/i18n-currency-name-1.3.0.tgz",
+      "integrity": "sha512-Txbw0UmGgyvkZEFzjycmh7hEwYeRftILvx4G72PrMBHoS18PGnPODWbZvw7bi+KoV+buMezEHy8ezojc0f7YvQ=="
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.10",
@@ -31257,6 +31346,14 @@
         "ts-node": "^10.7.0"
       }
     },
+    "country-data-list": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/country-data-list/-/country-data-list-1.2.3.tgz",
+      "integrity": "sha512-suiYKZupOpEc/Ly/fuy/EScHGnUcgnXmlimO6Tk+W5w9nXeY6TQmplQ66Pn3qNwp9jvCGAAc7XsctLuFXpp/iw==",
+      "requires": {
+        "currency-symbol-map": "~5"
+      }
+    },
     "craco-less": {
       "version": "2.1.0-alpha.0",
       "resolved": "https://registry.npmjs.org/craco-less/-/craco-less-2.1.0-alpha.0.tgz",
@@ -31573,6 +31670,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
       "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
     },
+    "currency-symbol-map": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/currency-symbol-map/-/currency-symbol-map-5.1.0.tgz",
+      "integrity": "sha512-LO/lzYRw134LMDVnLyAf1dHE5tyO6axEFkR3TXjQIOmMkAM9YL6QsiUwuXzZAmFnuDJcs4hayOgyIYtViXFrLw=="
+    },
     "damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -31802,6 +31904,11 @@
       "resolved": "https://registry.npmjs.org/device-specs/-/device-specs-1.0.0.tgz",
       "integrity": "sha512-fYXbFSeilT7bnKWFi4OERSPHdtaEoDGn4aUhV5Nly6/I+Tp6JZ/6Icmd7LVIF5euyodGpxz2e/bfUmDnIdSIDw==",
       "dev": true
+    },
+    "diacritics": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/diacritics/-/diacritics-1.3.0.tgz",
+      "integrity": "sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA=="
     },
     "didyoumean": {
       "version": "1.2.2",
@@ -33832,6 +33939,14 @@
       "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
       "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true
+    },
+    "i18n-iso-countries": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/i18n-iso-countries/-/i18n-iso-countries-7.6.0.tgz",
+      "integrity": "sha512-HPKjOUKS0BkjiY4ayrsuFbu7Ock++pXLs+FAOYl4WfTL5L0ploEH68fiRAP6Zev5g/jvMFt54KcPGJcb942wbg==",
+      "requires": {
+        "diacritics": "1.3.0"
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@navikt/ds-react": "^2.8.11",
     "@navikt/ds-tokens": "^2.8.11",
     "@navikt/fnrvalidator": "^1.3.3",
+    "@navikt/land-verktoy": "3.2.10",
     "@portabletext/react": "^2.0.2",
     "@sanity/client": "^4.0.1",
     "@sentry/browser": "^7.47.0",
@@ -116,6 +117,11 @@
     "typescript": "^4.9.5"
   },
   "overrides": {
+    "@navikt/land-verktoy": {
+      "@navikt/ds-css": "^2.8.11",
+      "@navikt/ds-icons": "^2.8.11",
+      "@navikt/ds-react": "^2.8.11"
+    },
     "react-day-picker": {
       "react": "$react"
     },

--- a/src/components/dato/Datovelger.tsx
+++ b/src/components/dato/Datovelger.tsx
@@ -13,7 +13,7 @@ import { erDatoInnaforBegrensinger } from './utils';
 import { BodyShort, Label } from '@navikt/ds-react';
 
 export const StyledDatovelger = styled.div<{ fetSkrift?: boolean }>`
-  .navds-body-short {
+  .navds-label {
     font-weight: ${(props) => (props.fetSkrift ? 'bold' : 'normal')};
   }
 `;

--- a/src/components/dato/Datovelger.tsx
+++ b/src/components/dato/Datovelger.tsx
@@ -10,12 +10,10 @@ import styled from 'styled-components/macro';
 import { DatepickerLimitations } from 'nav-datovelger/lib/types';
 import Feilmelding from '../feil/Feilmelding';
 import { erDatoInnaforBegrensinger } from './utils';
-import { BodyShort, Label } from '@navikt/ds-react';
+import { Label } from '@navikt/ds-react';
 
-export const StyledDatovelger = styled.div<{ fetSkrift?: boolean }>`
-  .navds-label {
-    font-weight: ${(props) => (props.fetSkrift ? 'bold' : 'normal')};
-  }
+export const StyledLabel = styled(Label)<{ fetSkrift?: boolean }>`
+  font-weight: ${(props) => (props.fetSkrift ? 'bold' : 'normal')};
 `;
 
 const LabelWrapper = styled.div`
@@ -109,12 +107,12 @@ const Datovelger: React.FC<Props> = ({
   }, [_dato]);
 
   return (
-    <StyledDatovelger fetSkrift={fetSkrift}>
+    <div>
       <FeltGruppe>
         <LabelWrapper>
-          <Label htmlFor={datolabelid}>
+          <StyledLabel fetSkrift={fetSkrift} htmlFor={datolabelid}>
             <LocaleTekst tekst={tekstid} />
-          </Label>
+          </StyledLabel>
         </LabelWrapper>
         <Datepicker
           inputId={datolabelid}
@@ -136,7 +134,7 @@ const Datovelger: React.FC<Props> = ({
       {!gjemFeilmelding && _dato !== '' && feilmelding !== '' && (
         <Feilmelding tekstid={feilmelding} />
       )}
-    </StyledDatovelger>
+    </div>
   );
 };
 

--- a/src/components/dato/PeriodeDatovelger.tsx
+++ b/src/components/dato/PeriodeDatovelger.tsx
@@ -19,7 +19,6 @@ import { Label } from '@navikt/ds-react';
 const PeriodeGruppe = styled.div`
   display: grid;
   grid-template-columns: repeat(2, min-content);
-  grid-template-rows: repeat(2, min-content);
   grid-gap: 2rem;
 
   .feilmelding {
@@ -136,6 +135,7 @@ const PeriodeDatovelgere: FC<Props> = ({
           tekstid={fomTekstid ? fomTekstid : 'periode.fra'}
           datobegrensning={datobegrensning}
           gjemFeilmelding={true}
+          fetSkrift={false}
         />
 
         <Datovelger

--- a/src/components/dato/PeriodeDatovelger.tsx
+++ b/src/components/dato/PeriodeDatovelger.tsx
@@ -135,7 +135,6 @@ const PeriodeDatovelgere: FC<Props> = ({
           tekstid={fomTekstid ? fomTekstid : 'periode.fra'}
           datobegrensning={datobegrensning}
           gjemFeilmelding={true}
-          fetSkrift={false}
         />
 
         <Datovelger

--- a/src/components/dato/ÅrMånedvelger.tsx
+++ b/src/components/dato/ÅrMånedvelger.tsx
@@ -10,11 +10,10 @@ import FeltGruppe from '../gruppe/FeltGruppe';
 import LocaleTekst from '../../language/LocaleTekst';
 import { tilDato } from '../../utils/dato';
 import { hentUid } from '../../utils/autentiseringogvalidering/uuid';
-import { DatoBegrensning, StyledDatovelger } from './Datovelger';
+import { DatoBegrensning, StyledLabel } from './Datovelger';
 import styled from 'styled-components/macro';
 import KalenderKnapp from './KalenderKnapp';
 import { addYears, subYears, addMonths } from 'date-fns';
-import { BodyShort } from '@navikt/ds-react';
 
 const InputContainer = styled.div`
   display: inline-block;
@@ -93,13 +92,11 @@ const ÅrMånedVelger: React.FC<Props> = ({
   settLocaleForDatePicker();
 
   return (
-    <StyledDatovelger fetSkrift={fetSkrift}>
+    <div>
       <FeltGruppe>
-        <label htmlFor={datolabelid}>
-          <BodyShort>
-            <LocaleTekst tekst={tekstid} />
-          </BodyShort>
-        </label>
+        <StyledLabel fetSkrift={fetSkrift} htmlFor={datolabelid}>
+          <LocaleTekst tekst={tekstid} />
+        </StyledLabel>
       </FeltGruppe>
       <FeltGruppe classname="nav-datovelger">
         <InputContainer className="nav-datovelger__inputContainer">
@@ -148,7 +145,7 @@ const ÅrMånedVelger: React.FC<Props> = ({
           )}
         </InputContainer>
       </FeltGruppe>
-    </StyledDatovelger>
+    </div>
   );
 };
 

--- a/src/components/spørsmål/SelectSpørsmål.tsx
+++ b/src/components/spørsmål/SelectSpørsmål.tsx
@@ -55,10 +55,6 @@ const SelectSpørsmål: FC<Props> = ({
     }
   };
 
-  useEffect(() => {
-    console.log(valgtSvarId);
-  }, [valgtSvarId]);
-
   return (
     <SkjemaGruppe legend={legend}>
       <StyledSelect key={spørsmål.søknadid}>

--- a/src/components/spørsmål/SelectSpørsmål.tsx
+++ b/src/components/spørsmål/SelectSpørsmål.tsx
@@ -1,7 +1,7 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import { ISpørsmål, ISvar } from '../../models/felles/spørsmålogsvar';
 import LesMerTekst from '../LesMerTekst';
-import { SkjemaGruppe } from 'nav-frontend-skjema';
+import { Checkbox, SkjemaGruppe } from 'nav-frontend-skjema';
 import styled from 'styled-components/macro';
 import Show from '../../utils/showIf';
 import { logSpørsmålBesvart } from '../../utils/amplitude';
@@ -16,14 +16,14 @@ const StyledSelect = styled.div`
 interface Props {
   spørsmål: ISpørsmål;
   settSpørsmålOgSvar: (spørsmål: ISpørsmål, svar: ISvar) => void;
-  valgtSvar: string | undefined;
+  valgtSvarId: string | undefined;
   skalLogges?: boolean;
 }
 
 const SelectSpørsmål: FC<Props> = ({
   spørsmål,
   settSpørsmålOgSvar,
-  valgtSvar,
+  valgtSvarId,
   skalLogges = true,
 }) => {
   const intl = useLokalIntlContext();
@@ -55,6 +55,10 @@ const SelectSpørsmål: FC<Props> = ({
     }
   };
 
+  useEffect(() => {
+    console.log(valgtSvarId);
+  }, [valgtSvarId]);
+
   return (
     <SkjemaGruppe legend={legend}>
       <StyledSelect key={spørsmål.søknadid}>
@@ -70,7 +74,7 @@ const SelectSpørsmål: FC<Props> = ({
           label={legend}
           hideLabel
           onChange={(e) => håndterSelectChange(e.target.value)} // Logg spørsmål
-          value={valgtSvar}
+          value={valgtSvarId}
         >
           <option value="" disabled selected>
             Velg et alternativ

--- a/src/components/spørsmål/SelectSpørsmål.tsx
+++ b/src/components/spørsmål/SelectSpørsmål.tsx
@@ -17,16 +17,16 @@ interface Props {
   spørsmål: ISpørsmål;
   settSpørsmålOgSvar: (spørsmål: ISpørsmål, svar: ISvar) => void;
   valgtSvar: string | undefined;
+  skalLogges?: boolean;
 }
 
 const SelectSpørsmål: FC<Props> = ({
   spørsmål,
   settSpørsmålOgSvar,
   valgtSvar,
+  skalLogges = true,
 }) => {
   const intl = useLokalIntlContext();
-
-  const skalLogges = true;
 
   const url = window.location.href;
 
@@ -41,13 +41,15 @@ const SelectSpørsmål: FC<Props> = ({
     );
 
     if (svar !== undefined) {
-      logSpørsmålBesvart(
-        skjemanavn,
-        skjemaId,
-        legend,
-        svar.svar_tekst,
-        skalLogges
-      );
+      if (skalLogges) {
+        logSpørsmålBesvart(
+          skjemanavn,
+          skjemaId,
+          legend,
+          svar.svar_tekst,
+          skalLogges
+        );
+      }
 
       settSpørsmålOgSvar(spørsmål, svar);
     }

--- a/src/components/spørsmål/SelectSpørsmål.tsx
+++ b/src/components/spørsmål/SelectSpørsmål.tsx
@@ -1,0 +1,87 @@
+import React, { FC } from 'react';
+import { ISpørsmål, ISvar } from '../../models/felles/spørsmålogsvar';
+import LesMerTekst from '../LesMerTekst';
+import { SkjemaGruppe } from 'nav-frontend-skjema';
+import styled from 'styled-components/macro';
+import Show from '../../utils/showIf';
+import { logSpørsmålBesvart } from '../../utils/amplitude';
+import { skjemanavnTilId, urlTilSkjemanavn } from '../../utils/skjemanavn';
+import { useLokalIntlContext } from '../../context/LokalIntlContext';
+import { Select } from '@navikt/ds-react';
+
+const StyledSelect = styled.div`
+  padding-top: 1rem;
+`;
+
+interface Props {
+  spørsmål: ISpørsmål;
+  settSpørsmålOgSvar: (spørsmål: ISpørsmål, svar: ISvar) => void;
+  valgtSvar: string | undefined;
+}
+
+const SelectSpørsmål: FC<Props> = ({
+  spørsmål,
+  settSpørsmålOgSvar,
+  valgtSvar,
+}) => {
+  const intl = useLokalIntlContext();
+
+  const skalLogges = true;
+
+  const url = window.location.href;
+
+  const skjemanavn = urlTilSkjemanavn(url);
+  const skjemaId = skjemanavnTilId(skjemanavn);
+
+  const legend = intl.formatMessage({ id: spørsmål.tekstid });
+
+  const håndterSelectChange = (valgtVerdi: string) => {
+    const svar = spørsmål.svaralternativer.find(
+      (svar) => svar.id === valgtVerdi
+    );
+
+    if (svar !== undefined) {
+      logSpørsmålBesvart(
+        skjemanavn,
+        skjemaId,
+        legend,
+        svar.svar_tekst,
+        skalLogges
+      );
+
+      settSpørsmålOgSvar(spørsmål, svar);
+    }
+  };
+
+  return (
+    <SkjemaGruppe legend={legend}>
+      <StyledSelect key={spørsmål.søknadid}>
+        <Show if={spørsmål.lesmer}>
+          <LesMerTekst
+            åpneTekstid={spørsmål.lesmer ? spørsmål.lesmer.headerTekstid : ''}
+            innholdTekstid={
+              spørsmål.lesmer ? spørsmål!.lesmer!.innholdTekstid : ''
+            }
+          />
+        </Show>
+        <Select
+          label={legend}
+          hideLabel
+          onChange={(e) => håndterSelectChange(e.target.value)} // Logg spørsmål
+          value={valgtSvar}
+        >
+          <option value="" disabled selected>
+            Velg et alternativ
+          </option>
+          {spørsmål.svaralternativer.map((svar: ISvar) => (
+            <option key={svar.id} value={svar.id}>
+              {svar.svar_tekst}
+            </option>
+          ))}
+        </Select>
+      </StyledSelect>
+    </SkjemaGruppe>
+  );
+};
+
+export default SelectSpørsmål;

--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -179,6 +179,7 @@ export default {
     'Where are you and the child/children currently present?',
   'medlemskap.spm.bosatt': 'Have you lived in Norway for the past five years?',
   'medlemskap.periodeBoddIUtlandet.utenlandsopphold': 'Period spent abroad ',
+  'medlemskap.periodeBoddIUtlandet.land': 'In what country where you staying?',
   'medlemskap.periodeBoddIUtlandet.slett': 'Remove period spent abroad',
   'medlemskap.periodeBoddIUtlandet': 'When did you live overseas?',
   'medlemskap.periodeBoddIUtlandet.begrunnelse': 'Why did you live overseas?',

--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -175,6 +175,8 @@ export default {
     'We ask about this to work out what information we need from you.',
   'medlemskap.spm.opphold':
     'Are you and the child/children currently present in Norway?',
+  'medlemskap.spm.oppholdsland':
+    'Where are you and the child/children currently present?',
   'medlemskap.spm.bosatt': 'Have you lived in Norway for the past five years?',
   'medlemskap.periodeBoddIUtlandet.utenlandsopphold': 'Period spent abroad ',
   'medlemskap.periodeBoddIUtlandet.slett': 'Remove period spent abroad',

--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -176,7 +176,7 @@ export default {
   'medlemskap.spm.opphold':
     'Are you and the child/children currently present in Norway?',
   'medlemskap.spm.oppholdsland':
-    'Where are you and the child/children currently present?',
+    'Where are you and your child/children currently present?',
   'medlemskap.spm.bosatt': 'Have you lived in Norway for the past five years?',
   'medlemskap.periodeBoddIUtlandet.utenlandsopphold': 'Period spent abroad ',
   'medlemskap.periodeBoddIUtlandet.land': 'In what country where you staying?',

--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -179,7 +179,7 @@ export default {
     'Where are you and your child/children currently present?',
   'medlemskap.spm.bosatt': 'Have you lived in Norway for the past five years?',
   'medlemskap.periodeBoddIUtlandet.utenlandsopphold': 'Period spent abroad ',
-  'medlemskap.periodeBoddIUtlandet.land': 'In what country where you staying?',
+  'medlemskap.periodeBoddIUtlandet.land': 'In what country were you staying?',
   'medlemskap.periodeBoddIUtlandet.slett': 'Remove period spent abroad',
   'medlemskap.periodeBoddIUtlandet': 'When did you live overseas?',
   'medlemskap.periodeBoddIUtlandet.begrunnelse': 'Why did you live overseas?',

--- a/src/language/tekster_nb.ts
+++ b/src/language/tekster_nb.ts
@@ -171,6 +171,7 @@ export default {
   'sivilstatus.hjelpetekst-innhold.begrunnelse':
     'Vi spør om dette for å vite hvilken informasjon vi trenger fra deg.',
   'medlemskap.spm.opphold': 'Oppholder du og barnet/barna dere i Norge?',
+  'medlemskap.spm.oppholdsland': 'Hvor oppholder du og barnet/barna dere?',
   'medlemskap.spm.bosatt': 'Har du oppholdt deg i Norge de siste 5 årene?',
   'medlemskap.periodeBoddIUtlandet.utenlandsopphold': 'Utenlandsperiode',
   'medlemskap.periodeBoddIUtlandet.slett': 'Fjern utenlandsperiode',

--- a/src/language/tekster_nb.ts
+++ b/src/language/tekster_nb.ts
@@ -176,6 +176,7 @@ export default {
   'medlemskap.periodeBoddIUtlandet.utenlandsopphold': 'Utenlandsperiode',
   'medlemskap.periodeBoddIUtlandet.slett': 'Fjern utenlandsperiode',
   'medlemskap.periodeBoddIUtlandet': 'Når oppholdt du deg i utlandet?',
+  'medlemskap.periodeBoddIUtlandet.land': 'I hvilket land oppholdt du deg i?',
   'medlemskap.periodeBoddIUtlandet.begrunnelse':
     'Hvorfor oppholdt du deg i utlandet?',
   'medlemskap.periodeBoddIUtlandet.flereutenlandsopphold':

--- a/src/language/tekster_nn.ts
+++ b/src/language/tekster_nn.ts
@@ -257,7 +257,7 @@ export default {
 
   // --- MEDLEMSKAP
   'medlemskap.spm.opphold': 'Oppheld du deg i Noreg?',
-  'medlemskap.spm.oppholdsland': 'Kvar oppheld du og barnet/barna de?',
+  'medlemskap.spm.oppholdsland': 'Kvar oppheld du og barnet/barna dokker?',
   'medlemskap.spm.bosatt': 'Have you lived in Norway for the past five years?',
 
   'medlemskap.periodeBoddIUtlandet.utenlandsopphold': 'Period spent abroad ',

--- a/src/language/tekster_nn.ts
+++ b/src/language/tekster_nn.ts
@@ -257,6 +257,7 @@ export default {
 
   // --- MEDLEMSKAP
   'medlemskap.spm.opphold': 'Oppheld du deg i Noreg?',
+  'medlemskap.spm.oppholdsland': 'Kvar oppheld du og barnet/barna de?',
   'medlemskap.spm.bosatt': 'Have you lived in Norway for the past five years?',
 
   'medlemskap.periodeBoddIUtlandet.utenlandsopphold': 'Period spent abroad ',

--- a/src/language/tekster_nn.ts
+++ b/src/language/tekster_nn.ts
@@ -264,6 +264,7 @@ export default {
 
   'medlemskap.periodeBoddIUtlandet.slett': 'Remove period spent abroad',
   'medlemskap.periodeBoddIUtlandet': 'When did you live overseas?',
+  'medlemskap.periodeBoddIUtlandet.land': 'I hvilket land oppholdt du deg i?',
   'medlemskap.periodeBoddIUtlandet.begrunnelse': 'Why did you live overseas?',
   'medlemskap.periodeBoddIUtlandet.flereutenlandsopphold':
     'Have you spent more periods abroad during the last five years?',

--- a/src/models/steg/omDeg/medlemskap.ts
+++ b/src/models/steg/omDeg/medlemskap.ts
@@ -3,6 +3,7 @@ import { IPeriode } from '../../felles/periode';
 
 export interface IMedlemskap {
   søkerOppholderSegINorge?: IBooleanFelt;
+  oppholdsland?: string;
   søkerBosattINorgeSisteTreÅr?: IBooleanFelt;
   perioderBoddIUtlandet?: IUtenlandsopphold[];
 }
@@ -15,6 +16,7 @@ export interface IUtenlandsopphold {
 
 export enum EMedlemskap {
   søkerOppholderSegINorge = 'søkerOppholderSegINorge',
+  oppholdsland = 'oppholdsland',
   søkerBosattINorgeSisteTreÅr = 'søkerBosattINorgeSisteTreÅr',
   perioderBoddIUtlandet = 'perioderBoddIUtlandet',
 }

--- a/src/models/steg/omDeg/medlemskap.ts
+++ b/src/models/steg/omDeg/medlemskap.ts
@@ -28,6 +28,6 @@ export enum EMedlemskap {
 }
 
 export interface ILandMedKode {
-  landkode: string;
-  label: string;
+  id: string; // Bruker Alpha3 landkode som id
+  svar_tekst: string;
 }

--- a/src/models/steg/omDeg/medlemskap.ts
+++ b/src/models/steg/omDeg/medlemskap.ts
@@ -1,13 +1,13 @@
 import {
   IBooleanFelt,
-  ISelectFelt,
+  ISpørsmålFelt,
   ITekstFelt,
 } from '../../søknad/søknadsfelter';
 import { IPeriode } from '../../felles/periode';
 
 export interface IMedlemskap {
   søkerOppholderSegINorge?: IBooleanFelt;
-  oppholdsland?: ISelectFelt;
+  oppholdsland?: ISpørsmålFelt;
   søkerBosattINorgeSisteTreÅr?: IBooleanFelt;
   perioderBoddIUtlandet?: IUtenlandsopphold[];
 }
@@ -15,7 +15,7 @@ export interface IMedlemskap {
 export interface IUtenlandsopphold {
   id: string;
   periode: IPeriode;
-  land?: ISelectFelt;
+  land?: ISpørsmålFelt;
   begrunnelse: ITekstFelt;
 }
 

--- a/src/models/steg/omDeg/medlemskap.ts
+++ b/src/models/steg/omDeg/medlemskap.ts
@@ -1,9 +1,13 @@
-import { IBooleanFelt, ITekstFelt } from '../../søknad/søknadsfelter';
+import {
+  IBooleanFelt,
+  ISelectFelt,
+  ITekstFelt,
+} from '../../søknad/søknadsfelter';
 import { IPeriode } from '../../felles/periode';
 
 export interface IMedlemskap {
   søkerOppholderSegINorge?: IBooleanFelt;
-  oppholdsland?: string;
+  oppholdsland?: ISelectFelt;
   søkerBosattINorgeSisteTreÅr?: IBooleanFelt;
   perioderBoddIUtlandet?: IUtenlandsopphold[];
 }
@@ -11,6 +15,7 @@ export interface IMedlemskap {
 export interface IUtenlandsopphold {
   id: string;
   periode: IPeriode;
+  land?: ISelectFelt;
   begrunnelse: ITekstFelt;
 }
 
@@ -19,4 +24,5 @@ export enum EMedlemskap {
   oppholdsland = 'oppholdsland',
   søkerBosattINorgeSisteTreÅr = 'søkerBosattINorgeSisteTreÅr',
   perioderBoddIUtlandet = 'perioderBoddIUtlandet',
+  utenlandsoppholdLand = 'utenlandsoppholdLand',
 }

--- a/src/models/steg/omDeg/medlemskap.ts
+++ b/src/models/steg/omDeg/medlemskap.ts
@@ -26,3 +26,8 @@ export enum EMedlemskap {
   perioderBoddIUtlandet = 'perioderBoddIUtlandet',
   utenlandsoppholdLand = 'utenlandsoppholdLand',
 }
+
+export interface ILandMedKode {
+  landkode: string;
+  label: string;
+}

--- a/src/models/søknad/søknadsfelter.ts
+++ b/src/models/søknad/søknadsfelter.ts
@@ -18,11 +18,6 @@ export interface ITekstListeFelt {
   verdi: string[];
 }
 
-export interface ISelectFelt {
-  label: string;
-  verdi: string;
-}
-
 export interface ISpørsmålFelt extends ITekstFelt {
   spørsmålid: string;
   svarid: string;

--- a/src/models/søknad/søknadsfelter.ts
+++ b/src/models/søknad/søknadsfelter.ts
@@ -18,6 +18,11 @@ export interface ITekstListeFelt {
   verdi: string[];
 }
 
+export interface ISelectFelt {
+  label: string;
+  verdi: string;
+}
+
 export interface ISpørsmålFelt extends ITekstFelt {
   spørsmålid: string;
   svarid: string;

--- a/src/søknad/steg/1-omdeg/medlemskap/Medlemskap.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/Medlemskap.tsx
@@ -73,8 +73,6 @@ const Medlemskap: React.FC<Props> = ({ medlemskap, settMedlemskap }) => {
   };
 
   const settOppholdsland = (spørsmål: ISpørsmål, valgtSvar: ISvar) => {
-    console.log('Valgt oppholdsland: ', valgtSvar);
-
     const svar = valgtSvar.svar_tekst;
     const endretMedlemskap = medlemskap;
 

--- a/src/søknad/steg/1-omdeg/medlemskap/Medlemskap.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/Medlemskap.tsx
@@ -123,24 +123,26 @@ const Medlemskap: React.FC<Props> = ({ medlemskap, settMedlemskap }) => {
 
       {(søkerOppholderSegINorge?.verdi === true ||
         oppholdsland?.hasOwnProperty('verdi')) && (
-        <KomponentGruppe key={bosattINorgeDeSisteTreÅrConfig.søknadid}>
-          <JaNeiSpørsmål
-            spørsmål={bosattINorgeDeSisteTreÅrConfig}
-            valgtSvar={hentValgtSvar(
-              bosattINorgeDeSisteTreÅrConfig,
-              medlemskap
-            )}
-            onChange={settMedlemskapBooleanFelt}
-          />
-        </KomponentGruppe>
-      )}
+        <>
+          <KomponentGruppe key={bosattINorgeDeSisteTreÅrConfig.søknadid}>
+            <JaNeiSpørsmål
+              spørsmål={bosattINorgeDeSisteTreÅrConfig}
+              valgtSvar={hentValgtSvar(
+                bosattINorgeDeSisteTreÅrConfig,
+                medlemskap
+              )}
+              onChange={settMedlemskapBooleanFelt}
+            />
+          </KomponentGruppe>
 
-      {søkerBosattINorgeSisteTreÅr?.verdi === false && (
-        <PeriodeBoddIUtlandet
-          medlemskap={medlemskap}
-          settMedlemskap={settMedlemskap}
-          land={land}
-        />
+          {søkerBosattINorgeSisteTreÅr?.verdi === false && (
+            <PeriodeBoddIUtlandet
+              medlemskap={medlemskap}
+              settMedlemskap={settMedlemskap}
+              land={land}
+            />
+          )}
+        </>
       )}
     </SeksjonGruppe>
   );

--- a/src/søknad/steg/1-omdeg/medlemskap/Medlemskap.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/Medlemskap.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
   ESvar,
   ISpørsmål,
@@ -18,9 +18,7 @@ import {
   IMedlemskap,
 } from '../../../../models/steg/omDeg/medlemskap';
 import { hentBooleanFraValgtSvar } from '../../../../utils/spørsmålogsvar';
-import LocaleTekst from '../../../../language/LocaleTekst';
 import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
-import { Alert } from '@navikt/ds-react';
 import SelectSpørsmål from '../../../../components/spørsmål/SelectSpørsmål';
 
 interface Props {
@@ -36,14 +34,9 @@ const Medlemskap: React.FC<Props> = ({ medlemskap, settMedlemskap }) => {
   } = medlemskap;
 
   const oppholderSegINorgeConfig = oppholderSegINorge(intl);
-  const oppholdslandConfig = søkersOppholdsland([
-    'Norge',
-    'Sverige',
-    'Danmark',
-    'Tyskland',
-    'Spania',
-    'USA',
-  ]);
+
+  const land = ['Norge', 'Sverige', 'Danmark', 'Tyskland', 'Spania', 'USA'];
+  const oppholdslandConfig = søkersOppholdsland(land);
   const bosattINorgeDeSisteTreÅrConfig = bosattINorgeDeSisteTreÅr(intl);
 
   const settMedlemskapBooleanFelt = (spørsmål: ISpørsmål, valgtSvar: ISvar) => {
@@ -78,7 +71,7 @@ const Medlemskap: React.FC<Props> = ({ medlemskap, settMedlemskap }) => {
   const settOppholdsland = (spørsmål: ISpørsmål, valgtSvar: ISvar) => {
     console.log('Valgt oppholdsland: ', valgtSvar);
 
-    const svar = valgtSvar.id;
+    const svar = valgtSvar.svar_tekst;
     const endretMedlemskap = medlemskap;
 
     settMedlemskap({
@@ -104,14 +97,6 @@ const Medlemskap: React.FC<Props> = ({ medlemskap, settMedlemskap }) => {
   );
 
   const valgtSvarOppholdsland = hentValgtSvar(oppholdslandConfig, medlemskap);
-
-  useEffect(() => {
-    console.log('Oppholdsland: ', oppholdsland);
-  }, [oppholdsland]);
-
-  useEffect(() => {
-    console.log('Medlemskap: ', medlemskap);
-  }, [medlemskap]);
 
   return (
     <SeksjonGruppe aria-live="polite">
@@ -151,6 +136,7 @@ const Medlemskap: React.FC<Props> = ({ medlemskap, settMedlemskap }) => {
         <PeriodeBoddIUtlandet
           medlemskap={medlemskap}
           settMedlemskap={settMedlemskap}
+          land={land}
         />
       )}
     </SeksjonGruppe>

--- a/src/søknad/steg/1-omdeg/medlemskap/Medlemskap.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/Medlemskap.tsx
@@ -8,6 +8,7 @@ import {
   oppholderSegINorge,
   bosattINorgeDeSisteTreÅr,
   søkersOppholdsland,
+  hentLand,
 } from './MedlemskapConfig';
 import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
 import JaNeiSpørsmål from '../../../../components/spørsmål/JaNeiSpørsmål';
@@ -20,6 +21,7 @@ import {
 import { hentBooleanFraValgtSvar } from '../../../../utils/spørsmålogsvar';
 import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
 import SelectSpørsmål from '../../../../components/spørsmål/SelectSpørsmål';
+import { useSpråkContext } from '../../../../context/SpråkContext';
 
 interface Props {
   medlemskap: IMedlemskap;
@@ -35,8 +37,10 @@ const Medlemskap: React.FC<Props> = ({ medlemskap, settMedlemskap }) => {
 
   const oppholderSegINorgeConfig = oppholderSegINorge(intl);
 
-  const land = ['Norge', 'Sverige', 'Danmark', 'Tyskland', 'Spania', 'USA'];
+  const [locale] = useSpråkContext();
+  const land = hentLand(locale);
   const oppholdslandConfig = søkersOppholdsland(land);
+
   const bosattINorgeDeSisteTreÅrConfig = bosattINorgeDeSisteTreÅr(intl);
 
   const settMedlemskapBooleanFelt = (spørsmål: ISpørsmål, valgtSvar: ISvar) => {

--- a/src/søknad/steg/1-omdeg/medlemskap/Medlemskap.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/Medlemskap.tsx
@@ -73,14 +73,15 @@ const Medlemskap: React.FC<Props> = ({ medlemskap, settMedlemskap }) => {
   };
 
   const settOppholdsland = (spørsmål: ISpørsmål, valgtSvar: ISvar) => {
-    const svar = valgtSvar.svar_tekst;
     const endretMedlemskap = medlemskap;
 
     settMedlemskap({
       ...endretMedlemskap,
-      [spørsmål.søknadid]: {
+      oppholdsland: {
+        spørsmålid: spørsmål.søknadid,
+        svarid: valgtSvar.id,
         label: intl.formatMessage({ id: spørsmål.tekstid }),
-        verdi: svar,
+        verdi: valgtSvar.svar_tekst,
       },
     });
   };

--- a/src/søknad/steg/1-omdeg/medlemskap/Medlemskap.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/Medlemskap.tsx
@@ -99,8 +99,6 @@ const Medlemskap: React.FC<Props> = ({ medlemskap, settMedlemskap }) => {
     medlemskap
   );
 
-  const valgtSvarOppholdsland = hentValgtSvar(oppholdslandConfig, medlemskap);
-
   return (
     <SeksjonGruppe aria-live="polite">
       <KomponentGruppe key={oppholderSegINorgeConfig.søknadid}>
@@ -115,7 +113,7 @@ const Medlemskap: React.FC<Props> = ({ medlemskap, settMedlemskap }) => {
         <KomponentGruppe>
           <SelectSpørsmål
             spørsmål={oppholdslandConfig}
-            valgtSvar={valgtSvarOppholdsland}
+            valgtSvarId={medlemskap.oppholdsland?.svarid}
             settSpørsmålOgSvar={settOppholdsland}
           />
         </KomponentGruppe>

--- a/src/søknad/steg/1-omdeg/medlemskap/MedlemskapConfig.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/MedlemskapConfig.tsx
@@ -11,6 +11,17 @@ export const oppholderSegINorge = (intl: LokalIntlShape): ISpørsmål => ({
   svaralternativer: JaNeiSvar(intl),
 });
 
+export const søkersOppholdsland = (hierarki: string[]): ISpørsmål => ({
+  søknadid: EMedlemskap.oppholdsland,
+  tekstid: 'medlemskap.spm.oppholdsland',
+  flersvar: false,
+
+  svaralternativer: hierarki.map((land) => ({
+    id: land,
+    svar_tekst: land,
+  })),
+});
+
 export const bosattINorgeDeSisteTreÅr = (intl: LokalIntlShape): ISpørsmål => ({
   søknadid: EMedlemskap.søkerBosattINorgeSisteTreÅr,
   tekstid: 'medlemskap.spm.bosatt',

--- a/src/søknad/steg/1-omdeg/medlemskap/MedlemskapConfig.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/MedlemskapConfig.tsx
@@ -47,9 +47,9 @@ export const utenlandsoppholdLand = (land: ILandMedKode[]): ISpørsmål => ({
 
 export const hentLand = (språk: LocaleType): ILandMedKode[] => {
   const land = CountryData.getCountryInstance(språk).countries;
-  return land.map((land: { value: string; label: string }) => {
+  return land.map((land: { alpha3: string; label: string }) => {
     return {
-      landkode: land.value,
+      landkode: land.alpha3,
       label: land.label,
     };
   });

--- a/src/søknad/steg/1-omdeg/medlemskap/MedlemskapConfig.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/MedlemskapConfig.tsx
@@ -29,3 +29,14 @@ export const bosattINorgeDeSisteTreÅr = (intl: LokalIntlShape): ISpørsmål => 
 
   svaralternativer: JaNeiSvar(intl),
 });
+
+export const utenlandsoppholdLand = (hierarki: string[]): ISpørsmål => ({
+  søknadid: EMedlemskap.utenlandsoppholdLand,
+  tekstid: 'medlemskap.periodeBoddIUtlandet.land',
+  flersvar: false,
+
+  svaralternativer: hierarki.map((land) => ({
+    id: land,
+    svar_tekst: land,
+  })),
+});

--- a/src/søknad/steg/1-omdeg/medlemskap/MedlemskapConfig.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/MedlemskapConfig.tsx
@@ -19,11 +19,7 @@ export const søkersOppholdsland = (land: ILandMedKode[]): ISpørsmål => ({
   søknadid: EMedlemskap.oppholdsland,
   tekstid: 'medlemskap.spm.oppholdsland',
   flersvar: false,
-
-  svaralternativer: land.map((land) => ({
-    id: land.landkode,
-    svar_tekst: land.label,
-  })),
+  svaralternativer: land,
 });
 
 export const bosattINorgeDeSisteTreÅr = (intl: LokalIntlShape): ISpørsmål => ({
@@ -38,19 +34,15 @@ export const utenlandsoppholdLand = (land: ILandMedKode[]): ISpørsmål => ({
   søknadid: EMedlemskap.utenlandsoppholdLand,
   tekstid: 'medlemskap.periodeBoddIUtlandet.land',
   flersvar: false,
-
-  svaralternativer: land.map((land) => ({
-    id: land.landkode,
-    svar_tekst: land.label,
-  })),
+  svaralternativer: land,
 });
 
 export const hentLand = (språk: LocaleType): ILandMedKode[] => {
   const land = CountryData.getCountryInstance(språk).countries;
   return land.map((land: { alpha3: string; label: string }) => {
     return {
-      landkode: land.alpha3,
-      label: land.label,
+      id: land.alpha3,
+      svar_tekst: land.label,
     };
   });
 };

--- a/src/søknad/steg/1-omdeg/medlemskap/MedlemskapConfig.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/MedlemskapConfig.tsx
@@ -5,7 +5,7 @@ import {
   ILandMedKode,
 } from '../../../../models/steg/omDeg/medlemskap';
 import { LocaleType, LokalIntlShape } from '../../../../language/typer';
-import CountryData from '@navikt/land-verktoy';
+import CountryData, { Countries, CountryFilter } from '@navikt/land-verktoy';
 
 export const oppholderSegINorge = (intl: LokalIntlShape): ISpørsmål => ({
   søknadid: EMedlemskap.søkerOppholderSegINorge,
@@ -38,11 +38,16 @@ export const utenlandsoppholdLand = (land: ILandMedKode[]): ISpørsmål => ({
 });
 
 export const hentLand = (språk: LocaleType): ILandMedKode[] => {
-  const land = CountryData.getCountryInstance(språk).countries;
-  return land.map((land: { alpha3: string; label: string }) => {
-    return {
-      id: land.alpha3,
-      svar_tekst: land.label,
-    };
-  });
+  const landFilter = CountryFilter.STANDARD({});
+  const filtrertLandliste: Countries =
+    CountryData.getCountryInstance(språk).filterByValueOnArray(landFilter);
+
+  return filtrertLandliste
+    .map((land: { alpha3: string; label: string }) => {
+      return {
+        id: land.alpha3,
+        svar_tekst: land.label,
+      };
+    })
+    .sort((a, b) => a.svar_tekst.localeCompare(b.svar_tekst));
 };

--- a/src/søknad/steg/1-omdeg/medlemskap/MedlemskapConfig.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/MedlemskapConfig.tsx
@@ -1,7 +1,11 @@
 import { ISpørsmål } from '../../../../models/felles/spørsmålogsvar';
 import { JaNeiSvar } from '../../../../helpers/svar';
-import { EMedlemskap } from '../../../../models/steg/omDeg/medlemskap';
-import { LokalIntlShape } from '../../../../language/typer';
+import {
+  EMedlemskap,
+  ILandMedKode,
+} from '../../../../models/steg/omDeg/medlemskap';
+import { LocaleType, LokalIntlShape } from '../../../../language/typer';
+import CountryData from '@navikt/land-verktoy';
 
 export const oppholderSegINorge = (intl: LokalIntlShape): ISpørsmål => ({
   søknadid: EMedlemskap.søkerOppholderSegINorge,
@@ -11,14 +15,14 @@ export const oppholderSegINorge = (intl: LokalIntlShape): ISpørsmål => ({
   svaralternativer: JaNeiSvar(intl),
 });
 
-export const søkersOppholdsland = (hierarki: string[]): ISpørsmål => ({
+export const søkersOppholdsland = (land: ILandMedKode[]): ISpørsmål => ({
   søknadid: EMedlemskap.oppholdsland,
   tekstid: 'medlemskap.spm.oppholdsland',
   flersvar: false,
 
-  svaralternativer: hierarki.map((land) => ({
-    id: land,
-    svar_tekst: land,
+  svaralternativer: land.map((land) => ({
+    id: land.landkode,
+    svar_tekst: land.label,
   })),
 });
 
@@ -30,13 +34,23 @@ export const bosattINorgeDeSisteTreÅr = (intl: LokalIntlShape): ISpørsmål => 
   svaralternativer: JaNeiSvar(intl),
 });
 
-export const utenlandsoppholdLand = (hierarki: string[]): ISpørsmål => ({
+export const utenlandsoppholdLand = (land: ILandMedKode[]): ISpørsmål => ({
   søknadid: EMedlemskap.utenlandsoppholdLand,
   tekstid: 'medlemskap.periodeBoddIUtlandet.land',
   flersvar: false,
 
-  svaralternativer: hierarki.map((land) => ({
-    id: land,
-    svar_tekst: land,
+  svaralternativer: land.map((land) => ({
+    id: land.landkode,
+    svar_tekst: land.label,
   })),
 });
+
+export const hentLand = (språk: LocaleType): ILandMedKode[] => {
+  const land = CountryData.getCountryInstance(språk).countries;
+  return land.map((land: { value: string; label: string }) => {
+    return {
+      landkode: land.value,
+      label: land.label,
+    };
+  });
+};

--- a/src/søknad/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.tsx
@@ -18,7 +18,8 @@ import { Label } from '@navikt/ds-react';
 const PeriodeBoddIUtlandet: FC<{
   medlemskap: IMedlemskap;
   settMedlemskap: (medlemskap: IMedlemskap) => void;
-}> = ({ medlemskap, settMedlemskap }) => {
+  land: string[];
+}> = ({ medlemskap, settMedlemskap, land }) => {
   const intl = useLokalIntlContext();
   const tomtUtenlandsopphold: IUtenlandsopphold = {
     id: hentUid(),
@@ -68,6 +69,7 @@ const PeriodeBoddIUtlandet: FC<{
               perioderBoddIUtlandet={perioderBoddIUtlandet}
               utenlandsopphold={periode}
               oppholdsnr={index}
+              land={land}
             />
           </KomponentGruppe>
         );

--- a/src/søknad/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.tsx
@@ -7,6 +7,7 @@ import Utenlandsopphold from './Utenlandsopphold';
 import { hentTekst } from '../../../../utils/søknad';
 import { hentUid } from '../../../../utils/autentiseringogvalidering/uuid';
 import {
+  ILandMedKode,
   IMedlemskap,
   IUtenlandsopphold,
 } from '../../../../models/steg/omDeg/medlemskap';
@@ -18,7 +19,7 @@ import { Label } from '@navikt/ds-react';
 const PeriodeBoddIUtlandet: FC<{
   medlemskap: IMedlemskap;
   settMedlemskap: (medlemskap: IMedlemskap) => void;
-  land: string[];
+  land: ILandMedKode[];
 }> = ({ medlemskap, settMedlemskap, land }) => {
   const intl = useLokalIntlContext();
   const tomtUtenlandsopphold: IUtenlandsopphold = {

--- a/src/søknad/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
@@ -161,7 +161,7 @@ const Utenlandsopphold: FC<Props> = ({
       <SelectSpørsmål
         spørsmål={landConfig}
         settSpørsmålOgSvar={settLand}
-        valgtSvar={perioderBoddIUtlandet[oppholdsnr].land?.verdi}
+        valgtSvarId={perioderBoddIUtlandet[oppholdsnr].land?.svarid}
         skalLogges={false}
       />
       {erPeriodeDatoerValgt(utenlandsopphold.periode) &&

--- a/src/søknad/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
@@ -4,7 +4,10 @@ import SlettKnapp from '../../../../components/knapper/SlettKnapp';
 import { hentTittelMedNr } from '../../../../language/utils';
 import PeriodeDatovelgere from '../../../../components/dato/PeriodeDatovelger';
 import { hentTekst } from '../../../../utils/søknad';
-import { IUtenlandsopphold } from '../../../../models/steg/omDeg/medlemskap';
+import {
+  ILandMedKode,
+  IUtenlandsopphold,
+} from '../../../../models/steg/omDeg/medlemskap';
 import { erPeriodeDatoerValgt } from '../../../../helpers/steg/omdeg';
 import { EPeriode } from '../../../../models/felles/periode';
 import styled from 'styled-components/macro';
@@ -36,7 +39,7 @@ interface Props {
   settPeriodeBoddIUtlandet: (periodeBoddIUtlandet: IUtenlandsopphold[]) => void;
   utenlandsopphold: IUtenlandsopphold;
   oppholdsnr: number;
-  land: string[];
+  land: ILandMedKode[];
 }
 
 const Utenlandsopphold: FC<Props> = ({

--- a/src/søknad/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
@@ -134,10 +134,6 @@ const Utenlandsopphold: FC<Props> = ({
     perioderBoddIUtlandet && settPeriodeBoddIUtlandet(periodeMedNyttLand);
   };
 
-  useEffect(() => {
-    console.log(perioderBoddIUtlandet);
-  }, [perioderBoddIUtlandet]);
-
   return (
     <Container aria-live="polite">
       <TittelOgSlettKnapp>

--- a/src/søknad/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
@@ -122,6 +122,8 @@ const Utenlandsopphold: FC<Props> = ({
           return {
             ...utenlandsopphold,
             land: {
+              spørsmålid: spørsmål.søknadid,
+              svarid: svar.id,
               label: intl.formatMessage({ id: spørsmål.tekstid }),
               verdi: svar.svar_tekst,
             },


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨ 
[FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12261)
Søknad skal inneholde to nye felter for å registrere hvilket land søker oppholder seg i nå (`oppholdsland`) og hvilket land de oppholdt seg under et utenlandsopphold (`land`).

### Hva er gjort? 🤓 

- Lagt til et nytt type spørsmål `SelectSpørsmål`
- Endret logikken for hvordan spørsmål vises
  - Man skal få opp spørsmålet om man har utenlandsopphold dersom svaret er "Ja" på at man oppholder seg i Norge, eller man har valgt et land ved "Nei" på opphold. 
- Tatt i bruk [land-verktoy](https://github.com/navikt/land-verktoy) for å hente liste med land. 
  - Her kan man sende inn "nb" eller "en" (ikke nn). 

### Hvordan er det testet? 🧪
- Lagd egne tester for mapping av feltene i api
- Lastet opp i preprod og sjekket at feltene følger med til PDF når en søknad sendes inn med de nye feltene

### Bilder 
🚧 Venter på svar angående tekster 🚧

<img width="596" alt="image" src="https://user-images.githubusercontent.com/46678893/235129218-a6695544-08fb-493e-bd74-633ac29836d7.png">

<img width="596" alt="image" src="https://user-images.githubusercontent.com/46678893/235129731-23aa089e-bb6a-40e7-a571-894f33820bf5.png">

### Andre relevante PR-er 🤝

- ef-sak-frontend [PR 2301](https://github.com/navikt/familie-ef-sak-frontend/pull/2301) (Visning av den nye søknadsdataen)
- ef-soknad-api [PR 844](https://github.com/navikt/familie-ef-soknad-api/pull/844) (mapper de nye feltene)
- ef-sak PR (legger til de nye feltene i søknadsdata)
- familie-kontrakter [PR 744](https://github.com/navikt/familie-kontrakter/pull/774) (legger til oppholdsland i medlemskap og land i utenlandsopphold) og [PR 746](https://github.com/navikt/familie-kontrakter/pull/776) (gi mulighet til å sette de nye feltene i `TestSøknadsBuilder`)
- familie-mottak [PR 964](https://github.com/navikt/familie-ef-mottak/pull/964) (bumper kontrakterversjon)