### PR TITLE
💄 Styling og refaktorering av Opplastede vedlegg

### DIFF
--- a/src/components/filopplaster/Filopplaster.css
+++ b/src/components/filopplaster/Filopplaster.css
@@ -20,41 +20,6 @@
   font-size: 16px;
   text-align: left;
 }
-.filopplaster-wrapper .opplastede-filer .fil {
-  position: relative;
-  margin-top: 1rem;
-  margin-bottom: 1.5rem;
-  display: flex;
-  justify-content: space-between;
-}
-.filopplaster-wrapper .opplastede-filer .fil .navds-body-short {
-  display: inline-block;
-}
-.filopplaster-wrapper .opplastede-filer .fil .filstørrelse {
-  margin-left: 10px;
-}
-.filopplaster-wrapper .opplastede-filer .fil .filnavn {
-  margin-left: 1rem;
-}
-.filopplaster-wrapper .opplastede-filer .fil .vedleggsikon {
-  position: relative;
-  top: 5px;
-}
-.filopplaster-wrapper .opplastede-filer .fil .slett {
-  position: relative;
-  top: 5px;
-  color: #0067c5;
-  cursor: pointer;
-}
-.filopplaster-wrapper .opplastede-filer .fil .slett p {
-  text-decoration: underline;
-}
-.filopplaster-wrapper .opplastede-filer .fil .slett .slettikon {
-  margin-left: 10px;
-}
-.filopplaster-wrapper .opplastede-filer hr {
-  border: 1px solid #b7b1a9;
-}
 .filopplaster-wrapper .filopplaster {
   text-align: center;
   font-weight: bold;

--- a/src/components/filopplaster/Filopplaster.tsx
+++ b/src/components/filopplaster/Filopplaster.tsx
@@ -192,12 +192,10 @@ const Filopplaster: React.FC<Props> = ({
           </ul>
         ) : null}
 
-        <div className="opplastede-filer">
-          <OpplastedeFiler
-            filliste={dokumentasjon.opplastedeVedlegg || []}
-            slettVedlegg={slettVedlegg}
-          />
-        </div>
+        <OpplastedeFiler
+          filliste={dokumentasjon.opplastedeVedlegg || []}
+          slettVedlegg={slettVedlegg}
+        />
       </div>
 
       <div className="filopplaster">

--- a/src/components/filopplaster/OpplastedeFiler.tsx
+++ b/src/components/filopplaster/OpplastedeFiler.tsx
@@ -5,6 +5,8 @@ import { IVedlegg } from '../../models/steg/vedlegg';
 import { BodyShort, Button } from '@navikt/ds-react';
 import styled from 'styled-components';
 import { TrashFillIcon } from '@navikt/aksel-icons';
+import { hentTekst } from '../../utils/søknad';
+import LocaleTekst from '../../language/LocaleTekst';
 
 interface Props {
   filliste: IVedlegg[];
@@ -39,7 +41,7 @@ const OpplastedeFiler: React.FC<Props> = ({ filliste, slettVedlegg }) => {
                 icon={<TrashFillIcon />}
                 iconPosition="right"
               >
-                slett
+                <LocaleTekst tekst="dokumentasjon.knapp.slett" />
               </Button>
             </Filrad>
             {index === filliste.length - 1 ? '' : <hr />}

--- a/src/components/filopplaster/OpplastedeFiler.tsx
+++ b/src/components/filopplaster/OpplastedeFiler.tsx
@@ -1,48 +1,52 @@
 import React from 'react';
-import slett from '../../assets/slett.svg';
 import vedlegg from '../../assets/vedlegg.svg';
 import { formaterFilstørrelse } from './utils';
 import { IVedlegg } from '../../models/steg/vedlegg';
-import { BodyShort } from '@navikt/ds-react';
+import { BodyShort, Button } from '@navikt/ds-react';
+import styled from 'styled-components';
+import { TrashFillIcon } from '@navikt/aksel-icons';
 
 interface Props {
   filliste: IVedlegg[];
   slettVedlegg: (vedlegg: IVedlegg) => void;
 }
 
+const Container = styled.div`
+  margin-bottom: 5rem;
+`;
+
+const Filrad = styled.div`
+  display: grid;
+  grid-template-columns: 1.5rem 1fr auto;
+  gap: 1rem;
+  align-items: center;
+`;
+
 const OpplastedeFiler: React.FC<Props> = ({ filliste, slettVedlegg }) => {
   return (
-    <>
+    <Container>
       {filliste.map((fil: IVedlegg, index: number) => {
         return (
           <div key={fil.dokumentId}>
-            <div className="fil">
-              <div>
-                <img
-                  className="vedleggsikon"
-                  src={vedlegg}
-                  alt="Vedleggsikon"
-                />
-                <BodyShort className="filnavn">{fil.navn}</BodyShort>
-                <BodyShort className="filstørrelse">
-                  ({formaterFilstørrelse(fil.størrelse)})
-                </BodyShort>
-              </div>
-              <div
-                className="slett"
-                onClick={() => {
-                  slettVedlegg(fil);
-                }}
+            <Filrad>
+              <img src={vedlegg} alt="Vedleggsikon" />
+              <BodyShort>
+                {fil.navn} ({formaterFilstørrelse(fil.størrelse)})
+              </BodyShort>
+              <Button
+                size="small"
+                variant="tertiary"
+                icon={<TrashFillIcon />}
+                iconPosition="right"
               >
-                <BodyShort>slett</BodyShort>
-                <img className="slettikon" src={slett} alt="Rødt kryss" />
-              </div>
-            </div>
+                slett
+              </Button>
+            </Filrad>
             {index === filliste.length - 1 ? '' : <hr />}
           </div>
         );
       })}
-    </>
+    </Container>
   );
 };
 

--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -652,6 +652,7 @@ export default {
     'If you have already submitted this documentation to NAV in the past, you do not need to submit it again.',
   'dokumentasjon.checkbox.sendtTidligere':
     'I have already submitted this documentation to NAV in the past',
+  'dokumentasjon.knapp.slett': 'delete',
   'dokumentasjon.inngåttEkteskap.tittel': 'Documentation of your marriage',
   'dokumentasjon.separasjonEllerSkilsmisse.tittel':
     'Documentation of your separation or divorce',

--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -652,7 +652,7 @@ export default {
     'If you have already submitted this documentation to NAV in the past, you do not need to submit it again.',
   'dokumentasjon.checkbox.sendtTidligere':
     'I have already submitted this documentation to NAV in the past',
-  'dokumentasjon.knapp.slett': 'delete',
+  'dokumentasjon.knapp.slett': 'Delete',
   'dokumentasjon.inngåttEkteskap.tittel': 'Documentation of your marriage',
   'dokumentasjon.separasjonEllerSkilsmisse.tittel':
     'Documentation of your separation or divorce',

--- a/src/language/tekster_nb.ts
+++ b/src/language/tekster_nb.ts
@@ -635,6 +635,7 @@ export default {
     'Har du sendt inn denne dokumentasjonen til NAV tidligere? Da trenger du ikke å sende den på nytt.',
   'dokumentasjon.checkbox.sendtTidligere':
     'Jeg har sendt inn denne dokumentasjonen til NAV tidligere',
+  'dokumentasjon.knapp.slett': 'slett',
   'dokumentasjon.inngåttEkteskap.tittel': 'Dokumentasjon på inngått ekteskap',
   'dokumentasjon.separasjonEllerSkilsmisse.tittel':
     'Dokumentasjon på separasjon eller skilsmisse',

--- a/src/language/tekster_nb.ts
+++ b/src/language/tekster_nb.ts
@@ -635,7 +635,7 @@ export default {
     'Har du sendt inn denne dokumentasjonen til NAV tidligere? Da trenger du ikke å sende den på nytt.',
   'dokumentasjon.checkbox.sendtTidligere':
     'Jeg har sendt inn denne dokumentasjonen til NAV tidligere',
-  'dokumentasjon.knapp.slett': 'slett',
+  'dokumentasjon.knapp.slett': 'Slett',
   'dokumentasjon.inngåttEkteskap.tittel': 'Dokumentasjon på inngått ekteskap',
   'dokumentasjon.separasjonEllerSkilsmisse.tittel':
     'Dokumentasjon på separasjon eller skilsmisse',

--- a/src/language/tekster_nn.ts
+++ b/src/language/tekster_nn.ts
@@ -988,6 +988,7 @@ export default {
     'If you have already submitted this documentation to NAV in the past, you do not need to submit it again.',
   'dokumentasjon.checkbox.sendtTidligere':
     'I have already submitted this documentation to NAV in the past',
+  'dokumentasjon.knapp.slett': 'delete',
   'dokumentasjon.inngåttEkteskap.tittel': 'Documentation of your marriage',
   'dokumentasjon.separasjonEllerSkilsmisse.tittel':
     'Documentation of your separation or divorce',

--- a/src/language/tekster_nn.ts
+++ b/src/language/tekster_nn.ts
@@ -988,7 +988,7 @@ export default {
     'If you have already submitted this documentation to NAV in the past, you do not need to submit it again.',
   'dokumentasjon.checkbox.sendtTidligere':
     'I have already submitted this documentation to NAV in the past',
-  'dokumentasjon.knapp.slett': 'delete',
+  'dokumentasjon.knapp.slett': 'Delete',
   'dokumentasjon.inngåttEkteskap.tittel': 'Documentation of your marriage',
   'dokumentasjon.separasjonEllerSkilsmisse.tittel':
     'Documentation of your separation or divorce',


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Etter at dokumentasjonsbehov ble rammet inn i et `GuidePanel` ble det litt trangere og listen med opplastede dokumenter litt stygg 🥲 [PR 1327](https://github.com/navikt/familie-ef-soknad/pull/1327)

### Hva er gjort? 🤓
Skrevet om koden så det så penere ut. Dette innebar f.eks. å bruke ikoner og knapper fra aksel og slette masse css. 
Har også gjort at det står "delete" om man har valgt engelsk. 

### Bilder: 
| Før      | Etter |
| ----------- | ----------- |
| <img width="561" alt="image" src="https://github.com/navikt/familie-ef-soknad/assets/46678893/a6610a15-177d-42c7-81a5-51b0dd14809d"> | <img width="561" alt="image" src="https://github.com/navikt/familie-ef-soknad/assets/46678893/da1afced-35c4-4588-8945-948754dff584">
 |
