### PR TITLE
Skal unngå bruk av any i amplitude

### DIFF
--- a/src/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -58,9 +58,7 @@ const Oppsummering: React.FC = () => {
           ]);
         }
 
-        logManglendeFelter(ESkjemanavn.Barnetilsyn, skjemaId, {
-          feilmelding: e,
-        });
+        logManglendeFelter(ESkjemanavn.Barnetilsyn, skjemaId, e);
       });
   }, [søknad, manglendeFelter, skjemaId]);
 

--- a/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
@@ -74,9 +74,7 @@ const Oppsummering: React.FC = () => {
           ]);
         }
 
-        logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, {
-          feilmelding: e,
-        });
+        logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, e);
       });
 
     aktivitetSchema
@@ -94,9 +92,7 @@ const Oppsummering: React.FC = () => {
           ]);
         }
 
-        logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, {
-          feilmelding: e,
-        });
+        logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, e);
       });
 
     sivilstatusSchema
@@ -114,9 +110,7 @@ const Oppsummering: React.FC = () => {
           ]);
         }
 
-        logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, {
-          feilmelding: e,
-        });
+        logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, e);
       });
 
     merOmDinSituasjonSchema
@@ -134,9 +128,7 @@ const Oppsummering: React.FC = () => {
           ]);
         }
 
-        logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, {
-          feilmelding: e,
-        });
+        logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, e);
       });
 
     medlemskapSchema
@@ -154,9 +146,7 @@ const Oppsummering: React.FC = () => {
           ]);
         }
 
-        logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, {
-          feilmelding: 'test',
-        });
+        logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, e);
       });
   }, [søknad, manglendeFelter, skjemaId]);
 

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -12,6 +12,7 @@ amplitudeInstance.init('default', '', {
   platform: window.location.toString(),
 });
 
+// eslint-disable-next-line
 export function logEvent(eventName: string, eventProperties: any) {
   amplitudeInstance.logEvent(eventName, eventProperties);
 }
@@ -21,8 +22,7 @@ export const logSpørsmålBesvart = (
   skjemaId: number,
   spørsmål: string,
   svar: string,
-  skalLogges: boolean,
-  props?: any
+  skalLogges: boolean
 ) => {
   if (skalLogges) {
     logEvent('skjema spørsmål besvart', {
@@ -30,7 +30,6 @@ export const logSpørsmålBesvart = (
       skjemaId,
       spørsmål,
       svar,
-      ...props,
     });
   }
 };
@@ -180,49 +179,52 @@ export const logAdressesperre = (skjemanavn: string) => {
 export const logInnsendingFeilet = (
   skjemanavn: string,
   skjemaId: number,
-  feilmelding: string,
-  props?: any
+  feilmelding: string
 ) => {
   logEvent('skjema innsending feilet', {
     skjemanavn,
     skjemaId,
     feilmelding,
-    ...props,
   });
 };
 
 export const logBrowserBackOppsummering = (
   skjemanavn: string,
-  skjemaId: number,
-  ...props: any
+  skjemaId: number
 ) => {
   logEvent('browser_back_oppsummering', {
     skjemanavn,
     skjemaId,
-    ...props,
   });
 };
+
+interface FeilFilopplasting {
+  type_feil: string;
+  feilmelding: string;
+  filstørrelse?: number;
+  filtype?: string;
+}
 
 export const logFeilFilopplasting = (
   skjemanavn: string,
   skjemaId: number,
-  ...props: any
+  feilInformasjon: FeilFilopplasting
 ) => {
   logEvent('filopplasting_feilet', {
     skjemanavn,
     skjemaId,
-    ...props,
+    ...feilInformasjon,
   });
 };
 
 export const logManglendeFelter = (
   skjemanavn: string,
   skjemaId: number,
-  ...props: any
+  feilmelding: string
 ) => {
   logEvent('manglende_felter', {
     skjemanavn,
     skjemaId,
-    ...props,
+    feilmelding,
   });
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Forsatt mange warnings i søknad 😢 

Nå har målet vært å fjerne alle `any` i amplitude.ts. Noen steder er det bare fjernet mulighet for å sende inn flere props enn de som er definerte ordentlig (fordi det ikke ble brukt), mens andre steder er det definert ordentlig. 