### PR TITLE
Gjenbruk fikset opp i noen småfeil

### DIFF
--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -120,15 +120,7 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                     personData,
                     barn.forelder!
                   );
-                console.log('forelder', forelder);
-                console.log(
-                  'finnGjeldeneBarnOgNullstillForelderHvisDenErDdød()',
-                  finnGjeldeneBarnOgNullstillForelderHvisDenErDdød(
-                    barn,
-                    personData,
-                    barn.forelder!
-                  )
-                );
+
                 return {
                   ...barn,
                   medforelder,

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -7,10 +7,7 @@ import {
 } from '../../models/steg/barnasbosted';
 import { IForelder } from '../../models/steg/forelder';
 import { harValgtSvar } from '../../utils/spørsmålogsvar';
-import {
-  IDatoFelt,
-  ITekstFelt,
-} from '../../models/søknad/søknadsfelter';
+import { IDatoFelt, ITekstFelt } from '../../models/søknad/søknadsfelter';
 
 export const erIdentUtfyltOgGyldig = (ident?: string): boolean =>
   !!ident && erGyldigFødselsnummer(ident);

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -93,12 +93,11 @@ export const skalBorAnnenForelderINorgeVises = (
   );
 };
 
-export const harValgtBorISammeHusEllerBorIkkeINorge = (forelder: IForelder) => {
+export const harValgtBorISammeHus = (forelder: IForelder) => {
   const { borAnnenForelderISammeHus } = forelder;
   return (
     (harValgtSvar(borAnnenForelderISammeHus?.verdi) &&
       borAnnenForelderISammeHus?.svarid !== EBorAnnenForelderISammeHus.ja) ||
-    harValgtSvar(forelder.borAnnenForelderISammeHusBeskrivelse?.verdi) ||
-    !forelder.borINorge?.verdi
+    harValgtSvar(forelder.borAnnenForelderISammeHusBeskrivelse?.verdi)
   );
 };

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -59,7 +59,8 @@ export const skalOmAndreForelderVises = (
   førsteBarnTilHverForelder: IBarn[],
   lagtTilAnnenForelderId: 'annen-forelder',
   barnHarSammeForelder: boolean | undefined,
-  forelder: IForelder
+  forelder: IForelder,
+  finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass: boolean
 ) => {
   return (
     (!barn.medforelder?.verdi && førsteBarnTilHverForelder.length === 0) ||
@@ -67,7 +68,9 @@ export const skalOmAndreForelderVises = (
     (førsteBarnTilHverForelder.length > 0 && barnHarSammeForelder === false) ||
     (barnHarSammeForelder === false &&
       (barn.harSammeAdresse.verdi ||
-        harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi)))
+        harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi))) ||
+    finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass ===
+      false
   );
 };
 

--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -10,7 +10,7 @@ import { ESvar, ISpørsmål, ISvar } from '../../models/felles/spørsmålogsvar'
 import { harValgtSvar } from '../../utils/spørsmålogsvar';
 import { erDatoGyldigOgInnaforBegrensninger } from '../../components/dato/utils';
 import { DatoBegrensning } from '../../components/dato/Datovelger';
-import { harValgtBorISammeHusEllerBorIkkeINorge } from './barnetsBostedEndre';
+import { harValgtBorISammeHus } from './barnetsBostedEndre';
 import { stringHarVerdiOgErIkkeTom } from '../../utils/typer';
 import { erGyldigDato } from '../../utils/dato';
 import { IBooleanFelt } from '../../models/søknad/søknadsfelter';
@@ -37,7 +37,7 @@ export const erForelderUtfylt = (
     utfyltAvtaleDeltBosted &&
     utfyltNødvendigeSamværSpørsmål(forelder) &&
     utfyltNødvendigBostedSpørsmål(forelder) &&
-    harValgtBorISammeHusEllerBorIkkeINorge(forelder) &&
+    harValgtBorISammeHus(forelder) &&
     visSpørsmålHvisIkkeSammeForelder(forelder) &&
     utfyltBoddSammenAnnenForelder(forelder);
 

--- a/src/models/søknad/person.ts
+++ b/src/models/søknad/person.ts
@@ -1,5 +1,6 @@
 import { IBarn } from '../steg/barn';
 import { IDatoFelt, ITekstFelt } from './søknadsfelter';
+import { hentTekst } from '../../utils/søknad';
 
 export interface IPerson {
   hash: string;

--- a/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
@@ -105,11 +105,15 @@ const BarnasBostedInnhold: React.FC<Props> = ({
     }
   };
 
+  console.log('barnMedLevendeMedforelder', barnMedLevendeMedforelder);
   return (
     <>
       {barnMedLevendeMedforelder.map((barn: IBarn, index: number) => {
         const key = barn.fødselsdato.verdi + index;
         if (index === aktivIndex) {
+          {
+            console.log('index === aktivIndex', index === aktivIndex);
+          }
           return (
             <BarnetsBostedEndre
               barn={barn}

--- a/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
@@ -4,7 +4,6 @@ import { useLokalIntlContext } from '../../../context/LokalIntlContext';
 import BarnetsBostedLagtTil from '../../../søknad/steg/4-barnasbosted/BarnetsBostedLagtTil';
 import BarnetsBostedEndre from '../../../søknad/steg/4-barnasbosted/BarnetsBostedEndre';
 import { IBarn } from '../../../models/steg/barn';
-
 import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
 import BarneHeader from '../../../components/BarneHeader';
 import {
@@ -49,7 +48,8 @@ const BarnasBostedInnhold: React.FC<Props> = ({
 
   const barnMedLevendeMedforelder = aktuelleBarn.filter(
     (barn: IBarn) =>
-      barn.medforelder?.verdi && barn.medforelder?.verdi?.død !== true
+      !barn.medforelder?.verdi ||
+      (barn.medforelder?.verdi && barn.medforelder?.verdi?.død !== true)
   );
 
   const barnMedDødMedforelder = aktuelleBarn.filter((barn: IBarn) => {

--- a/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
@@ -105,15 +105,11 @@ const BarnasBostedInnhold: React.FC<Props> = ({
     }
   };
 
-  console.log('barnMedLevendeMedforelder', barnMedLevendeMedforelder);
   return (
     <>
       {barnMedLevendeMedforelder.map((barn: IBarn, index: number) => {
         const key = barn.fødselsdato.verdi + index;
         if (index === aktivIndex) {
-          {
-            console.log('index === aktivIndex', index === aktivIndex);
-          }
           return (
             <BarnetsBostedEndre
               barn={barn}

--- a/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
@@ -48,7 +48,8 @@ const BarnasBostedInnhold: React.FC<Props> = ({
   const intl = useLokalIntlContext();
 
   const barnMedLevendeMedforelder = aktuelleBarn.filter(
-    (barn: IBarn) => barn.medforelder?.verdi?.død === false
+    (barn: IBarn) =>
+      !barn.medforelder?.verdi || barn.medforelder?.verdi?.død === false
   );
   console.log('barnMedLevendeMedforelder: ', barnMedLevendeMedforelder);
   console.log('aktuelle barn', aktuelleBarn);

--- a/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
@@ -48,8 +48,7 @@ const BarnasBostedInnhold: React.FC<Props> = ({
   const intl = useLokalIntlContext();
 
   const barnMedLevendeMedforelder = aktuelleBarn.filter(
-    (barn: IBarn) =>
-      !barn.medforelder?.verdi || barn.medforelder?.verdi?.død === false
+    (barn: IBarn) => barn.medforelder?.verdi?.død === false
   );
   console.log('barnMedLevendeMedforelder: ', barnMedLevendeMedforelder);
   console.log('aktuelle barn', aktuelleBarn);

--- a/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
@@ -51,6 +51,8 @@ const BarnasBostedInnhold: React.FC<Props> = ({
     (barn: IBarn) =>
       !barn.medforelder?.verdi || barn.medforelder?.verdi?.død === false
   );
+  console.log('barnMedLevendeMedforelder: ', barnMedLevendeMedforelder);
+  console.log('aktuelle barn', aktuelleBarn);
 
   const barnMedDødMedforelder = aktuelleBarn.filter((barn: IBarn) => {
     return barn.medforelder?.verdi?.død === true;
@@ -141,6 +143,7 @@ const BarnasBostedInnhold: React.FC<Props> = ({
           );
         }
       })}
+      <h1>Test</h1>
       {sisteBarnUtfylt &&
         barnMedDødMedforelder.map((barn: IBarn) => (
           <SeksjonGruppe key={barn.id}>

--- a/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
@@ -49,10 +49,8 @@ const BarnasBostedInnhold: React.FC<Props> = ({
 
   const barnMedLevendeMedforelder = aktuelleBarn.filter(
     (barn: IBarn) =>
-      !barn.medforelder?.verdi || barn.medforelder?.verdi?.død === false
+      barn.medforelder?.verdi && barn.medforelder?.verdi?.død !== true
   );
-  console.log('barnMedLevendeMedforelder: ', barnMedLevendeMedforelder);
-  console.log('aktuelle barn', aktuelleBarn);
 
   const barnMedDødMedforelder = aktuelleBarn.filter((barn: IBarn) => {
     return barn.medforelder?.verdi?.død === true;
@@ -143,7 +141,6 @@ const BarnasBostedInnhold: React.FC<Props> = ({
           );
         }
       })}
-      <h1>Test</h1>
       {sisteBarnUtfylt &&
         barnMedDødMedforelder.map((barn: IBarn) => (
           <SeksjonGruppe key={barn.id}>

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -153,6 +153,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     harValgtBorISammeHusEllerBorIkkeINorge(forelder) &&
     utfyltBorINorge(forelder);
 
+  console.log('førsteBarnTilHverForelder', førsteBarnTilHverForelder);
   return (
     <div className="barnas-bosted">
       <SeksjonGruppe>

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -131,12 +131,21 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     );
   };
 
+  const finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass =
+    barneListe.some(
+      (b) =>
+        b.skalHaBarnepass?.verdi &&
+        b.medforelder?.verdi?.ident &&
+        b.medforelder?.verdi?.navn
+    );
+
   const visOmAndreForelder = skalOmAndreForelderVises(
     barn,
     førsteBarnTilHverForelder,
     lagtTilAnnenForelderId,
     barnHarSammeForelder,
-    forelder
+    forelder,
+    finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass
   );
 
   const visBorAnnenForelderINorge = skalBorAnnenForelderINorgeVises(
@@ -153,14 +162,6 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     harValgtBorISammeHusEllerBorIkkeINorge(forelder) &&
     utfyltBorINorge(forelder);
 
-  const finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass =
-    barneListe.some(
-      (b) =>
-        b.skalHaBarnepass?.verdi &&
-        b.medforelder?.verdi?.ident &&
-        b.medforelder?.verdi?.navn
-    );
-
   const skalViseAnnenForelderValg =
     // (førsteBarnTilHverForelder.length > 0 && !barn.medforelder?.verdi) ||
     finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass;
@@ -170,6 +171,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     'finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass',
     finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass
   );
+
   return (
     <div className="barnas-bosted">
       <SeksjonGruppe>

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -157,12 +157,12 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     barneListe.some(
       (b) =>
         b.skalHaBarnepass?.verdi &&
-        b.medforelder?.verdi.ident &&
-        b.medforelder.verdi.navn
+        b.medforelder?.verdi?.ident &&
+        b.medforelder?.verdi?.navn
     );
 
   const skalViseAnnenForelderValg =
-    (førsteBarnTilHverForelder.length > 0 && !barn.medforelder?.verdi) ||
+    // (førsteBarnTilHverForelder.length > 0 && !barn.medforelder?.verdi) ||
     finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass;
 
   console.log('førsteBarnTilHverForelder', førsteBarnTilHverForelder);

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -131,7 +131,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     );
   };
 
-  const finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass =
+  const finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn =
     barneListe.some(
       (b) =>
         b.skalHaBarnepass?.verdi &&
@@ -145,7 +145,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     lagtTilAnnenForelderId,
     barnHarSammeForelder,
     forelder,
-    finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass
+    finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn
   );
 
   const visBorAnnenForelderINorge = skalBorAnnenForelderINorgeVises(
@@ -162,15 +162,8 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     harValgtBorISammeHus(forelder) && utfyltBorINorge(forelder);
 
   const skalViseAnnenForelderValg =
-    // (førsteBarnTilHverForelder.length > 0 && !barn.medforelder?.verdi) ||
-    finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass &&
+    finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn &&
     !barn.medforelder?.verdi;
-
-  console.log('førsteBarnTilHverForelder', førsteBarnTilHverForelder);
-  console.log(
-    'finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass',
-    finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass
-  );
 
   return (
     <div className="barnas-bosted">

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -34,7 +34,7 @@ import {
   erIdentUtfyltOgGyldig,
   finnFørsteBarnTilHverForelder,
   finnTypeBarnForMedForelder,
-  harValgtBorISammeHusEllerBorIkkeINorge,
+  harValgtBorISammeHus,
   skalBorAnnenForelderINorgeVises,
   skalOmAndreForelderVises,
 } from '../../../helpers/steg/barnetsBostedEndre';
@@ -159,8 +159,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   );
 
   const skalFylleUtHarBoddSammenFør =
-    harValgtBorISammeHusEllerBorIkkeINorge(forelder) &&
-    utfyltBorINorge(forelder);
+    harValgtBorISammeHus(forelder) && utfyltBorINorge(forelder);
 
   const skalViseAnnenForelderValg =
     // (førsteBarnTilHverForelder.length > 0 && !barn.medforelder?.verdi) ||

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -164,7 +164,8 @@ const BarnetsBostedEndre: React.FC<Props> = ({
 
   const skalViseAnnenForelderValg =
     // (førsteBarnTilHverForelder.length > 0 && !barn.medforelder?.verdi) ||
-    finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass;
+    finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass &&
+    !barn.medforelder?.verdi;
 
   console.log('førsteBarnTilHverForelder', førsteBarnTilHverForelder);
   console.log(

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -153,7 +153,23 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     harValgtBorISammeHusEllerBorIkkeINorge(forelder) &&
     utfyltBorINorge(forelder);
 
+  const finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass =
+    barneListe.some(
+      (b) =>
+        b.skalHaBarnepass?.verdi &&
+        b.medforelder?.verdi.ident &&
+        b.medforelder.verdi.navn
+    );
+
+  const skalViseAnnenForelderValg =
+    (førsteBarnTilHverForelder.length > 0 && !barn.medforelder?.verdi) ||
+    finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass;
+
   console.log('førsteBarnTilHverForelder', førsteBarnTilHverForelder);
+  console.log(
+    'finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass',
+    finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass
+  );
   return (
     <div className="barnas-bosted">
       <SeksjonGruppe>
@@ -174,18 +190,17 @@ const BarnetsBostedEndre: React.FC<Props> = ({
           <SeksjonGruppe>
             <BarnetsAndreForelderTittel barn={barn} />
 
-            {førsteBarnTilHverForelder.length > 0 &&
-              !barn.medforelder?.verdi && (
-                <AnnenForelderKnapper
-                  barn={barn}
-                  forelder={forelder}
-                  oppdaterAnnenForelder={leggTilAnnenForelderId}
-                  førsteBarnTilHverForelder={førsteBarnTilHverForelder}
-                  settBarnHarSammeForelder={settBarnHarSammeForelder}
-                  settForelder={settForelder}
-                  oppdaterBarn={oppdaterBarnISøknaden}
-                />
-              )}
+            {skalViseAnnenForelderValg && (
+              <AnnenForelderKnapper
+                barn={barn}
+                forelder={forelder}
+                oppdaterAnnenForelder={leggTilAnnenForelderId}
+                førsteBarnTilHverForelder={førsteBarnTilHverForelder}
+                settBarnHarSammeForelder={settBarnHarSammeForelder}
+                settForelder={settForelder}
+                oppdaterBarn={oppdaterBarnISøknaden}
+              />
+            )}
 
             {visOmAndreForelder && (
               <OmAndreForelder


### PR DESCRIPTION
- Gjort slik at informasjon om annen forelder fra gjenbruk ikke vises i oppsummering hvis den er død og ikke blir sendt med [Favro - oppgave 5](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-17705).
- Fikset slik at spørsmål om bor på samme sted må fylles ut selvom svar på annen forelder bor i Norge er nei.
- Skal ikke vise annen forelder knapp når det ikke skal være andre alternativer (barn).

Vi squasher ved merge, og lar console logger bli frem til merge.