### PR TITLE
Skal bruke gcr distroless node 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/node:18
+FROM gcr.io/distroless/nodejs:18
 
 WORKDIR /app
 COPY ./build build


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Chainguard har fjernet node 18 😢 