### PR TITLE
skal bytte ut tekstfelt for valg av oppholdsland til medforelder med …

### DIFF
--- a/src/models/steg/forelder.ts
+++ b/src/models/steg/forelder.ts
@@ -16,7 +16,7 @@ export interface IForelder {
   hvorforIkkeOppgi?: ISpørsmålFelt;
   ikkeOppgittAnnenForelderBegrunnelse?: ITekstFelt;
   borINorge?: ISpørsmålBooleanFelt;
-  land?: ITekstFelt;
+  land?: ISpørsmålFelt;
   avtaleOmDeltBosted?: ISpørsmålBooleanFelt;
   harAnnenForelderSamværMedBarn?: ISpørsmålFelt;
   harDereSkriftligSamværsavtale?: ISpørsmålFelt;


### PR DESCRIPTION
…en Select-variant som tar inn alle tilgjengelige land

### Hvorfor er denne endringen nødvendig? ✨
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12285)

Det er ønsket at vi bytter ut tekstfelt for inntasting av medforelders oppholdsland med en Select-variant hvor man velger blant 196 mulige land. 

Ny select-variant:
<img width="535" alt="Skjermbilde 2023-08-01 kl  16 20 14" src="https://github.com/navikt/familie-ef-soknad/assets/32769446/dc02cc21-87d1-4ee0-a0cf-2dc0344a4bb7">

Valget blir synlig i ettertid, som før:
<img width="502" alt="Skjermbilde 2023-08-01 kl  16 20 33" src="https://github.com/navikt/familie-ef-soknad/assets/32769446/5c8e7d8a-e0e5-4afd-aa1d-91e8b8b48650">

Testet i preprod ✅ 