### PR TITLE
Validerbosituasjon oppsummering

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,7 @@ Det skrives ut 3 ulike tekstbolker i "Utdata"-fanen under kodesnutten. Denne ska
 
 ## Sett opp Prettier lokalt on save (IntelliJ)
 
-1. I IntelliJ, åpne `Preferences/Plugins` for så å søke opp og installere `File Watchers` og `Prettier` hvis dette ikke allerede er gjort.  
-2. Finn `File Watchers` under `Preferences/Tools/File Watchers`, og trykk på `+-ikonet nederst til venstre. for å legge til en ny Watcher.
-3. Fyll deretter inn feltene slik som tabellen under, og fjern ellers avhuking på `Auto-Save edited files to trigger the watcher` og `Trigger the watcher on external changes`. Trykk ok. 
- 
-
-| File Watcher  | Second Header |
-| -------- | ------------ |
-| Name  | Prettier |
-| File type | any |
-|  Scope | Project Files |
-| Program | $ProjectFileDir$/node_modules/.bin/prettier |
-| Arguments | --write $FilePathRelativeToProjectRoot$ |
-| Output paths to refresh | $FilePathRelativeToProjectRoot$ |
-| Working Directory | $ProjectFileDir$ |
-
+1. I IntelliJ, åpne settings. Finn prettier. Ligger under Languages and Frameworks -> Javascript -> Prettier.
+2. Sjekk av bokser for: 'On reformat code' og 'On save'
 
 Test om Prettier fungerer ved å gå inn i en tilfeldig tsx-fil, lag et par nye linjer, og `Ctrl`+ `S`. Hvis koden reformatteres (fjerner alle utenom en av de tomme linjene), så er Prettier på plass lokalt! :sparkles:

--- a/src/models/søknad/toggles.ts
+++ b/src/models/søknad/toggles.ts
@@ -5,4 +5,6 @@ export interface Toggles {
 export enum ToggleName {
   feilsituasjon = 'familie.ef.soknad.feilsituasjon',
   leggTilNynorsk = 'familie.ef.soknad.nynorsk',
+
+  validerBosituasjon = 'familie.ef.soknad.validerbosituasjon',
 }

--- a/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
@@ -85,8 +85,6 @@ const Oppsummering: React.FC = () => {
     }
   }
 
-
-
   useEffect(() => {
 
     {(toggles[ToggleName.validerBosituasjon]) && validerHvisSøkerSkalGifteSeg()}

--- a/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
@@ -1,23 +1,30 @@
-import React, {useEffect, useState} from 'react';
+import React, { useEffect, useState } from 'react';
 import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
-import {useLokalIntlContext} from '../../../context/LokalIntlContext';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
 import OppsummeringOmDeg from '../../../søknad/steg/7-oppsummering/OppsummeringOmDeg';
 import OppsummeringBarnasBosituasjon from '../../../søknad/steg/7-oppsummering/OppsummeringBarnasBosituasjon';
 import OppsummeringBarnaDine from '../../../søknad/steg/7-oppsummering/OppsummeringBarnaDine';
 import OppsummeringAktiviteter from '../../../søknad/steg/7-oppsummering/OppsummeringAktiviteter';
 import OppsummeringDinSituasjon from '../../../søknad/steg/7-oppsummering/OppsummeringDinSituasjon';
 import OppsummeringBosituasjonenDin from '../../../søknad/steg/7-oppsummering/OppsummeringBosituasjon';
-import {useSøknad} from '../../../context/SøknadContext';
-import {ERouteOvergangsstønad, RoutesOvergangsstonad,} from '../../routing/routesOvergangsstonad';
-import {hentPath} from '../../../utils/routing';
-import Side, {ESide} from '../../../components/side/Side';
-import {hentTekst} from '../../../utils/søknad';
-import {Stønadstype} from '../../../models/søknad/stønadstyper';
-import {logBrowserBackOppsummering, logManglendeFelter, logSidevisningOvergangsstonad,} from '../../../utils/amplitude';
-import {useMount} from '../../../utils/hooks';
-import {IBarn} from '../../../models/steg/barn';
-import {useNavigationType} from 'react-router-dom';
-import {ESkjemanavn, skjemanavnIdMapping} from '../../../utils/skjemanavn';
+import { useSøknad } from '../../../context/SøknadContext';
+import {
+  ERouteOvergangsstønad,
+  RoutesOvergangsstonad,
+} from '../../routing/routesOvergangsstonad';
+import { hentPath } from '../../../utils/routing';
+import Side, { ESide } from '../../../components/side/Side';
+import { hentTekst } from '../../../utils/søknad';
+import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import {
+  logBrowserBackOppsummering,
+  logManglendeFelter,
+  logSidevisningOvergangsstonad,
+} from '../../../utils/amplitude';
+import { useMount } from '../../../utils/hooks';
+import { IBarn } from '../../../models/steg/barn';
+import { useNavigationType } from 'react-router-dom';
+import { ESkjemanavn, skjemanavnIdMapping } from '../../../utils/skjemanavn';
 import {
   aktivitetSchema,
   datoSkalGifteSegEllerBliSamboerScema,
@@ -30,9 +37,9 @@ import {
   merOmDinSituasjonSchema,
   sivilstatusSchema,
 } from '../../../utils/validering/validering';
-import {Accordion, Alert, BodyShort} from '@navikt/ds-react';
-import {ToggleName} from "../../../models/søknad/toggles";
-import {useToggles} from "../../../context/TogglesContext";
+import { Accordion, Alert, BodyShort } from '@navikt/ds-react';
+import { ToggleName } from '../../../models/søknad/toggles';
+import { useToggles } from '../../../context/TogglesContext';
 
 const Oppsummering: React.FC = () => {
   const { toggles } = useToggles();
@@ -56,38 +63,52 @@ const Oppsummering: React.FC = () => {
     // eslint-disable-next-line
   }, []);
 
-  const feilIkkeRegistrertFor = (felt:ManglendeFelter) => {
-    return !manglendeFelter.includes(
-        manglendeFelterTilTekst[felt]
-    );
-  }
+  const feilIkkeRegistrertFor = (felt: ManglendeFelter) => {
+    return !manglendeFelter.includes(manglendeFelterTilTekst[felt]);
+  };
 
   const oppdaterManglendeFelter = (manglendeFelt: ManglendeFelter) => {
     settManglendeFelter((prev: string[]): string[] => [
       ...prev,
       manglendeFelterTilTekst[manglendeFelt],
     ]);
-  }
+  };
 
-  const validerHvisSøkerSkalGifteSeg = () =>{
-    if(søknad.bosituasjon.skalGifteSegEllerBliSamboer?.verdi){
-      console.log("validerer gifte seg", søknad.bosituasjon)
-      const gyldigDatoForgiftemål =  datoSkalGifteSegEllerBliSamboerScema.isValidSync(søknad.bosituasjon.datoSkalGifteSegEllerBliSamboer);
-      const gyldigIdent =  søknad.bosituasjon.vordendeSamboerEktefelle && identSchema.isValidSync(søknad.bosituasjon.vordendeSamboerEktefelle.ident);
-      const gyldigFødselsdato = søknad.bosituasjon.vordendeSamboerEktefelle && fødselsdatoSchema.isValidSync(søknad.bosituasjon.vordendeSamboerEktefelle.fødselsdato);
-      const harGyldigIdentEllerDatoPåVordende = gyldigFødselsdato || gyldigIdent;
+  const validerHvisSøkerSkalGifteSeg = () => {
+    if (søknad.bosituasjon.skalGifteSegEllerBliSamboer?.verdi) {
+      const gyldigDatoForgiftemål =
+        datoSkalGifteSegEllerBliSamboerScema.isValidSync(
+          søknad.bosituasjon.datoSkalGifteSegEllerBliSamboer
+        );
+      const gyldigIdent =
+        søknad.bosituasjon.vordendeSamboerEktefelle &&
+        identSchema.isValidSync(
+          søknad.bosituasjon.vordendeSamboerEktefelle.ident
+        );
+      const gyldigFødselsdato =
+        søknad.bosituasjon.vordendeSamboerEktefelle &&
+        fødselsdatoSchema.isValidSync(
+          søknad.bosituasjon.vordendeSamboerEktefelle.fødselsdato
+        );
+      const harGyldigIdentEllerDatoPåVordende =
+        gyldigFødselsdato || gyldigIdent;
       if (!harGyldigIdentEllerDatoPåVordende || !gyldigDatoForgiftemål) {
         if (feilIkkeRegistrertFor(ManglendeFelter.BOSITUASJONEN_DIN)) {
           oppdaterManglendeFelter(ManglendeFelter.BOSITUASJONEN_DIN);
         }
-        logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, "ValidationError: vordendeSamboerEktefelle mangler gyldig ident eller fødselsdato");
+        logManglendeFelter(
+          ESkjemanavn.Overgangsstønad,
+          skjemaId,
+          'ValidationError: vordendeSamboerEktefelle mangler gyldig ident eller fødselsdato'
+        );
       }
     }
-  }
+  };
 
   useEffect(() => {
-
-    {(toggles[ToggleName.validerBosituasjon]) && validerHvisSøkerSkalGifteSeg()}
+    {
+      toggles[ToggleName.validerBosituasjon] && validerHvisSøkerSkalGifteSeg();
+    }
 
     aktivitetSchema
       .validate(søknad.aktivitet)
@@ -98,7 +119,7 @@ const Oppsummering: React.FC = () => {
             manglendeFelterTilTekst[ManglendeFelter.AKTIVITET]
           )
         ) {
-          oppdaterManglendeFelter(ManglendeFelter.AKTIVITET)
+          oppdaterManglendeFelter(ManglendeFelter.AKTIVITET);
         }
         logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, e);
       });
@@ -107,8 +128,8 @@ const Oppsummering: React.FC = () => {
       .validate(søknad.sivilstatus)
       .then()
       .catch((e) => {
-        if (feilIkkeRegistrertFor(ManglendeFelter.OM_DEG)){
-          oppdaterManglendeFelter(ManglendeFelter.OM_DEG)
+        if (feilIkkeRegistrertFor(ManglendeFelter.OM_DEG)) {
+          oppdaterManglendeFelter(ManglendeFelter.OM_DEG);
         }
         logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, e);
       });
@@ -117,8 +138,8 @@ const Oppsummering: React.FC = () => {
       .validate(søknad.merOmDinSituasjon)
       .then()
       .catch((e) => {
-        if (feilIkkeRegistrertFor(ManglendeFelter.MER_OM_DIN_SITUASJON)){
-          oppdaterManglendeFelter(ManglendeFelter.MER_OM_DIN_SITUASJON)
+        if (feilIkkeRegistrertFor(ManglendeFelter.MER_OM_DIN_SITUASJON)) {
+          oppdaterManglendeFelter(ManglendeFelter.MER_OM_DIN_SITUASJON);
         }
         logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, e);
       });
@@ -127,8 +148,8 @@ const Oppsummering: React.FC = () => {
       .validate(søknad.medlemskap)
       .then()
       .catch((e) => {
-        if (feilIkkeRegistrertFor(ManglendeFelter.OM_DEG)){
-          oppdaterManglendeFelter(ManglendeFelter.OM_DEG)
+        if (feilIkkeRegistrertFor(ManglendeFelter.OM_DEG)) {
+          oppdaterManglendeFelter(ManglendeFelter.OM_DEG);
         }
         logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, e);
       });

--- a/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
@@ -27,7 +27,7 @@ import { useNavigationType } from 'react-router-dom';
 import { ESkjemanavn, skjemanavnIdMapping } from '../../../utils/skjemanavn';
 import {
   aktivitetSchema,
-  datoSkalGifteSegEllerBliSamboerScema,
+  datoSkalGifteSegEllerBliSamboerSchema,
   fødselsdatoSchema,
   identSchema,
   listManglendeFelter,
@@ -76,23 +76,23 @@ const Oppsummering: React.FC = () => {
 
   const validerHvisSøkerSkalGifteSeg = () => {
     if (søknad.bosituasjon.skalGifteSegEllerBliSamboer?.verdi) {
-      const gyldigDatoForgiftemål =
-        datoSkalGifteSegEllerBliSamboerScema.isValidSync(
+      const harGyldigDatoForGiftemål =
+        datoSkalGifteSegEllerBliSamboerSchema.isValidSync(
           søknad.bosituasjon.datoSkalGifteSegEllerBliSamboer
         );
-      const gyldigIdent =
+      const harGyldigIdent =
         søknad.bosituasjon.vordendeSamboerEktefelle &&
         identSchema.isValidSync(
           søknad.bosituasjon.vordendeSamboerEktefelle.ident
         );
-      const gyldigFødselsdato =
+      const harGyldigFødselsdato =
         søknad.bosituasjon.vordendeSamboerEktefelle &&
         fødselsdatoSchema.isValidSync(
           søknad.bosituasjon.vordendeSamboerEktefelle.fødselsdato
         );
       const harGyldigIdentEllerDatoPåVordende =
-        gyldigFødselsdato || gyldigIdent;
-      if (!harGyldigIdentEllerDatoPåVordende || !gyldigDatoForgiftemål) {
+        harGyldigFødselsdato || harGyldigIdent;
+      if (!harGyldigIdentEllerDatoPåVordende || !harGyldigDatoForGiftemål) {
         if (feilIkkeRegistrertFor(ManglendeFelter.BOSITUASJONEN_DIN)) {
           oppdaterManglendeFelter(ManglendeFelter.BOSITUASJONEN_DIN);
         }

--- a/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
@@ -33,8 +33,9 @@ import {
 import {Accordion, Alert, BodyShort} from '@navikt/ds-react';
 import {ToggleName} from "../../../models/søknad/toggles";
 import {useToggles} from "../../../context/TogglesContext";
-const { toggles } = useToggles();
+
 const Oppsummering: React.FC = () => {
+  const { toggles } = useToggles();
   const intl = useLokalIntlContext();
   const { mellomlagreOvergangsstønad, søknad } = useSøknad();
   const skjemaId = skjemanavnIdMapping[ESkjemanavn.Overgangsstønad];
@@ -83,9 +84,11 @@ const Oppsummering: React.FC = () => {
     }
   }
 
+
+
   useEffect(() => {
 
-    {toggles[ToggleName.validerBosituasjon] && validerHvisSøkerSkalGifteSeg()}
+    {(toggles[ToggleName.validerBosituasjon]) && validerHvisSøkerSkalGifteSeg()}
 
     aktivitetSchema
       .validate(søknad.aktivitet)

--- a/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
@@ -56,28 +56,29 @@ const Oppsummering: React.FC = () => {
     // eslint-disable-next-line
   }, []);
 
+  const feilIkkeRegistrertFor = (felt:ManglendeFelter) => {
+    return !manglendeFelter.includes(
+        manglendeFelterTilTekst[felt]
+    );
+  }
+
+  const oppdaterManglendeFelter = (manglendeFelt: ManglendeFelter) => {
+    settManglendeFelter((prev: string[]): string[] => [
+      ...prev,
+      manglendeFelterTilTekst[manglendeFelt],
+    ]);
+  }
+
   const validerHvisSøkerSkalGifteSeg = () =>{
     if(søknad.bosituasjon.skalGifteSegEllerBliSamboer?.verdi){
-      console.log("søknad.bosituasjon", søknad.bosituasjon)
+      console.log("validerer gifte seg", søknad.bosituasjon)
       const gyldigDatoForgiftemål =  datoSkalGifteSegEllerBliSamboerScema.isValidSync(søknad.bosituasjon.datoSkalGifteSegEllerBliSamboer);
       const gyldigIdent =  søknad.bosituasjon.vordendeSamboerEktefelle && identSchema.isValidSync(søknad.bosituasjon.vordendeSamboerEktefelle.ident);
       const gyldigFødselsdato = søknad.bosituasjon.vordendeSamboerEktefelle && fødselsdatoSchema.isValidSync(søknad.bosituasjon.vordendeSamboerEktefelle.fødselsdato);
-      //const harIkkeGyldigIdentEllerDatoPåVordende = (!gyldigFødselsdato && !gyldigIdent);
       const harGyldigIdentEllerDatoPåVordende = gyldigFødselsdato || gyldigIdent;
-
-      console.log(" gyldig dato for giftemål", gyldigFødselsdato)
-      console.log(" gyldig ident", gyldigIdent)
-      console.log(" gyldig gyldigFødselsdato", gyldigDatoForgiftemål)
-
       if (!harGyldigIdentEllerDatoPåVordende || !gyldigDatoForgiftemål) {
-
-        if (!manglendeFelter.includes(
-            manglendeFelterTilTekst[ManglendeFelter.BOSITUASJONEN_DIN]
-        )) {
-          settManglendeFelter((prev: string[]): string[] => [
-            ...prev,
-            manglendeFelterTilTekst[ManglendeFelter.BOSITUASJONEN_DIN],
-          ]);
+        if (feilIkkeRegistrertFor(ManglendeFelter.BOSITUASJONEN_DIN)) {
+          oppdaterManglendeFelter(ManglendeFelter.BOSITUASJONEN_DIN);
         }
         logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, "ValidationError: vordendeSamboerEktefelle mangler gyldig ident eller fødselsdato");
       }
@@ -99,12 +100,8 @@ const Oppsummering: React.FC = () => {
             manglendeFelterTilTekst[ManglendeFelter.AKTIVITET]
           )
         ) {
-          settManglendeFelter((prev: string[]): string[] => [
-            ...prev,
-            manglendeFelterTilTekst[ManglendeFelter.AKTIVITET],
-          ]);
+          oppdaterManglendeFelter(ManglendeFelter.AKTIVITET)
         }
-
         logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, e);
       });
 
@@ -112,17 +109,9 @@ const Oppsummering: React.FC = () => {
       .validate(søknad.sivilstatus)
       .then()
       .catch((e) => {
-        if (
-          !manglendeFelter.includes(
-            manglendeFelterTilTekst[ManglendeFelter.OM_DEG]
-          )
-        ) {
-          settManglendeFelter((prev: string[]): string[] => [
-            ...prev,
-            manglendeFelterTilTekst[ManglendeFelter.OM_DEG],
-          ]);
+        if (feilIkkeRegistrertFor(ManglendeFelter.OM_DEG)){
+          oppdaterManglendeFelter(ManglendeFelter.OM_DEG)
         }
-
         logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, e);
       });
 
@@ -130,17 +119,9 @@ const Oppsummering: React.FC = () => {
       .validate(søknad.merOmDinSituasjon)
       .then()
       .catch((e) => {
-        if (
-          !manglendeFelter.includes(
-            manglendeFelterTilTekst[ManglendeFelter.MER_OM_DIN_SITUASJON]
-          )
-        ) {
-          settManglendeFelter((prev: string[]): string[] => [
-            ...prev,
-            manglendeFelterTilTekst[ManglendeFelter.MER_OM_DIN_SITUASJON],
-          ]);
+        if (feilIkkeRegistrertFor(ManglendeFelter.MER_OM_DIN_SITUASJON)){
+          oppdaterManglendeFelter(ManglendeFelter.MER_OM_DIN_SITUASJON)
         }
-
         logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, e);
       });
 
@@ -148,17 +129,9 @@ const Oppsummering: React.FC = () => {
       .validate(søknad.medlemskap)
       .then()
       .catch((e) => {
-        if (
-          !manglendeFelter.includes(
-            manglendeFelterTilTekst[ManglendeFelter.OM_DEG]
-          )
-        ) {
-          settManglendeFelter((prev: string[]): string[] => [
-            ...prev,
-            manglendeFelterTilTekst[ManglendeFelter.OM_DEG],
-          ]);
+        if (feilIkkeRegistrertFor(ManglendeFelter.OM_DEG)){
+          oppdaterManglendeFelter(ManglendeFelter.OM_DEG)
         }
-
         logManglendeFelter(ESkjemanavn.Overgangsstønad, skjemaId, e);
       });
   }, [søknad, manglendeFelter, skjemaId]);

--- a/src/utils/validering/validering.ts
+++ b/src/utils/validering/validering.ts
@@ -1,5 +1,5 @@
 import { object, string, array } from 'yup';
-import {dnr as dnrValidator, fnr as fnrValidator} from "@navikt/fnrvalidator";
+import { dnr as dnrValidator, fnr as fnrValidator } from '@navikt/fnrvalidator';
 
 // eslint-disable-next-line
 const datoRegex = /^\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01])$/;
@@ -115,18 +115,23 @@ export const sivilstatusSchema = object({
 });
 
 const identErGyldig = (ident: string): boolean =>
-    fnrValidator(ident).status === 'valid' ||
-    dnrValidator(ident).status === 'valid';
-
+  fnrValidator(ident).status === 'valid' ||
+  dnrValidator(ident).status === 'valid';
 
 export const datoSkalGifteSegEllerBliSamboerScema = object({
-    verdi: string().required().matches(datoRegex, 'Ikke en gyldig dato'),
-  })
+  verdi: string().required().matches(datoRegex, 'Ikke en gyldig dato'),
+});
 
 export const identSchema = object({
-    verdi: string().required().test( "ident", "Ikke gyldig ident",  (ident: string ) => (  identErGyldig(ident)  )),
-})
+  verdi: string()
+    .required()
+    .test('ident', 'Ikke gyldig ident', (ident: string) =>
+      identErGyldig(ident)
+    ),
+});
 
 export const fødselsdatoSchema = object({
-    verdi: string().required("Fødselsdato mangler").matches(datoRegex, 'Ikke en gyldig dato'),
-})
+  verdi: string()
+    .required('Fødselsdato mangler')
+    .matches(datoRegex, 'Ikke en gyldig dato'),
+});

--- a/src/utils/validering/validering.ts
+++ b/src/utils/validering/validering.ts
@@ -114,20 +114,6 @@ export const sivilstatusSchema = object({
   }).default(undefined),
 });
 
-
-// const yup = require('yup')
-// const {
-//     setLocale
-// } = yup
-//
-// setLocale({
-//     mixed: {
-//         notType: 'the ${path} is obligatory',
-//         required: 'the field ${path} is obligatory',
-//         oneOf: 'the field ${path} must have one of the following values: ${values}'
-//     }
-// })
-
 const identErGyldig = (ident: string): boolean =>
     fnrValidator(ident).status === 'valid' ||
     dnrValidator(ident).status === 'valid';

--- a/src/utils/validering/validering.ts
+++ b/src/utils/validering/validering.ts
@@ -1,4 +1,5 @@
 import { object, string, array } from 'yup';
+import {dnr as dnrValidator, fnr as fnrValidator} from "@navikt/fnrvalidator";
 
 // eslint-disable-next-line
 const datoRegex = /^\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01])$/;
@@ -113,13 +114,33 @@ export const sivilstatusSchema = object({
   }).default(undefined),
 });
 
-export const bosituasjonSchema = object({
-  datoSkalGifteSegEllerBliSamboer: object({
+
+// const yup = require('yup')
+// const {
+//     setLocale
+// } = yup
+//
+// setLocale({
+//     mixed: {
+//         notType: 'the ${path} is obligatory',
+//         required: 'the field ${path} is obligatory',
+//         oneOf: 'the field ${path} must have one of the following values: ${values}'
+//     }
+// })
+
+const identErGyldig = (ident: string): boolean =>
+    fnrValidator(ident).status === 'valid' ||
+    dnrValidator(ident).status === 'valid';
+
+
+export const datoSkalGifteSegEllerBliSamboerScema = object({
     verdi: string().required().matches(datoRegex, 'Ikke en gyldig dato'),
-  }).default(undefined),
-  vordendeSamboerEktefelle: object({
-    fødselsdato: object({
-      verdi: string().required().matches(datoRegex, 'Ikke en gyldig dato'),
-    }),
-  }).default(undefined),
-});
+  })
+
+export const identSchema = object({
+    verdi: string().required().test( "ident", "Ikke gyldig ident",  (ident: string ) => (  identErGyldig(ident)  )),
+})
+
+export const fødselsdatoSchema = object({
+    verdi: string().required("Fødselsdato mangler").matches(datoRegex, 'Ikke en gyldig dato'),
+})

--- a/src/utils/validering/validering.ts
+++ b/src/utils/validering/validering.ts
@@ -118,7 +118,7 @@ const identErGyldig = (ident: string): boolean =>
   fnrValidator(ident).status === 'valid' ||
   dnrValidator(ident).status === 'valid';
 
-export const datoSkalGifteSegEllerBliSamboerScema = object({
+export const datoSkalGifteSegEllerBliSamboerSchema = object({
   verdi: string().required().matches(datoRegex, 'Ikke en gyldig dato'),
 });
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Før fiks var det ikke mulig å legge inn vordende (personinformasjon om en du har planer om å gifte deg med) uten å legge inn fødselsdato på denne. Vi krever at du må legge inn enten fnr, eller fødselsdato tidligere. Her var ikke fnr godt nok vi godtok bare fødselsdato.

Prøvde først å gjøre dette med ett schema (som tiligere), men etter x antall forsøk ga jeg opp. Det er sikkert mulig hvis noen har lyst til å gi det et forsøk. 

Test i preprod: 
Alt ok - sender inn med fnr (dette fungerte ikke tidligere - klagde på at fødselsdato ikke var satt) 
![image](https://github.com/navikt/familie-ef-soknad/assets/53942238/ab859500-9dc4-4035-99b7-c3bac223b7bf)

Dato = feil
![image](https://github.com/navikt/familie-ef-soknad/assets/53942238/551ee56d-3fce-4256-9ec3-b86ad49ee8f4)

Både fnr og dato mangler: 
![image](https://github.com/navikt/familie-ef-soknad/assets/53942238/bb744aa1-afc3-4922-a461-427af6e9fb8f)

Skal ikke gifte seg = ok. 
![image](https://github.com/navikt/familie-ef-soknad/assets/53942238/6989d876-229c-4f3a-b7d0-fbf7455110c7)

Alt er feil 
![image](https://github.com/navikt/familie-ef-soknad/assets/53942238/24a66c36-e2be-453e-a9c1-f7ca10065db6)

