### PR TITLE
Skilte personer skal også få spørsmål knyttet til ekteskap

### DIFF
--- a/src/søknad/steg/1-omdeg/sivilstatus/Sivilstatus.tsx
+++ b/src/søknad/steg/1-omdeg/sivilstatus/Sivilstatus.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../../../utils/sivilstatus';
 import { IMedlemskap } from '../../../../models/steg/omDeg/medlemskap';
 import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+import SøkerErSkilt from './SøkerErSkilt';
 
 interface Props {
   sivilstatus: ISivilstatus;
@@ -107,21 +108,19 @@ const Sivilstatus: React.FC<Props> = ({
         />
       )}
 
+      {erSøkerUgift(sivilstand) && (
+        <SøkerErUgift
+          erUformeltGift={erUformeltGift}
+          settSivilstatusFelt={settSivilstatusFelt}
+          sivilstatus={sivilstatus}
+        />
+      )}
+
       {erSøkerSkilt(sivilstand) && (
-        <>
-          <SøkerErUgift
-            erUformeltGift={erUformeltGift}
-            settSivilstatusFelt={settSivilstatusFelt}
-            sivilstatus={sivilstatus}
-          />
-          <Søknadsbegrunnelse
-            sivilstatus={sivilstatus}
-            settSivilstatus={settSivilstatus}
-            settDato={settDato}
-            settDokumentasjonsbehov={settDokumentasjonsbehov}
-            settMedlemskap={settMedlemskap}
-          />
-        </>
+        <SøkerErSkilt
+          settSivilstatusFelt={settSivilstatusFelt}
+          sivilstatus={sivilstatus}
+        />
       )}
 
       {(erSøkerUgift(sivilstand) &&

--- a/src/søknad/steg/1-omdeg/sivilstatus/Sivilstatus.tsx
+++ b/src/søknad/steg/1-omdeg/sivilstatus/Sivilstatus.tsx
@@ -106,12 +106,22 @@ const Sivilstatus: React.FC<Props> = ({
           sivilstatus={sivilstatus}
         />
       )}
-      {erSøkerUgift(sivilstand) && (
-        <SøkerErUgift
-          erUformeltGift={erUformeltGift}
-          settSivilstatusFelt={settSivilstatusFelt}
-          sivilstatus={sivilstatus}
-        />
+
+      {erSøkerSkilt(sivilstand) && (
+        <>
+          <SøkerErUgift
+            erUformeltGift={erUformeltGift}
+            settSivilstatusFelt={settSivilstatusFelt}
+            sivilstatus={sivilstatus}
+          />
+          <Søknadsbegrunnelse
+            sivilstatus={sivilstatus}
+            settSivilstatus={settSivilstatus}
+            settDato={settDato}
+            settDokumentasjonsbehov={settDokumentasjonsbehov}
+            settMedlemskap={settMedlemskap}
+          />
+        </>
       )}
 
       {(erSøkerUgift(sivilstand) &&

--- a/src/søknad/steg/1-omdeg/sivilstatus/SøkerErSkilt.tsx
+++ b/src/søknad/steg/1-omdeg/sivilstatus/SøkerErSkilt.tsx
@@ -1,0 +1,62 @@
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import JaNeiSpørsmål from '../../../../components/spørsmål/JaNeiSpørsmål';
+import { erUformeltGiftSpørsmål } from './SivilstatusConfig';
+import {
+  ESvar,
+  ISpørsmål,
+  ISvar,
+} from '../../../../models/felles/spørsmålogsvar';
+import AlertstripeDokumentasjon from '../../../../components/AlertstripeDokumentasjon';
+import LocaleTekst from '../../../../language/LocaleTekst';
+import { hentSvarAlertFraSpørsmål } from '../../../../utils/søknad';
+import React from 'react';
+import { ISivilstatus } from '../../../../models/steg/omDeg/sivilstatus';
+import Show from '../../../../utils/showIf';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+
+interface Props {
+  sivilstatus: ISivilstatus;
+  settSivilstatusFelt: (spørsmål: ISpørsmål, valgtSvar: ISvar) => void;
+}
+
+const SøkerErSkilt: React.FC<Props> = ({
+  sivilstatus,
+  settSivilstatusFelt,
+}: Props) => {
+  const intl = useLokalIntlContext();
+
+  const hentValgtSvar = (spørsmål: ISpørsmål, sivilstatus: ISivilstatus) => {
+    for (const [key, value] of Object.entries(sivilstatus)) {
+      if (key === spørsmål.søknadid && value !== undefined) {
+        return value.verdi;
+      }
+    }
+  };
+
+  const harSvartJaPåUformeltGift =
+    sivilstatus.erUformeltGift?.svarid === ESvar.JA;
+
+  return (
+    <>
+      <KomponentGruppe>
+        <JaNeiSpørsmål
+          spørsmål={erUformeltGiftSpørsmål(intl)}
+          onChange={settSivilstatusFelt}
+          valgtSvar={hentValgtSvar(erUformeltGiftSpørsmål(intl), sivilstatus)}
+        />
+        <Show if={harSvartJaPåUformeltGift}>
+          <AlertstripeDokumentasjon>
+            <LocaleTekst
+              tekst={hentSvarAlertFraSpørsmål(
+                ESvar.JA,
+                erUformeltGiftSpørsmål(intl)
+              )}
+            />
+          </AlertstripeDokumentasjon>
+        </Show>
+      </KomponentGruppe>
+    </>
+  );
+};
+
+export default SøkerErSkilt;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Personer som er registrert skilt skal også få spørsmål knyttet til ekteskap, har derfor gjort slik at disse spørsmålene også dukker opp til personer med sivilstatus som skilt.

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-11518