### PR TITLE
Dependabot: Grupperer avhengigheter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,9 +23,18 @@ updates:
   open-pull-requests-limit: 30
   registries: "*"
   versioning-strategy: increase
-  ignore:
-    - dependency-name: "*"
-      update-types: [ "version-update:semver-patch" ]
+  groups:
+    minor-and-patch-dependencies:
+      patterns:
+        - "*"
+      update-types:
+        - "minor"
+        - "patch"
+    major-dependencies:
+      patterns:
+        - "*"
+      update-types:
+        - "major"
 - package-ecosystem: npm
   directory: "/server"
   schedule:


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Grupperer avhengigheter, en PR for major og en PR for minor og patch.