### PR TITLE
legger til et felt på barn for å vise i frontend hvem som er den andr…

### DIFF
--- a/src/models/steg/barn.ts
+++ b/src/models/steg/barn.ts
@@ -22,6 +22,7 @@ export interface IBarn {
   barnepass?: IBarnepass; // Gjelder kun barnetilsyn
   harAdressesperre?: boolean;
   medforelder?: IMedforelderFelt;
+  annenForelderId?: string; // Gjelder kun for visning av avhuking i frontend
 }
 
 export enum EBarn {

--- a/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
+++ b/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
@@ -11,31 +11,27 @@ import { cloneDeep } from 'lodash';
 
 interface Props {
   barn: IBarn;
+  forelder: IForelder;
+  oppdaterAnnenForelder: (annenForelderId: string) => void;
   førsteBarnTilHverForelder?: IBarn[];
   settForelder: (verdi: IForelder) => void;
-  forelder: IForelder;
-  settBarnHarSammeForelder: Function;
 }
 
 const AnnenForelderKnapper: React.FC<Props> = ({
   barn,
+  forelder,
+  oppdaterAnnenForelder,
   førsteBarnTilHverForelder,
   settForelder,
-  forelder,
-  settBarnHarSammeForelder,
 }) => {
   const intl = useLokalIntlContext();
-
-  const [andreForelderRadioVerdi, settAndreForelderRadioVerdi] =
-    useState<string>('');
 
   const leggTilSammeForelder = (
     e: SyntheticEvent<EventTarget, Event>,
     detAndreBarnet: IBarn
   ) => {
-    settBarnHarSammeForelder(true);
     const denAndreForelderen = cloneDeep(detAndreBarnet.forelder);
-    settAndreForelderRadioVerdi(detAndreBarnet.id);
+    oppdaterAnnenForelder(detAndreBarnet.id);
 
     settForelder({
       ...forelder,
@@ -59,8 +55,7 @@ const AnnenForelderKnapper: React.FC<Props> = ({
   };
 
   const leggTilAnnenForelder = () => {
-    settBarnHarSammeForelder(false);
-    settAndreForelderRadioVerdi('annen-forelder');
+    oppdaterAnnenForelder('annen-forelder');
     const id = hentUid();
 
     !barn.harSammeAdresse.verdi &&
@@ -95,7 +90,7 @@ const AnnenForelderKnapper: React.FC<Props> = ({
                 id: 'barnasbosted.forelder.sammesom',
               })} ${hentBarnetsNavnEllerBeskrivelse(b, intl)}`}
               value={`${andreForelder}${b.id}`}
-              checked={andreForelderRadioVerdi === b.id}
+              checked={barn.annenForelderId === b.id}
               onChange={(e) => leggTilSammeForelder(e, b)}
             />
           );
@@ -105,7 +100,7 @@ const AnnenForelderKnapper: React.FC<Props> = ({
           name={`${andreForelder}${barn.navn}`}
           label={intl.formatMessage({ id: 'barnasbosted.forelder.annen' })}
           value={andreForelderAnnen}
-          checked={andreForelderRadioVerdi === 'annen-forelder'}
+          checked={barn.annenForelderId === 'annen-forelder'}
           onChange={() => leggTilAnnenForelder()}
         />
       </div>

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -35,10 +35,21 @@ const lagOppdatertBarneliste = (
 ) => {
   return barneliste.map((b) => {
     if (b === nåværendeBarn) {
-      let nyttBarn = nåværendeBarn;
+      return { ...nåværendeBarn, forelder: forelder };
+    } else {
+      return b;
+    }
+  });
+};
 
-      nyttBarn.forelder = forelder;
-      return nyttBarn;
+const oppdaterBarnetsAndreForelder = (
+  barneliste: IBarn[],
+  nåværendeBarn: IBarn,
+  andreForelderId: string
+): IBarn[] => {
+  return barneliste.map((b) => {
+    if (b === nåværendeBarn) {
+      return { ...nåværendeBarn, annenForelderId: andreForelderId };
     } else {
       return b;
     }
@@ -96,9 +107,11 @@ const BarnetsBostedEndre: React.FC<Props> = ({
         }
   );
 
-  const [barnHarSammeForelder, settBarnHarSammeForelder] = useState<
-    boolean | undefined
-  >(undefined);
+  const barnHarSammeForelder =
+    barn.annenForelderId !== null &&
+    barn.annenForelderId !== undefined &&
+    barn.annenForelderId !== '' &&
+    barn.annenForelderId !== 'annen-forelder';
 
   const [kjennerIkkeIdent, settKjennerIkkeIdent] = useState<boolean>(
     forelder.fødselsdato?.verdi ? true : false
@@ -176,6 +189,15 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     scrollTilLagtTilBarn();
   };
 
+  const leggTilAnnenForelderId = (annenForelderId: string) => {
+    const nyBarneListe = oppdaterBarnetsAndreForelder(
+      barneListe,
+      barn,
+      annenForelderId
+    );
+    settBarneListe(nyBarneListe);
+  };
+
   const visOmAndreForelder =
     (!barn.medforelder?.verdi && førsteBarnTilHverForelder.length === 0) ||
     (førsteBarnTilHverForelder.length > 0 && barnHarSammeForelder === false) ||
@@ -211,7 +233,6 @@ const BarnetsBostedEndre: React.FC<Props> = ({
               settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
             />
           )}
-
           {(barn.harSammeAdresse?.verdi ||
             harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi)) && (
             <SeksjonGruppe>
@@ -221,10 +242,10 @@ const BarnetsBostedEndre: React.FC<Props> = ({
                 !barn.medforelder?.verdi && (
                   <AnnenForelderKnapper
                     barn={barn}
+                    forelder={forelder}
+                    oppdaterAnnenForelder={leggTilAnnenForelderId}
                     førsteBarnTilHverForelder={førsteBarnTilHverForelder}
                     settForelder={settForelder}
-                    forelder={forelder}
-                    settBarnHarSammeForelder={settBarnHarSammeForelder}
                   />
                 )}
               {visOmAndreForelder && (
@@ -271,33 +292,34 @@ const BarnetsBostedEndre: React.FC<Props> = ({
             />
           )}
 
-          {!barnHarSammeForelder && visSpørsmålHvisIkkeSammeForelder(forelder) && (
-            <>
-              {forelder.borINorge?.verdi && (
-                <BorAnnenForelderISammeHus
-                  forelder={forelder}
-                  settForelder={settForelder}
-                  barn={barn}
-                />
-              )}
+          {!barnHarSammeForelder &&
+            visSpørsmålHvisIkkeSammeForelder(forelder) && (
+              <>
+                {forelder.borINorge?.verdi && (
+                  <BorAnnenForelderISammeHus
+                    forelder={forelder}
+                    settForelder={settForelder}
+                    barn={barn}
+                  />
+                )}
 
-              {skalFylleUtHarBoddSammenFør && (
-                <BoddSammenFør
-                  forelder={forelder}
-                  barn={barn}
-                  settForelder={settForelder}
-                />
-              )}
-              {(boddSammenFør?.svarid === ESvar.NEI ||
-                erGyldigDato(flyttetFra?.verdi)) && (
-                <HvorMyeSammen
-                  forelder={forelder}
-                  barn={barn}
-                  settForelder={settForelder}
-                />
-              )}
-            </>
-          )}
+                {skalFylleUtHarBoddSammenFør && (
+                  <BoddSammenFør
+                    forelder={forelder}
+                    barn={barn}
+                    settForelder={settForelder}
+                  />
+                )}
+                {(boddSammenFør?.svarid === ESvar.NEI ||
+                  erGyldigDato(flyttetFra?.verdi)) && (
+                  <HvorMyeSammen
+                    forelder={forelder}
+                    barn={barn}
+                    settForelder={settForelder}
+                  />
+                )}
+              </>
+            )}
 
           {erForelderUtfylt(forelder) &&
             (erIdentUtfyltOgGylding(forelder.ident?.verdi) ||


### PR DESCRIPTION
…e forelderen

### Hvorfor er denne endringen nødvendig? ✨
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-10351)
Det har tidligere vært slik at valget om barnets andre forelder ikke persisteres slik at dersom man navigerer seg tilbake igjen til dette valget fra oppsummeringen så vil det vises som ikke valgt.

Det jeg har gjort er å legge til et felt på ` IBarn` som holder styr på hvilket valg som har blitt gjort tidligere. Denne staten gjelder kun for frontend. 

En annen mulighet hadde kanskje vært å legge til det nye feltet på `IForelder` men jeg synes det logisk sett passet bedre å sette det på barnet.

Når man nå navigerer seg tilbake til steg fire skal spørsmålet `Barnets andre forelder` være checked med det tidligere valget:
 <img width="610" alt="Skjermbilde 2023-08-01 kl  11 05 26" src="https://github.com/navikt/familie-ef-soknad/assets/32769446/e88520b8-3596-44ab-94c0-d880927c3893">
 
Testet i preprod ✅ 


