### PR TITLE
Skjule infoboks

### DIFF
--- a/src/barnetilsyn/Forside.tsx
+++ b/src/barnetilsyn/Forside.tsx
@@ -23,8 +23,8 @@ import { Alert, Panel, Heading } from '@navikt/ds-react';
 import VeilederSnakkeboble from '../assets/VeilederSnakkeboble';
 import styled from 'styled-components';
 import {
+  erMellomStartenAvMaiOgSluttenAvAugust,
   nåværendeÅr,
-  useErMellomStartenAvMaiOgSluttenAvAugust,
 } from '../utils/dato';
 
 const StyledAlert = styled(Alert)`
@@ -33,8 +33,7 @@ const StyledAlert = styled(Alert)`
 
 const Forside: React.FC<any> = () => {
   const intl = useLokalIntlContext();
-  const erMellomStartenAvMaiOgSluttenAvAugust =
-    useErMellomStartenAvMaiOgSluttenAvAugust();
+  const erMellomMaiOgAugust = erMellomStartenAvMaiOgSluttenAvAugust();
 
   useMount(() => {
     if (!(kanBrukeMellomlagretSøknad && mellomlagretBarnetilsyn))
@@ -106,7 +105,7 @@ const Forside: React.FC<any> = () => {
             <LocaleTekst tekst={'barnetilsyn.sidetittel'} />
           </Heading>
 
-          {erMellomStartenAvMaiOgSluttenAvAugust ? (
+          {erMellomMaiOgAugust ? (
             <StyledAlert variant="info">
               <Heading spacing size="small" level="3">
                 Søker du om stønad til barnetilsyn fra august {nåværendeÅr}?

--- a/src/barnetilsyn/Forside.tsx
+++ b/src/barnetilsyn/Forside.tsx
@@ -22,10 +22,7 @@ import { useLokalIntlContext } from '../context/LokalIntlContext';
 import { Alert, Panel, Heading } from '@navikt/ds-react';
 import VeilederSnakkeboble from '../assets/VeilederSnakkeboble';
 import styled from 'styled-components';
-import {
-  erMellomStartenAvMaiOgSluttenAvAugust,
-  nåværendeÅr,
-} from '../utils/dato';
+import { erNåværendeMånedMellomMåneder, nåværendeÅr } from '../utils/dato';
 
 const StyledAlert = styled(Alert)`
   margin-bottom: 2rem;
@@ -33,7 +30,7 @@ const StyledAlert = styled(Alert)`
 
 const Forside: React.FC<any> = () => {
   const intl = useLokalIntlContext();
-  const erMellomMaiOgAugust = erMellomStartenAvMaiOgSluttenAvAugust();
+  const erDagensDatoMellomMaiOgAugust = erNåværendeMånedMellomMåneder(5, 8);
 
   useMount(() => {
     if (!(kanBrukeMellomlagretSøknad && mellomlagretBarnetilsyn))
@@ -105,7 +102,7 @@ const Forside: React.FC<any> = () => {
             <LocaleTekst tekst={'barnetilsyn.sidetittel'} />
           </Heading>
 
-          {erMellomMaiOgAugust ? (
+          {erDagensDatoMellomMaiOgAugust ? (
             <StyledAlert variant="info">
               <Heading spacing size="small" level="3">
                 Søker du om stønad til barnetilsyn fra august {nåværendeÅr}?

--- a/src/barnetilsyn/Forside.tsx
+++ b/src/barnetilsyn/Forside.tsx
@@ -21,8 +21,11 @@ import { isIE } from 'react-device-detect';
 import { useLokalIntlContext } from '../context/LokalIntlContext';
 import { Alert, Panel, Heading } from '@navikt/ds-react';
 import VeilederSnakkeboble from '../assets/VeilederSnakkeboble';
-import styled from "styled-components";
-
+import styled from 'styled-components';
+import {
+  nåværendeÅr,
+  useErMellomStartenAvMaiOgSluttenAvAugust,
+} from '../utils/dato';
 
 const StyledAlert = styled(Alert)`
   margin-bottom: 2rem;
@@ -30,6 +33,9 @@ const StyledAlert = styled(Alert)`
 
 const Forside: React.FC<any> = () => {
   const intl = useLokalIntlContext();
+  const erMellomStartenAvMaiOgSluttenAvAugust =
+    useErMellomStartenAvMaiOgSluttenAvAugust();
+
   useMount(() => {
     if (!(kanBrukeMellomlagretSøknad && mellomlagretBarnetilsyn))
       logSidevisningBarnetilsyn('Forside');
@@ -100,12 +106,16 @@ const Forside: React.FC<any> = () => {
             <LocaleTekst tekst={'barnetilsyn.sidetittel'} />
           </Heading>
 
-          <StyledAlert  variant="info">
-            <Heading spacing size="small" level="3">
-              Søker du om stønad til barnetilsyn fra august 2023?
-            </Heading>
-            For å få stønad fra august må du kunne dokumentere utgiftene til barnepass med faktura for denne måneden. Vi anbefaler derfor at du venter med å søke frem til du får fakturaen.
-          </StyledAlert>
+          {erMellomStartenAvMaiOgSluttenAvAugust ? (
+            <StyledAlert variant="info">
+              <Heading spacing size="small" level="3">
+                Søker du om stønad til barnetilsyn fra august {nåværendeÅr}?
+              </Heading>
+              For å få stønad fra august må du kunne dokumentere utgiftene til
+              barnepass med faktura for denne måneden. Vi anbefaler derfor at du
+              venter med å søke frem til du får fakturaen.
+            </StyledAlert>
+          ) : null}
 
           {kanBrukeMellomlagretSøknad && mellomlagretBarnetilsyn ? (
             <FortsettSøknad

--- a/src/skolepenger/Forside.tsx
+++ b/src/skolepenger/Forside.tsx
@@ -21,8 +21,8 @@ import { isIE } from 'react-device-detect';
 import VeilederSnakkeboble from '../assets/VeilederSnakkeboble';
 import styled from 'styled-components';
 import {
+  erMellomStartenAvMaiOgSluttenAvAugust,
   nåværendeÅr,
-  useErMellomStartenAvMaiOgSluttenAvAugust,
 } from '../utils/dato';
 
 const StyledAlert = styled(Alert)`
@@ -39,8 +39,7 @@ const Forside: React.FC = () => {
     søknad,
     settSøknad,
   } = useSkolepengerSøknad();
-  const erMellomStartenAvMaiOgSluttenAvAugust =
-    useErMellomStartenAvMaiOgSluttenAvAugust();
+  const erMellomMaiOgAugust = erMellomStartenAvMaiOgSluttenAvAugust();
 
   useMount(() => {
     if (!(kanBrukeMellomlagretSøknad && mellomlagretSkolepenger))
@@ -103,7 +102,7 @@ const Forside: React.FC = () => {
             <LocaleTekst tekst={'skolepenger.overskrift'} />
           </Heading>
 
-          {erMellomStartenAvMaiOgSluttenAvAugust ? (
+          {erMellomMaiOgAugust ? (
             <StyledAlert variant="info">
               <Heading spacing size="small" level="3">
                 Søker du om stønad til skolepenger fra august {nåværendeÅr}?

--- a/src/skolepenger/Forside.tsx
+++ b/src/skolepenger/Forside.tsx
@@ -20,10 +20,7 @@ import { Alert, Panel, Heading } from '@navikt/ds-react';
 import { isIE } from 'react-device-detect';
 import VeilederSnakkeboble from '../assets/VeilederSnakkeboble';
 import styled from 'styled-components';
-import {
-  erMellomStartenAvMaiOgSluttenAvAugust,
-  nåværendeÅr,
-} from '../utils/dato';
+import { erNåværendeMånedMellomMåneder, nåværendeÅr } from '../utils/dato';
 
 const StyledAlert = styled(Alert)`
   margin-bottom: 2rem;
@@ -39,7 +36,7 @@ const Forside: React.FC = () => {
     søknad,
     settSøknad,
   } = useSkolepengerSøknad();
-  const erMellomMaiOgAugust = erMellomStartenAvMaiOgSluttenAvAugust();
+  const erDagensDatoMellomMaiOgAugust = erNåværendeMånedMellomMåneder(5, 8);
 
   useMount(() => {
     if (!(kanBrukeMellomlagretSøknad && mellomlagretSkolepenger))
@@ -102,7 +99,7 @@ const Forside: React.FC = () => {
             <LocaleTekst tekst={'skolepenger.overskrift'} />
           </Heading>
 
-          {erMellomMaiOgAugust ? (
+          {erDagensDatoMellomMaiOgAugust ? (
             <StyledAlert variant="info">
               <Heading spacing size="small" level="3">
                 Søker du om stønad til skolepenger fra august {nåværendeÅr}?

--- a/src/skolepenger/Forside.tsx
+++ b/src/skolepenger/Forside.tsx
@@ -20,6 +20,10 @@ import { Alert, Panel, Heading } from '@navikt/ds-react';
 import { isIE } from 'react-device-detect';
 import VeilederSnakkeboble from '../assets/VeilederSnakkeboble';
 import styled from 'styled-components';
+import {
+  nåværendeÅr,
+  useErMellomStartenAvMaiOgSluttenAvAugust,
+} from '../utils/dato';
 
 const StyledAlert = styled(Alert)`
   margin-bottom: 2rem;
@@ -35,6 +39,8 @@ const Forside: React.FC = () => {
     søknad,
     settSøknad,
   } = useSkolepengerSøknad();
+  const erMellomStartenAvMaiOgSluttenAvAugust =
+    useErMellomStartenAvMaiOgSluttenAvAugust();
 
   useMount(() => {
     if (!(kanBrukeMellomlagretSøknad && mellomlagretSkolepenger))
@@ -97,14 +103,16 @@ const Forside: React.FC = () => {
             <LocaleTekst tekst={'skolepenger.overskrift'} />
           </Heading>
 
-          <StyledAlert variant="info">
-            <Heading spacing size="small" level="3">
-              Søker du om stønad til skolepenger fra august 2023?
-            </Heading>
-            For å få stønad for nytt skoleår må du kunne dokumentere utgiftene
-            til skolepenger med faktura. Vi anbefaler derfor at du venter med å
-            søke frem til du får fakturaen.
-          </StyledAlert>
+          {erMellomStartenAvMaiOgSluttenAvAugust ? (
+            <StyledAlert variant="info">
+              <Heading spacing size="small" level="3">
+                Søker du om stønad til skolepenger fra august {nåværendeÅr}?
+              </Heading>
+              For å få stønad for nytt skoleår må du kunne dokumentere utgiftene
+              til skolepenger med faktura. Vi anbefaler derfor at du venter med
+              å søke frem til du får fakturaen.
+            </StyledAlert>
+          ) : null}
 
           {kanBrukeMellomlagretSøknad && mellomlagretSkolepenger ? (
             <FortsettSøknad

--- a/src/utils/dato.ts
+++ b/src/utils/dato.ts
@@ -14,7 +14,6 @@ import {
 import subMonths from 'date-fns/subMonths';
 import { nb } from 'date-fns/locale';
 import { IPeriode } from '../models/felles/periode';
-import { useState, useEffect } from 'react';
 
 export const STANDARD_DATOFORMAT = 'dd.MM.yyyy';
 export const FØDSELSNUMMER_DATOFORMAT = 'ddMMyy';

--- a/src/utils/dato.ts
+++ b/src/utils/dato.ts
@@ -14,6 +14,7 @@ import {
 import subMonths from 'date-fns/subMonths';
 import { nb } from 'date-fns/locale';
 import { IPeriode } from '../models/felles/periode';
+import { useState, useEffect } from 'react';
 
 export const STANDARD_DATOFORMAT = 'dd.MM.yyyy';
 export const FØDSELSNUMMER_DATOFORMAT = 'ddMMyy';
@@ -96,4 +97,24 @@ export const erPeriodeGyldig = (periode: IPeriode | undefined): boolean => {
 
 export const erEnMånedTilbakeITid = (dato: string): boolean => {
   return !isAfter(strengTilDato(dato), addMonths(dagensDato, -1));
+};
+
+export const nåværendeÅr = new Date().getFullYear();
+
+export const useErMellomStartenAvMaiOgSluttenAvAugust = () => {
+  const [
+    erMellomStartenAvMaiOgSLuttenAvAugust,
+    setErMellomStartenAvMaiOgSLuttenAvAugust,
+  ] = useState(false);
+
+  useEffect(() => {
+    const nåværendeDato = new Date();
+
+    const erMellomMaiOgAugust =
+      nåværendeDato.getMonth() >= 4 && nåværendeDato.getMonth() <= 7;
+
+    setErMellomStartenAvMaiOgSLuttenAvAugust(erMellomMaiOgAugust);
+  }, []);
+
+  return erMellomStartenAvMaiOgSLuttenAvAugust;
 };

--- a/src/utils/dato.ts
+++ b/src/utils/dato.ts
@@ -101,20 +101,7 @@ export const erEnMånedTilbakeITid = (dato: string): boolean => {
 
 export const nåværendeÅr = new Date().getFullYear();
 
-export const useErMellomStartenAvMaiOgSluttenAvAugust = () => {
-  const [
-    erMellomStartenAvMaiOgSLuttenAvAugust,
-    setErMellomStartenAvMaiOgSLuttenAvAugust,
-  ] = useState(false);
-
-  useEffect(() => {
-    const nåværendeDato = new Date();
-
-    const erMellomMaiOgAugust =
-      nåværendeDato.getMonth() >= 4 && nåværendeDato.getMonth() <= 7;
-
-    setErMellomStartenAvMaiOgSLuttenAvAugust(erMellomMaiOgAugust);
-  }, []);
-
-  return erMellomStartenAvMaiOgSLuttenAvAugust;
+export const erMellomStartenAvMaiOgSluttenAvAugust = () => {
+  const nåværendeDato = new Date();
+  return nåværendeDato.getMonth() >= 4 && nåværendeDato.getMonth() <= 7;
 };

--- a/src/utils/dato.ts
+++ b/src/utils/dato.ts
@@ -100,7 +100,19 @@ export const erEnMånedTilbakeITid = (dato: string): boolean => {
 
 export const nåværendeÅr = new Date().getFullYear();
 
-export const erMellomStartenAvMaiOgSluttenAvAugust = () => {
+export const erNåværendeMånedMellomMåneder = (
+  startMåned: number,
+  sluttMåned: number
+): boolean => {
   const nåværendeDato = new Date();
-  return nåværendeDato.getMonth() >= 4 && nåværendeDato.getMonth() <= 7;
+  const nåværendeMåned = nåværendeDato.getMonth() + 1;
+
+  if (sluttMåned < startMåned) {
+    return (
+      (nåværendeMåned >= startMåned && nåværendeMåned <= 12) ||
+      (nåværendeMåned >= 1 && nåværendeMåned <= sluttMåned)
+    );
+  } else {
+    return nåværendeMåned >= startMåned && nåværendeMåned <= sluttMåned;
+  }
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker kun å vise infoboks på barnetilsyn og skolepenger i perioden 1. mai til 31. august, har derfor gjort slik at infoboks kun vises i denne perioden.

- Årstallet i infoboksen er også endret til å være dynamisk i stedet for hardkodet.

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15276