### PR TITLE
Send inn oppsummering av dokumentasjonsbehov til amplitude ved innsending av søknad

### DIFF
--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -115,7 +115,7 @@ export const logDokumetasjonsbehovOppsummering = (
   dokBehov: IDokumentasjon[],
   skjemanavn: ESkjemanavn
 ) => {
-  const antallOppfylte = dokBehov.filter(
+  const antallOpplastede = dokBehov.filter(
     (dok) =>
       dok.harSendtInn === false &&
       dok.opplastedeVedlegg !== undefined &&
@@ -138,8 +138,9 @@ export const logDokumetasjonsbehovOppsummering = (
   logEvent('dokumentasjonsbehovOppsummering', {
     skjemanavn: skjemanavn,
     antallDokBehov: dokBehov.length,
-    antallOppfylte: antallOppfylte,
+    antallOpplastede: antallOpplastede,
     antallTidligereInnsendte: antallTidligereInnsendte,
+    antallOppfylte: antallOpplastede + antallTidligereInnsendte,
     antallIkkeOppfylte: antallIkkeOppfylte,
     harOppfyltAlle: harOppfyltAlle,
   });

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -111,6 +111,40 @@ export const logSidevisningSkolepenger = (side: string) => {
   });
 };
 
+export const logDokumetasjonsbehovOppsummering = (
+  dokBehov: IDokumentasjon[],
+  skjemanavn: ESkjemanavn
+) => {
+  const antallOppfylte = dokBehov.filter(
+    (dok) =>
+      dok.harSendtInn === false &&
+      dok.opplastedeVedlegg !== undefined &&
+      dok.opplastedeVedlegg.length > 0
+  ).length;
+
+  const antallTidligereInnsendte = dokBehov.filter(
+    (dok) => dok.harSendtInn === true
+  ).length;
+
+  const antallIkkeOppfylte = dokBehov.filter(
+    (dok) =>
+      dok.harSendtInn === false &&
+      (dok.opplastedeVedlegg === undefined ||
+        dok.opplastedeVedlegg.length === 0)
+  ).length;
+
+  const harOppfyltAlle = antallIkkeOppfylte === 0;
+
+  logEvent('dokumentasjonsbehovOppsummering', {
+    skjemanavn: skjemanavn,
+    antallDokBehov: dokBehov.length,
+    antallOppfylte: antallOppfylte,
+    antallTidligereInnsendte: antallTidligereInnsendte,
+    antallIkkeOppfylte: antallIkkeOppfylte,
+    harOppfyltAlle: harOppfyltAlle,
+  });
+};
+
 export const logDokumetasjonsbehov = (
   dokBehov: IDokumentasjon[],
   skjemanavn: ESkjemanavn

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -111,7 +111,7 @@ export const logSidevisningSkolepenger = (side: string) => {
   });
 };
 
-export const logDokumetasjonsbehovOppsummering = (
+const logDokumetasjonsbehovOppsummering = (
   dokBehov: IDokumentasjon[],
   skjemanavn: ESkjemanavn
 ) => {
@@ -146,7 +146,7 @@ export const logDokumetasjonsbehovOppsummering = (
   });
 };
 
-export const logDokumetasjonsbehov = (
+const logDokumetasjonsbehovDetaljer = (
   dokBehov: IDokumentasjon[],
   skjemanavn: ESkjemanavn
 ) => {
@@ -160,6 +160,14 @@ export const logDokumetasjonsbehov = (
       skjemanavn: skjemanavn,
     })
   );
+};
+
+export const logDokumetasjonsbehov = (
+  dokBehov: IDokumentasjon[],
+  skjemanavn: ESkjemanavn
+) => {
+  logDokumetasjonsbehovDetaljer(dokBehov, skjemanavn);
+  logDokumetasjonsbehovOppsummering(dokBehov, skjemanavn);
 };
 
 export const logAdressesperre = (skjemanavn: string) => {


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨ 
Vi ønsker å gjøre diverse målinger (se FAVRO) av dokumentasjonsbehov for å se hvor mange søknader som er fullstendige ved innsending. Det eksisterer nå en måling som sender inn et event per dokumentasjonsbehov per bruker. Dvs. at det per søknad bruker sender inn kommer 0-x eventer. Pga. manglende funksjonalitet i amplitude får vi ikke målt alt vi ønsker ved å bruke disse eventene, og ved å oppsummere dokumentasjonsbehovene i koden har vi bedre kontroll.

### Hvorfor fjernes ikke den gamle målingen? 🤔 

1. Vi ønsker fortsatt å se hvilke dokumenter som oftest mangler. Da må vi ha tittel på dokument som ligger i den gamle hvor det sendes et event per dokbehov.
2. Siden denne alt ligger ute har vi allerede brukt av kvoten for "nye eventtyper" 😢 
3. Dersom vi ser at tallene vi klarer å skaffe med den gamle målingen stemmer med den nye så kan vi bruke den gamle til å få historisk informasjon og ikke bare informasjon fra nå og utover.

### Hva er de ulike feltene? 🤓 

En søker kan ha 0 til mange dokumentasjonsbehov. Et dokumentasjonsbehov er en ting som bruker har blitt bedt om å dokumentere og det er oppfylt dersom man enten har lastet opp _minst ett vedlegg_ eller gir beskjed om at man har _sendt vedlegg som dokumenterer dette til nav tidligere_. Basert på dette per søknad innsendt: 

- `antallDokBehov` = antall ting søker har blitt bedt om å dokumentere
- `antallOpplastede` = antall dokbehov som er oppfylt ved at bruker har lastet opp _minst et vedlegg_
- `antallTidligereInnsendte` = antall dokbehov som er oppfylt ved at bruker har  _sendt inn dokumentasjon til nav tidligere_
- `antallOppfylte: antallOpplastede + antallTidligereInnsendte` = summen av alle dokbehov som bruker har dokumentert (enten nå eller før)
- `antallIkkeOppfylte` = antall dokbehov hvor det ikke er sendt inn noe tidligere og bruker ikke har lastet opp noe
- `harOppfyltAlle` = true / false basert på om `antallIkkeOppfylte  === 0`.

# Hvorfor må vi ha med så mange ting???? 👎 
Amplitude har veldig begrensede muligheter for å gjøre beregninger og bytte mellom and/or osv. Så for å ha litt mer oversikt over hva som faktisk måles så ble det tatt en beslutning om å oppsummere i koden 🤠 
