### PR TITLE
Skal vise frem filnavn penere på mobil

### DIFF
--- a/src/components/filopplaster/OpplastedeFiler.tsx
+++ b/src/components/filopplaster/OpplastedeFiler.tsx
@@ -17,6 +17,7 @@ const Filrad = styled.div`
   grid-template-columns: 1.5rem 1fr auto;
   gap: 1rem;
   align-items: center;
+  word-break: break-all;
 `;
 
 const OpplastedeFiler: React.FC<Props> = ({ filliste, slettVedlegg }) => {
@@ -26,7 +27,7 @@ const OpplastedeFiler: React.FC<Props> = ({ filliste, slettVedlegg }) => {
         <div key={fil.dokumentId}>
           <Filrad>
             <img src={vedlegg} alt="Vedleggsikon" />
-            <BodyShort>
+            <BodyShort size="small">
               {fil.navn} ({formaterFilstørrelse(fil.størrelse)})
             </BodyShort>
             <Button


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Opplastede dokumenter var stygg på mobil 😢 
<img width="524" alt="image" src="https://github.com/navikt/familie-ef-soknad/assets/46678893/a202b0b7-e45e-4714-a7df-89d65a32f199">

Resultat: 
<img width="524" alt="image" src="https://github.com/navikt/familie-ef-soknad/assets/46678893/fd9c00a7-06ee-4f66-9520-8ebc207e61b0">

Mulig `size="small` blir litt lite på desktop, venter på svar fra Lars: 
<img width="506" alt="image" src="https://github.com/navikt/familie-ef-soknad/assets/46678893/5b3deb65-0bfb-4528-b392-5613ca732d1a">
