### PR TITLE
Skal vise alert ved trykk på nei for arbeidssøker begynne om en uke

### DIFF
--- a/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
+++ b/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
@@ -121,11 +121,6 @@ const Spørsmål: FC<any> = ({ ident }) => {
               onChange={settJaNeiSpørsmål}
               valgtSvar={arbeidssøker.kanBegynneInnenEnUke?.verdi}
             />
-            {arbeidssøker.kanBegynneInnenEnUke?.svarid === ESvar.NEI && (
-              <Alert size="small" variant={'warning'} inline>
-                <LocaleTekst tekst={'arbeidssøker.alert.senestEnUke'} />
-              </Alert>
-            )}
           </KomponentGruppe>
         )}
         {arbeidssøker.kanBegynneInnenEnUke && (
@@ -144,12 +139,6 @@ const Spørsmål: FC<any> = ({ ident }) => {
               onChange={settJaNeiSpørsmål}
               valgtSvar={arbeidssøker.ønskerSøker50ProsentStilling?.verdi}
             />
-            {arbeidssøker.ønskerSøker50ProsentStilling?.svarid ===
-              ESvar.NEI && (
-              <Alert size="small" variant={'warning'} inline>
-                <LocaleTekst tekst={'arbeidssøker.alert.halvstilling'} />
-              </Alert>
-            )}
           </KomponentGruppe>
         )}
       </SeksjonGruppe>

--- a/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
+++ b/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
@@ -121,10 +121,14 @@ const Spørsmål: FC<any> = ({ ident }) => {
               onChange={settJaNeiSpørsmål}
               valgtSvar={arbeidssøker.kanBegynneInnenEnUke?.verdi}
             />
+            {arbeidssøker.kanBegynneInnenEnUke?.svarid === ESvar.NEI && (
+              <Alert size="small" variant={'warning'} inline>
+                <LocaleTekst tekst={'arbeidssøker.alert.senestEnUke'} />
+              </Alert>
+            )}
           </KomponentGruppe>
         )}
-
-        {arbeidssøker.kanBegynneInnenEnUke && (
+        {arbeidssøker.kanBegynneInnenEnUke?.svarid === ESvar.NEI && (
           <KomponentGruppe>
             <MultiSvarSpørsmål
               spørsmål={ønsketArbeidssted(intl)}

--- a/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
+++ b/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
@@ -144,6 +144,12 @@ const Spørsmål: FC<any> = ({ ident }) => {
               onChange={settJaNeiSpørsmål}
               valgtSvar={arbeidssøker.ønskerSøker50ProsentStilling?.verdi}
             />
+            {arbeidssøker.ønskerSøker50ProsentStilling?.svarid ===
+              ESvar.NEI && (
+              <Alert size="small" variant={'warning'} inline>
+                <LocaleTekst tekst={'arbeidssøker.alert.halvstilling'} />
+              </Alert>
+            )}
           </KomponentGruppe>
         )}
       </SeksjonGruppe>

--- a/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
+++ b/src/arbeidssøkerskjema/steg/1-Spørsmål.tsx
@@ -128,7 +128,7 @@ const Spørsmål: FC<any> = ({ ident }) => {
             )}
           </KomponentGruppe>
         )}
-        {arbeidssøker.kanBegynneInnenEnUke?.svarid === ESvar.NEI && (
+        {arbeidssøker.kanBegynneInnenEnUke && (
           <KomponentGruppe>
             <MultiSvarSpørsmål
               spørsmål={ønsketArbeidssted(intl)}

--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -481,8 +481,10 @@ export default {
     '“One hour’s travel time” means that the time it takes you to travel using a means of transport between your home and your place of work is not more than one hour. It does not include the time it takes you to walk from your home to the means of transport, and from the means of transport to your place of work.',
   'arbeidssøker.label.halvstilling':
     'Do you want to be registered as a job seeker looking for at least a 50 per cent position?',
-  'arbeidssøker.alert.halvstilling':
+  'arbeidssøker.hjelpetekst-innhold.halvstilling':
     'As a single parent, there is no requirement for you to apply for full-time work. or evening, night, weekend and shift work. ',
+  'arbeidssøker.alert.halvstilling':
+    'If you are are registered as a job seeker looking for a position less than 50 percent, you are not entitled to receive transitional benefits for single partents.',
   'arbeidssøker.tekst.tillegstønad':
     'As a single parent looking for work, you may be entitled to some form of supplemental benefit<br/> Supplemental benefit can be granted to cover expenses related to <ul><li>child minding</li><li>relocation</li></ul>NB! You can only receive supplemental benefit if you qualify for transitional benefit',
   'arbeidssøker.lenke.tilleggstønad': 'Read more about supplemental benefit',

--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -484,7 +484,7 @@ export default {
   'arbeidssøker.hjelpetekst-innhold.halvstilling':
     'As a single parent, there is no requirement for you to apply for full-time work. or evening, night, weekend and shift work. ',
   'arbeidssøker.alert.halvstilling':
-    'If you are are registered as a job seeker looking for a position less than 50 percent, you are not entitled to receive transitional benefits for single partents.',
+    'If you are registered as a job seeker looking for a position less than 50 percent, you are not entitled to receive transitional benefits for single partents.',
   'arbeidssøker.tekst.tillegstønad':
     'As a single parent looking for work, you may be entitled to some form of supplemental benefit<br/> Supplemental benefit can be granted to cover expenses related to <ul><li>child minding</li><li>relocation</li></ul>NB! You can only receive supplemental benefit if you qualify for transitional benefit',
   'arbeidssøker.lenke.tilleggstønad': 'Read more about supplemental benefit',

--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -467,6 +467,8 @@ export default {
     'Can you start working no later than one week after you are offered a job?',
   'arbeidssøker.hjelpetekst-innhold.kanBegynneInnenEnUke':
     'You must be available and able to respond quickly to offers of work or labour market schemes. You must therefore be able to arrange child minding at short notice.',
+  'arbeidssøker.alert.senestEnUke':
+    'If you are unable to start working within one week of receving a job offer, you are not entitled to receive transitional benefits for single partents.',
   'arbeidssøker.label.barnepass':
     'Har du eller kan du skaffe barnepass senest innen en uke etter at du har fått tilbud om jobb eller arbeidsmarkedtiltak? SKAL FJERNES I FØLGE INNHOLDSDOK (egen oppg)',
   'arbeidssøker.label.ønsketArbeidssted': 'Where do you want to seek work?',

--- a/src/language/tekster_nb.ts
+++ b/src/language/tekster_nb.ts
@@ -465,8 +465,10 @@ export default {
     '1 times reisevei vil si at reisetiden med transportmiddel mellom hjem og arbeidssted ikke er over 1 time hver vei. Det inkuderer ikke gangtid mellom bolig og transportmiddel, og transportmiddel og arbeidssted.',
   'arbeidssøker.label.halvstilling':
     'Ønsker du å stå som arbeidssøker til minst 50 prosent stilling?',
-  'arbeidssøker.alert.halvstilling':
+  'arbeidssøker.hjelpetekst-innhold.halvstilling':
     'Du kan søke heltidsjobb, men som enslig mor eller far holder det at du jobber minst 50 prosent. Det er heller ikke krav om at du må jobbe kvelds-, natt-, helg- og skiftarbeid.',
+  'arbeidssøker.alert.halvstilling':
+    'Når du er arbeidssøker til mindre enn 50 prosent stilling, har du ikke rett til overgangsstønad.',
   'arbeidssøker.tekst.tillegstønad':
     'Som enslig mor eller far som søker arbeid, kan du ha rett til tilleggsstønader <br/> Stønadene kan dekke utgifter til <ul><li>barnepass</li><li>flytting</li></ul>NB! Du kan kun få tilleggsstønader hvis du kvalifiserer til overgangsstønad',
   'arbeidssøker.lenke.tilleggstønad': 'Les mer om tilleggstønader',

--- a/src/language/tekster_nb.ts
+++ b/src/language/tekster_nb.ts
@@ -452,6 +452,8 @@ export default {
     'Kan du begynne i arbeid senest én uke etter at du har fått tilbud om jobb?',
   'arbeidssøker.hjelpetekst-innhold.kanBegynneInnenEnUke':
     'Du må være tilgjengelig og raskt kunne ta stilling til tilbud om arbeid eller arbeidsmarkedstiltak. Du må derfor kunne skaffe barnepass på kort varsel.',
+  'arbeidssøker.alert.senestEnUke':
+    'Når du ikke kan begynne i jobb innen èn uke etter at du har fått tilbud, har du ikke rett til overgangsstønad.',
   'arbeidssøker.label.barnepass':
     'Har du eller kan du skaffe barnepass senest innen en uke etter at du har fått tilbud om jobb eller arbeidsmarkedtiltak?',
   'arbeidssøker.label.ønsketArbeidssted': 'Hvor ønsker du å søke arbeid?',

--- a/src/language/tekster_nn.ts
+++ b/src/language/tekster_nn.ts
@@ -636,7 +636,7 @@ export default {
   'arbeidssøker.hjelpetekst-innhold.halvstilling':
     'As a single parent, there is no requirement for you to apply for full-time work. or evening, night, weekend and shift work. ',
   'arbeidssøker.alert.halvstilling':
-    'If you are are registered as a job seeker looking for a position less than 50 percent, you are not entitled to receive transitional benefits for single partents.',
+    'If you are registered as a job seeker looking for a position less than 50 percent, you are not entitled to receive transitional benefits for single partents.',
   'arbeidssøker.tekst.tillegstønad':
     'As a single parent looking for work, you may be entitled to some form of supplemental benefit<br/> ' +
     'Supplemental benefit can be granted to cover expenses related to <ul>' +

--- a/src/language/tekster_nn.ts
+++ b/src/language/tekster_nn.ts
@@ -619,6 +619,8 @@ export default {
     'Can you start working no later than one week after you are offered a job?',
   'arbeidssøker.hjelpetekst-innhold.kanBegynneInnenEnUke':
     'You must be available and able to respond quickly to offers of work or labour market schemes. You must therefore be able to arrange child minding at short notice.',
+  'arbeidssøker.alert.senestEnUke':
+    'Når du ikke kan begynne i jobb innen èn uke etter at du har fått tilbud, har du ikke rett til overgangsstønad.',
   'arbeidssøker.label.barnepass':
     'Har du eller kan du skaffe barnepass senest innen en uke etter at du har fått tilbud om jobb eller arbeidsmarkedtiltak? SKAL FJERNES I FØLGE INNHOLDSDOK (egen oppg)',
   'arbeidssøker.label.ønsketArbeidssted': 'Where do you want to seek work?',

--- a/src/language/tekster_nn.ts
+++ b/src/language/tekster_nn.ts
@@ -633,8 +633,10 @@ export default {
     '“One hour’s travel time” means that the time it takes you to travel using a means of transport between your home and your place of work is not more than one hour. It does not include the time it takes you to walk from your home to the means of transport, and from the means of transport to your place of work.',
   'arbeidssøker.label.halvstilling':
     'Do you want to be registered as a job seeker looking for at least a 50 per cent position?',
-  'arbeidssøker.alert.halvstilling':
+  'arbeidssøker.hjelpetekst-innhold.halvstilling':
     'As a single parent, there is no requirement for you to apply for full-time work. or evening, night, weekend and shift work. ',
+  'arbeidssøker.alert.halvstilling':
+    'If you are are registered as a job seeker looking for a position less than 50 percent, you are not entitled to receive transitional benefits for single partents.',
   'arbeidssøker.tekst.tillegstønad':
     'As a single parent looking for work, you may be entitled to some form of supplemental benefit<br/> ' +
     'Supplemental benefit can be granted to cover expenses related to <ul>' +

--- a/src/søknad/steg/5-aktivitet/arbeidssøker/Arbeidssøker.tsx
+++ b/src/søknad/steg/5-aktivitet/arbeidssøker/Arbeidssøker.tsx
@@ -147,6 +147,11 @@ const Arbeidssøker: React.FC<Props> = ({
             onChange={settJaNeiSpørsmål}
             valgtSvar={arbeidssøker.ønskerSøker50ProsentStilling?.verdi}
           />
+          {arbeidssøker.ønskerSøker50ProsentStilling?.svarid === ESvar.NEI && (
+            <Alert size="small" variant={'warning'} inline>
+              <LocaleTekst tekst={'arbeidssøker.alert.halvstilling'} />
+            </Alert>
+          )}
         </KomponentGruppe>
       )}
     </SeksjonGruppe>

--- a/src/søknad/steg/5-aktivitet/arbeidssøker/Arbeidssøker.tsx
+++ b/src/søknad/steg/5-aktivitet/arbeidssøker/Arbeidssøker.tsx
@@ -123,6 +123,11 @@ const Arbeidssøker: React.FC<Props> = ({
             onChange={settJaNeiSpørsmål}
             valgtSvar={arbeidssøker.kanBegynneInnenEnUke?.verdi}
           />
+          {arbeidssøker.kanBegynneInnenEnUke?.svarid === ESvar.NEI && (
+            <Alert size="small" variant={'warning'} inline>
+              <LocaleTekst tekst={'arbeidssøker.alert.senestEnUke'} />
+            </Alert>
+          )}
         </KomponentGruppe>
       )}
 

--- a/src/søknad/steg/5-aktivitet/arbeidssøker/ArbeidssøkerConfig.ts
+++ b/src/søknad/steg/5-aktivitet/arbeidssøker/ArbeidssøkerConfig.ts
@@ -82,7 +82,7 @@ export const ønskerHalvStilling = (intl: LokalIntlShape): ISpørsmål => ({
   flersvar: false,
   lesmer: {
     headerTekstid: '',
-    innholdTekstid: 'arbeidssøker.alert.halvstilling',
+    innholdTekstid: 'arbeidssøker.hjelpetekst-innhold.halvstilling',
   },
   svaralternativer: JaNeiSvar(intl),
 });


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨ 
[FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-11521) 

Vi ønsker å vise en feilmelding ved spørsmål hvor trykk på "nei" fører til at man ikke kan motta stønad.

### Bilder 🎨 
Spørsmål om man kan starte innen en uke: 
![image](https://github.com/navikt/familie-ef-soknad/assets/46678893/7e6a1ac2-17a0-4b04-a4c5-9929608372bd)

Spørsmål om man ønsker å registreres som arbeidssøker for minst 50% jobb:
![image](https://github.com/navikt/familie-ef-soknad/assets/46678893/12d1fdd4-20f1-4cdc-bade-6a0847bd0098)
