### PR TITLE
Ved gjenbruk skal ikke barn som er døde tas med i ny søknad

### DIFF
--- a/src/barnetilsyn/BarnetilsynApp.tsx
+++ b/src/barnetilsyn/BarnetilsynApp.tsx
@@ -47,19 +47,7 @@ const BarnetilsynApp = () => {
     settSøknad((prevSøknad) => {
       const prevBarn = prevSøknad.person.barn;
 
-      const sortertBarnelistePåMedforelder = [
-        ...prevBarn,
-        ...barnMedLabels,
-      ].sort((a, b) => {
-        if (a.medforelder?.verdi && !b.medforelder?.verdi) {
-          return -1;
-        }
-        if (!a.medforelder?.verdi && b.medforelder?.verdi) {
-          return 1;
-        }
-        return 0;
-      });
-
+      const sortertBarnelistePåMedforelder = [...prevBarn, ...barnMedLabels];
       return {
         ...prevSøknad,
         person: { ...person, barn: sortertBarnelistePåMedforelder },

--- a/src/barnetilsyn/BarnetilsynApp.tsx
+++ b/src/barnetilsyn/BarnetilsynApp.tsx
@@ -50,7 +50,15 @@ const BarnetilsynApp = () => {
       const sortertBarnelistePåMedforelder = [
         ...prevBarn,
         ...barnMedLabels,
-      ].sort((_, b) => (b.medforelder.verdi ? 1 : -1));
+      ].sort((a, b) => {
+        if (a.medforelder?.verdi && !b.medforelder?.verdi) {
+          return -1;
+        }
+        if (!a.medforelder?.verdi && b.medforelder?.verdi) {
+          return 1;
+        }
+        return 0;
+      });
 
       return {
         ...prevSøknad,

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -102,38 +102,46 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
       console.log('personData', personData);
 
       if (forrigeSøknad) {
-        settSøknad((prevSøknad) => ({
-          ...prevSøknad,
-          ...forrigeSøknad,
-          person: {
-            ...prevSøknad.person,
-            barn: [
-              ...forrigeSøknad.person.barn.map((barn) => {
-                const medforelder = finnGjeldeneBarnOgLagMedforelderFelt(
-                  barn,
-                  personData
-                );
+        settSøknad((prevSøknad) => {
+          const aktuelleBarn = forrigeSøknad.person.barn.filter((barn) =>
+            personData.barn.some(
+              (personBarn) => personBarn.fnr === barn.ident.verdi
+            )
+          );
 
-                const forelder =
-                  finnGjeldeneBarnOgNullstillForelderHvisDenErDdød(
+          return {
+            ...prevSøknad,
+            ...forrigeSøknad,
+            person: {
+              ...prevSøknad.person,
+              barn: [
+                ...aktuelleBarn.map((barn) => {
+                  const medforelder = finnGjeldeneBarnOgLagMedforelderFelt(
                     barn,
-                    personData,
-                    barn.forelder!
+                    personData
                   );
 
-                return {
-                  ...barn,
-                  medforelder,
-                  forelder,
-                  fraFolkeregister: prevSøknad.person.barn.find(
-                    (prevBarn) => prevBarn.ident.verdi === barn.ident.verdi
-                  )?.forelder?.fraFolkeregister,
-                };
-              }),
-              ...finnNyeBarnSidenForrigeSøknad(prevSøknad, forrigeSøknad),
-            ],
-          },
-        }));
+                  const forelder =
+                    finnGjeldeneBarnOgNullstillForelderHvisDenErDdød(
+                      barn,
+                      personData,
+                      barn.forelder!
+                    );
+
+                  return {
+                    ...barn,
+                    medforelder,
+                    forelder,
+                    fraFolkeregister: prevSøknad.person.barn.find(
+                      (prevBarn) => prevBarn.ident.verdi === barn.ident.verdi
+                    )?.forelder?.fraFolkeregister,
+                  };
+                }),
+                ...finnNyeBarnSidenForrigeSøknad(prevSøknad, forrigeSøknad),
+              ],
+            },
+          };
+        });
       }
     };
 

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -132,9 +132,10 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                     `${barn.navn} barn?.forelder?.navn`,
                     barn?.forelder?.navn
                   );
+
                   const erAnnenForelderEndret =
-                    // stringHarVerdiOgErIkkeTom(medforelder?.verdi.navn) &&
-                    // stringHarVerdiOgErIkkeTom(barn?.forelder?.navn) &&
+                    stringHarVerdiOgErIkkeTom(medforelder?.verdi.navn) &&
+                    stringHarVerdiOgErIkkeTom(barn?.forelder?.navn) &&
                     medforelder?.verdi.navn !== barn.forelder?.navn?.verdi;
 
                   const forelder = erAnnenForelderEndret

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -14,6 +14,7 @@ import Environment from '../Environment';
 import { EArbeidssituasjon } from '../models/steg/aktivitet/aktivitet';
 import {
   hentDataFraForrigeBarnetilsynSøknad,
+  hentFeltObjekt,
   hentMellomlagretSøknadFraDokument,
   hentPersonData,
   mellomlagreSøknadTilDokument,
@@ -138,8 +139,16 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                     forelder: forelder
                       ? {
                           ...forelder,
-                          navn: medforelder?.verdi?.navn,
-                          ident: medforelder?.verdi?.ident,
+                          navn: hentFeltObjekt(
+                            'person.navn',
+                            medforelder?.verdi?.navn,
+                            intl
+                          ),
+                          ident: hentFeltObjekt(
+                            'person.ident.visning',
+                            medforelder?.verdi?.ident,
+                            intl
+                          ),
                           id: hentUid(),
                         }
                       : undefined,

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -31,6 +31,7 @@ import { LocaleType } from '../language/typer';
 import { dagensDato, formatIsoDate } from '../utils/dato';
 import { IMedforelderFelt } from '../models/steg/medforelder';
 import { IForelder } from '../models/steg/forelder';
+import { hentUid } from '../utils/autentiseringogvalidering/uuid';
 
 const initialState = (intl: LokalIntlShape): ISøknad => {
   return {
@@ -131,7 +132,10 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                   return {
                     ...barn,
                     medforelder,
-                    forelder,
+                    forelder: {
+                      ...forelder,
+                      id: hentUid(),
+                    },
                     fraFolkeregister: prevSøknad.person.barn.find(
                       (prevBarn) => prevBarn.ident.verdi === barn.ident.verdi
                     )?.forelder?.fraFolkeregister,

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -125,11 +125,11 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                   );
 
                   console.log(
-                    `${barn.navn} medforelder?.verdi.navn`,
+                    `${barn.navn.verdi} medforelder?.verdi.navn`,
                     medforelder?.verdi.navn
                   );
                   console.log(
-                    `${barn.navn} barn?.forelder?.navn`,
+                    `${barn.navn.verdi} barn?.forelder?.navn`,
                     barn?.forelder?.navn
                   );
 
@@ -139,7 +139,10 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                     medforelder?.verdi.navn !== barn.forelder?.navn?.verdi;
 
                   const forelder = erAnnenForelderEndret
-                    ? undefined
+                    ? oppdaterBarnForelderIdentOgNavn(
+                        barn.forelder,
+                        medforelder
+                      )
                     : finnGjeldendeBarnOgNullstillAnnenForelderHvisDød(
                         barn,
                         personData,
@@ -153,18 +156,11 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                     medforelder,
                     forelder: forelder
                       ? {
-                          ...forelder,
-                          navn: hentFeltObjekt(
-                            'person.navn',
-                            medforelder?.verdi?.navn,
-                            intl
+                          forelder,
+                          ...oppdaterBarnForelderIdentOgNavn(
+                            forelder,
+                            medforelder
                           ),
-                          ident: hentFeltObjekt(
-                            'person.ident.visning',
-                            medforelder?.verdi?.ident,
-                            intl
-                          ),
-                          id: hentUid(),
                         }
                       : undefined,
                     fraFolkeregister: prevSøknad.person.barn.find(
@@ -178,6 +174,28 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
             },
           };
         });
+      }
+    };
+
+    const oppdaterBarnForelderIdentOgNavn = (
+      forelder: IForelder | undefined,
+      medforelder: IMedforelderFelt | undefined
+    ): IForelder => {
+      if (medforelder) {
+        return {
+          ...forelder,
+          navn: hentFeltObjekt('person.navn', medforelder.verdi.navn, intl),
+          ident: hentFeltObjekt(
+            'person.ident.visning',
+            medforelder.verdi.ident,
+            intl
+          ),
+          id: hentUid(),
+        };
+      } else {
+        return {
+          ...forelder,
+        };
       }
     };
 

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -138,6 +138,8 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                     forelder: forelder
                       ? {
                           ...forelder,
+                          navn: medforelder?.verdi?.navn,
+                          ident: medforelder?.verdi?.ident,
                           id: hentUid(),
                         }
                       : undefined,

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -148,15 +148,7 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                   };
                 }),
                 ...finnNyeBarnSidenForrigeSøknad(prevSøknad, forrigeSøknad),
-              ].sort((a, b) => {
-                if (a.medforelder?.verdi && !b.medforelder?.verdi) {
-                  return -1;
-                }
-                if (!a.medforelder?.verdi && b.medforelder?.verdi) {
-                  return 1;
-                }
-                return 0;
-              }),
+              ],
             },
           };
         });

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -33,6 +33,7 @@ import { dagensDato, formatIsoDate } from '../utils/dato';
 import { IMedforelderFelt } from '../models/steg/medforelder';
 import { IForelder } from '../models/steg/forelder';
 import { hentUid } from '../utils/autentiseringogvalidering/uuid';
+import { stringHarVerdiOgErIkkeTom } from '../utils/typer';
 
 const initialState = (intl: LokalIntlShape): ISøknad => {
   return {
@@ -122,8 +123,19 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                     barn,
                     personData
                   );
+
+                  console.log(
+                    `${barn.navn} medforelder?.verdi.navn`,
+                    medforelder?.verdi.navn
+                  );
+                  console.log(
+                    `${barn.navn} barn?.forelder?.navn`,
+                    barn?.forelder?.navn
+                  );
                   const erAnnenForelderEndret =
-                    medforelder?.verdi.navn !== barn.forelder?.navn;
+                    // stringHarVerdiOgErIkkeTom(medforelder?.verdi.navn) &&
+                    // stringHarVerdiOgErIkkeTom(barn?.forelder?.navn) &&
+                    medforelder?.verdi.navn !== barn.forelder?.navn?.verdi;
 
                   const forelder = erAnnenForelderEndret
                     ? undefined
@@ -132,6 +144,8 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                         personData,
                         barn.forelder!
                       );
+
+                  console.log(`${barn.navn} forelder`, forelder);
 
                   return {
                     ...barn,

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -135,6 +135,7 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                     fraFolkeregister: prevSøknad.person.barn.find(
                       (prevBarn) => prevBarn.ident.verdi === barn.ident.verdi
                     )?.forelder?.fraFolkeregister,
+                    erFraForrigeSøknad: true,
                   };
                 }),
                 ...finnNyeBarnSidenForrigeSøknad(prevSøknad, forrigeSøknad),

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -148,7 +148,15 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                   };
                 }),
                 ...finnNyeBarnSidenForrigeSøknad(prevSøknad, forrigeSøknad),
-              ],
+              ].sort((a, b) => {
+                if (a.medforelder?.verdi && !b.medforelder?.verdi) {
+                  return -1;
+                }
+                if (!a.medforelder?.verdi && b.medforelder?.verdi) {
+                  return 1;
+                }
+                return 0;
+              }),
             },
           };
         });

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -154,15 +154,7 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                   return {
                     ...barn,
                     medforelder,
-                    forelder: forelder
-                      ? {
-                          forelder,
-                          ...oppdaterBarnForelderIdentOgNavn(
-                            forelder,
-                            medforelder
-                          ),
-                        }
-                      : undefined,
+                    forelder: forelder,
                     fraFolkeregister: prevSøknad.person.barn.find(
                       (prevBarn) => prevBarn.ident.verdi === barn.ident.verdi
                     )?.forelder?.fraFolkeregister,

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -140,17 +140,17 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
     const finnGjeldeneBarnOgLagMedforelderFelt = (
       barn: IBarn,
       personData: PersonData
-    ): IMedforelderFelt => {
+    ): IMedforelderFelt | undefined => {
       const gjeldendeBarn = personData.barn.find(
         (personBarn) => personBarn.fnr === barn.ident.verdi
       );
 
-      return {
-        label: 'Annen forelder',
-        verdi: gjeldendeBarn?.medforelder ?? {
-          harAdressesperre: true,
-        },
-      };
+      return gjeldendeBarn?.medforelder
+        ? {
+            label: 'Annen forelder',
+            verdi: gjeldendeBarn?.medforelder,
+          }
+        : undefined;
     };
 
     const finnGjeldeneBarnOgNullstillForelderHvisDenErDdød = (

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -123,7 +123,7 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                   );
 
                   const forelder =
-                    finnGjeldeneBarnOgNullstillAnnenForelderHvisDød(
+                    finnGjeldendeBarnOgNullstillAnnenForelderHvisDød(
                       barn,
                       personData,
                       barn.forelder!
@@ -165,7 +165,7 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
         : undefined;
     };
 
-    const finnGjeldeneBarnOgNullstillAnnenForelderHvisDød = (
+    const finnGjeldendeBarnOgNullstillAnnenForelderHvisDød = (
       barn: IBarn,
       personData: PersonData,
       forelder: IForelder

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -121,13 +121,16 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                     barn,
                     personData
                   );
+                  const erAnnenForelderEndret =
+                    medforelder?.verdi.navn !== barn.forelder?.navn;
 
-                  const forelder =
-                    finnGjeldendeBarnOgNullstillAnnenForelderHvisDød(
-                      barn,
-                      personData,
-                      barn.forelder!
-                    );
+                  const forelder = erAnnenForelderEndret
+                    ? undefined
+                    : finnGjeldendeBarnOgNullstillAnnenForelderHvisDød(
+                        barn,
+                        personData,
+                        barn.forelder!
+                      );
 
                   return {
                     ...barn,

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -135,10 +135,12 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                   return {
                     ...barn,
                     medforelder,
-                    forelder: {
-                      ...forelder,
-                      id: hentUid(),
-                    },
+                    forelder: forelder
+                      ? {
+                          ...forelder,
+                          id: hentUid(),
+                        }
+                      : undefined,
                     fraFolkeregister: prevSøknad.person.barn.find(
                       (prevBarn) => prevBarn.ident.verdi === barn.ident.verdi
                     )?.forelder?.fraFolkeregister,

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -116,7 +116,7 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
               ...prevSøknad.person,
               barn: [
                 ...aktuelleBarn.map((barn) => {
-                  const medforelder = finnGjeldeneBarnOgLagMedforelderFelt(
+                  const medforelder = finnGjeldendeBarnOgLagMedforelderFelt(
                     barn,
                     personData
                   );
@@ -145,15 +145,13 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
       }
     };
 
-    const finnGjeldeneBarnOgLagMedforelderFelt = (
+    const finnGjeldendeBarnOgLagMedforelderFelt = (
       barn: IBarn,
       personData: PersonData
     ): IMedforelderFelt | undefined => {
       const gjeldendeBarn = personData.barn.find(
         (personBarn) => personBarn.fnr === barn.ident.verdi
       );
-      console.log('gjeldendeBarn', barn.navn);
-      console.log('gjeldendeBarn?.medforelder', gjeldendeBarn?.medforelder);
       return gjeldendeBarn?.medforelder
         ? {
             label: 'Annen forelder',

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -122,7 +122,7 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                   );
 
                   const forelder =
-                    finnGjeldeneBarnOgNullstillForelderHvisDenErDdød(
+                    finnGjeldeneBarnOgNullstillAnnenForelderHvisDød(
                       barn,
                       personData,
                       barn.forelder!
@@ -152,7 +152,8 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
       const gjeldendeBarn = personData.barn.find(
         (personBarn) => personBarn.fnr === barn.ident.verdi
       );
-
+      console.log('gjeldendeBarn', barn.navn);
+      console.log('gjeldendeBarn?.medforelder', gjeldendeBarn?.medforelder);
       return gjeldendeBarn?.medforelder
         ? {
             label: 'Annen forelder',
@@ -161,7 +162,7 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
         : undefined;
     };
 
-    const finnGjeldeneBarnOgNullstillForelderHvisDenErDdød = (
+    const finnGjeldeneBarnOgNullstillAnnenForelderHvisDød = (
       barn: IBarn,
       personData: PersonData,
       forelder: IForelder

--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -124,37 +124,21 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                     personData
                   );
 
-                  console.log(
-                    `${barn.navn.verdi} medforelder?.verdi.navn`,
-                    medforelder?.verdi.navn
+                  const forelder = oppdaterBarnForelderIdentOgNavn(
+                    barn.forelder,
+                    medforelder
                   );
-                  console.log(
-                    `${barn.navn.verdi} barn?.forelder?.navn`,
-                    barn?.forelder?.navn
-                  );
-
-                  const erAnnenForelderEndret =
-                    stringHarVerdiOgErIkkeTom(medforelder?.verdi.navn) &&
-                    stringHarVerdiOgErIkkeTom(barn?.forelder?.navn) &&
-                    medforelder?.verdi.navn !== barn.forelder?.navn?.verdi;
-
-                  const forelder = erAnnenForelderEndret
-                    ? oppdaterBarnForelderIdentOgNavn(
-                        barn.forelder,
-                        medforelder
-                      )
-                    : finnGjeldendeBarnOgNullstillAnnenForelderHvisDød(
-                        barn,
-                        personData,
-                        barn.forelder!
-                      );
-
-                  console.log(`${barn.navn} forelder`, forelder);
+                  const oppdatertForelder =
+                    finnGjeldendeBarnOgNullstillAnnenForelderHvisDød(
+                      barn,
+                      personData,
+                      forelder
+                    );
 
                   return {
                     ...barn,
                     medforelder,
-                    forelder: forelder,
+                    forelder: oppdatertForelder,
                     fraFolkeregister: prevSøknad.person.barn.find(
                       (prevBarn) => prevBarn.ident.verdi === barn.ident.verdi
                     )?.forelder?.fraFolkeregister,

--- a/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
+++ b/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
@@ -79,21 +79,19 @@ const BarnaDine: React.FC = () => {
           {hentTekst('barnadine.infohentet', intl)}
         </Alert>
         <BarneKortWrapper>
-          {søknad.person.barn
-            ?.sort((a: IBarn, b: IBarn) => parseInt(a.id) - parseInt(b.id))
-            .map((barn: IBarn) => (
-              <Barnekort
-                key={barn.id}
-                gjeldendeBarn={barn}
-                footer={
-                  <BarnMedISøknad
-                    id={barn.id ? barn.id : ''}
-                    toggleSkalHaBarnepass={toggleSkalHaBarnepass}
-                    skalHaBarnepass={!!barn.skalHaBarnepass?.verdi}
-                  />
-                }
-              />
-            ))}
+          {søknad.person.barn.map((barn: IBarn) => (
+            <Barnekort
+              key={barn.id}
+              gjeldendeBarn={barn}
+              footer={
+                <BarnMedISøknad
+                  id={barn.id ? barn.id : ''}
+                  toggleSkalHaBarnepass={toggleSkalHaBarnepass}
+                  skalHaBarnepass={!!barn.skalHaBarnepass?.verdi}
+                />
+              }
+            />
+          ))}
         </BarneKortWrapper>
       </BarnaDineContainer>
     </Side>

--- a/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
+++ b/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
@@ -79,19 +79,29 @@ const BarnaDine: React.FC = () => {
           {hentTekst('barnadine.infohentet', intl)}
         </Alert>
         <BarneKortWrapper>
-          {søknad.person.barn.map((barn: IBarn) => (
-            <Barnekort
-              key={barn.id}
-              gjeldendeBarn={barn}
-              footer={
-                <BarnMedISøknad
-                  id={barn.id ? barn.id : ''}
-                  toggleSkalHaBarnepass={toggleSkalHaBarnepass}
-                  skalHaBarnepass={!!barn.skalHaBarnepass?.verdi}
-                />
+          {søknad.person.barn
+            ?.sort((a: IBarn, b: IBarn) => {
+              if (a.medforelder?.verdi && !b.medforelder?.verdi) {
+                return -1;
               }
-            />
-          ))}
+              if (!a.medforelder?.verdi && b.medforelder?.verdi) {
+                return 1;
+              }
+              return 0;
+            })
+            .map((barn: IBarn) => (
+              <Barnekort
+                key={barn.id}
+                gjeldendeBarn={barn}
+                footer={
+                  <BarnMedISøknad
+                    id={barn.id ? barn.id : ''}
+                    toggleSkalHaBarnepass={toggleSkalHaBarnepass}
+                    skalHaBarnepass={!!barn.skalHaBarnepass?.verdi}
+                  />
+                }
+              />
+            ))}
         </BarneKortWrapper>
       </BarnaDineContainer>
     </Side>

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -83,6 +83,11 @@ export const skalBorAnnenForelderINorgeVises = (
   fødselsdato: IDatoFelt | null | undefined,
   kjennerIkkeIdent: boolean
 ) => {
+  console.log('!!barn.medforelder?.verdi', !!barn.medforelder?.verdi);
+  console.log(
+    'harValgtSvar(ident?.verdi || fødselsdato?.verdi) ||kjennerIkkeIdent))',
+    harValgtSvar(ident?.verdi || fødselsdato?.verdi) || kjennerIkkeIdent
+  );
   return (
     (typeBarn !== TypeBarn.BARN_MED_KOPIERT_FORELDERINFORMASJON &&
       !!barn.medforelder?.verdi) ||

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -62,11 +62,16 @@ export const skalOmAndreForelderVises = (
   forelder: IForelder,
   finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn: boolean
 ) => {
+  console.log(
+    'skalOmAndreForelderVises førsteBarnTilHverForelder',
+    førsteBarnTilHverForelder
+  );
+  console.log('barnHarSammeForelder !== true', barnHarSammeForelder !== true);
   return (
     (!barn.medforelder?.verdi && førsteBarnTilHverForelder.length === 0) ||
     barn.annenForelderId === lagtTilAnnenForelderId ||
-    (førsteBarnTilHverForelder.length > 0 && barnHarSammeForelder === false) ||
-    (barnHarSammeForelder === false &&
+    (førsteBarnTilHverForelder.length > 0 && barnHarSammeForelder !== true) ||
+    (barnHarSammeForelder !== true &&
       (barn.harSammeAdresse.verdi ||
         harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi))) ||
     finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn ===

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -42,10 +42,13 @@ export const finnFørsteBarnTilHverForelder = (
     return b !== barn && b.forelder;
   });
 
+  console.log('andreBarnMedForelder', andreBarnMedForelder);
+
   const unikeForeldreIDer = Array.from(
     new Set(andreBarnMedForelder.map((b) => b.forelder?.id))
   );
 
+  console.log('unikeForeldreIDer', unikeForeldreIDer);
   return unikeForeldreIDer
     .map((id) => {
       if (!id) return null;

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -89,7 +89,9 @@ export const skalBorAnnenForelderINorgeVises = (
     (!barnHarSammeForelder &&
       !forelder.kanIkkeOppgiAnnenForelderFar?.verdi &&
       harValgtSvar(forelder?.navn?.verdi) &&
-      (harValgtSvar(ident?.verdi || fødselsdato?.verdi) || kjennerIkkeIdent))
+      (barn.erFraForrigeSøknad ||
+        harValgtSvar(ident?.verdi || fødselsdato?.verdi) ||
+        kjennerIkkeIdent))
   );
 };
 

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -72,7 +72,7 @@ export const skalOmAndreForelderVises = (
     barn.annenForelderId === lagtTilAnnenForelderId ||
     (førsteBarnTilHverForelder.length > 0 &&
       barnHarSammeForelder !== true &&
-      barn.medforelder) ||
+      !barn.medforelder) ||
     (barn.erFraForrigeSøknad === false &&
       barnHarSammeForelder !== true &&
       (barn.harSammeAdresse.verdi ||

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -42,13 +42,10 @@ export const finnFørsteBarnTilHverForelder = (
     return b !== barn && b.forelder;
   });
 
-  console.log('andreBarnMedForelder', andreBarnMedForelder);
-
   const unikeForeldreIDer = Array.from(
     new Set(andreBarnMedForelder.map((b) => b.forelder?.id))
   );
 
-  console.log('unikeForeldreIDer', unikeForeldreIDer);
   return unikeForeldreIDer
     .map((id) => {
       if (!id) return null;

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -42,11 +42,12 @@ export const finnFørsteBarnTilHverForelder = (
   const andreBarnMedForelder: IBarn[] = barneListe.filter((b) => {
     return b !== barn && b.forelder;
   });
-
+  console.log('andreBarnMedForelder', andreBarnMedForelder);
   const unikeForeldreIDer = Array.from(
     new Set(andreBarnMedForelder.map((b) => b.forelder?.id))
   );
 
+  console.log('unikeForeldreIDer', unikeForeldreIDer);
   return unikeForeldreIDer
     .map((id) => {
       if (!id) return null;
@@ -55,7 +56,26 @@ export const finnFørsteBarnTilHverForelder = (
     .filter(Boolean) as IBarn[];
 };
 
-export const skalOmAndreForelderVises = (
+export const barnUtenForelderFraPDLOgIngenAndreForeldreDetKanKopieresFra = (
+  barn: IBarn,
+  førsteBarnTilHverForelder: IBarn[]
+) => {
+  return !barn.medforelder?.verdi && førsteBarnTilHverForelder.length === 0;
+};
+
+export const barnUtenForelderFraPdlOgErIkkeKopiert = (
+  førsteBarnTilHverForelder: IBarn[],
+  barnHarSammeForelder: boolean | undefined,
+  barn: IBarn
+) => {
+  return (
+    førsteBarnTilHverForelder.length > 0 &&
+    barnHarSammeForelder !== true &&
+    !barn.medforelder
+  );
+};
+
+export const skalAnnenForelderRedigeres = (
   barn: IBarn,
   førsteBarnTilHverForelder: IBarn[],
   lagtTilAnnenForelderId: 'annen-forelder',
@@ -64,11 +84,16 @@ export const skalOmAndreForelderVises = (
   finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn: boolean
 ) => {
   return (
-    (!barn.medforelder?.verdi && førsteBarnTilHverForelder.length === 0) ||
+    barnUtenForelderFraPDLOgIngenAndreForeldreDetKanKopieresFra(
+      barn,
+      førsteBarnTilHverForelder
+    ) ||
     barn.annenForelderId === lagtTilAnnenForelderId ||
-    (førsteBarnTilHverForelder.length > 0 &&
-      barnHarSammeForelder !== true &&
-      !barn.medforelder) ||
+    barnUtenForelderFraPdlOgErIkkeKopiert(
+      førsteBarnTilHverForelder,
+      barnHarSammeForelder,
+      barn
+    ) ||
     (barn.erFraForrigeSøknad === false &&
       barnHarSammeForelder !== true &&
       (barn.harSammeAdresse.verdi ||

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -60,7 +60,7 @@ export const skalOmAndreForelderVises = (
   lagtTilAnnenForelderId: 'annen-forelder',
   barnHarSammeForelder: boolean | undefined,
   forelder: IForelder,
-  finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass: boolean
+  finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn: boolean
 ) => {
   return (
     (!barn.medforelder?.verdi && førsteBarnTilHverForelder.length === 0) ||
@@ -69,7 +69,7 @@ export const skalOmAndreForelderVises = (
     (barnHarSammeForelder === false &&
       (barn.harSammeAdresse.verdi ||
         harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi))) ||
-    finnesRegistrertAnnenForelderBlantValgteBarnOgBarnSomSkalHaBarnepass ===
+    finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn ===
       false
   );
 };

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -8,13 +8,14 @@ import {
 import { IForelder } from '../../models/steg/forelder';
 import { harValgtSvar } from '../../utils/spørsmålogsvar';
 import { IDatoFelt, ITekstFelt } from '../../models/søknad/søknadsfelter';
+import { stringErNullEllerTom } from '../../utils/typer';
 
 export const erIdentUtfyltOgGyldig = (ident?: string): boolean =>
   !!ident && erGyldigFødselsnummer(ident);
 
 export const erFødselsdatoUtfyltOgGyldigEllerTomtFelt = (
   fødselsdato?: string
-) => erGyldigDato(fødselsdato) || fødselsdato === '';
+) => erGyldigDato(fødselsdato) || stringErNullEllerTom(fødselsdato);
 
 export const finnTypeBarnForMedForelder = (
   barn: IBarn,

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -70,7 +70,9 @@ export const skalOmAndreForelderVises = (
   return (
     (!barn.medforelder?.verdi && førsteBarnTilHverForelder.length === 0) ||
     barn.annenForelderId === lagtTilAnnenForelderId ||
-    (førsteBarnTilHverForelder.length > 0 && barnHarSammeForelder !== true) ||
+    (førsteBarnTilHverForelder.length > 0 &&
+      barnHarSammeForelder !== true &&
+      barn.medforelder) ||
     (barn.erFraForrigeSøknad === false &&
       barnHarSammeForelder !== true &&
       (barn.harSammeAdresse.verdi ||

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -63,11 +63,6 @@ export const skalOmAndreForelderVises = (
   forelder: IForelder,
   finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn: boolean
 ) => {
-  console.log(
-    'skalOmAndreForelderVises førsteBarnTilHverForelder',
-    førsteBarnTilHverForelder
-  );
-  console.log('barnHarSammeForelder !== true', barnHarSammeForelder !== true);
   return (
     (!barn.medforelder?.verdi && førsteBarnTilHverForelder.length === 0) ||
     barn.annenForelderId === lagtTilAnnenForelderId ||
@@ -92,11 +87,6 @@ export const skalBorAnnenForelderINorgeVises = (
   fødselsdato: IDatoFelt | null | undefined,
   kjennerIkkeIdent: boolean
 ) => {
-  console.log('!!barn.medforelder?.verdi', !!barn.medforelder?.verdi);
-  console.log(
-    'harValgtSvar(ident?.verdi || fødselsdato?.verdi) ||kjennerIkkeIdent))',
-    harValgtSvar(ident?.verdi || fødselsdato?.verdi) || kjennerIkkeIdent
-  );
   return (
     (typeBarn !== TypeBarn.BARN_MED_KOPIERT_FORELDERINFORMASJON &&
       !!barn.medforelder?.verdi) ||

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -71,7 +71,8 @@ export const skalOmAndreForelderVises = (
     (!barn.medforelder?.verdi && førsteBarnTilHverForelder.length === 0) ||
     barn.annenForelderId === lagtTilAnnenForelderId ||
     (førsteBarnTilHverForelder.length > 0 && barnHarSammeForelder !== true) ||
-    (barnHarSammeForelder !== true &&
+    (barn.erFraForrigeSøknad === false &&
+      barnHarSammeForelder !== true &&
       (barn.harSammeAdresse.verdi ||
         harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi))) ||
     finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn ===

--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -73,7 +73,7 @@ export const utfyltNavnOgIdent = (
   const kjennerIkkeIdent =
     stringHarVerdiOgErIkkeTom(forelder.navn?.verdi) &&
     !stringHarVerdiOgErIkkeTom(forelder.ident?.verdi);
-  console.log('kjennerIkkeIdent: ', kjennerIkkeIdent);
+
   return (
     (stringHarVerdiOgErIkkeTom(forelder.navn) &&
       (erIdentUtfyltOgGyldig(forelder.ident?.verdi) ||

--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -87,7 +87,8 @@ export const utfyltNødvendigSpørsmålUtenOppgiAnnenForelder = (
   return kanIkkeOppgiAnnenForelderFar?.verdi && (pgaDonorBarn || pgaAnnet);
 };
 
-export const utfyltNødvendigeSamværSpørsmål = (forelder: IForelder) => {
+export const utfyltNødvendigeSamværSpørsmål = (forelder?: IForelder) => {
+  if (!forelder) return;
   const {
     avtaleOmDeltBosted,
     harAnnenForelderSamværMedBarn,

--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -10,7 +10,10 @@ import { ESvar, ISpørsmål, ISvar } from '../../models/felles/spørsmålogsvar'
 import { harValgtSvar } from '../../utils/spørsmålogsvar';
 import { erDatoGyldigOgInnaforBegrensninger } from '../../components/dato/utils';
 import { DatoBegrensning } from '../../components/dato/Datovelger';
-import { harValgtBorISammeHus } from './barnetsBostedEndre';
+import {
+  finnTypeBarnForMedForelder,
+  harValgtBorISammeHus,
+} from './barnetsBostedEndre';
 import { stringHarVerdiOgErIkkeTom } from '../../utils/typer';
 import { erGyldigDato } from '../../utils/dato';
 import { IBooleanFelt } from '../../models/søknad/søknadsfelter';

--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -15,7 +15,10 @@ import {
   erIdentUtfyltOgGyldig,
   harValgtBorISammeHus,
 } from './barnetsBostedEndre';
-import { stringHarVerdiOgErIkkeTom } from '../../utils/typer';
+import {
+  stringErNullEllerTom,
+  stringHarVerdiOgErIkkeTom,
+} from '../../utils/typer';
 import { erGyldigDato } from '../../utils/dato';
 import { IBooleanFelt } from '../../models/søknad/søknadsfelter';
 

--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -24,9 +24,10 @@ export const utfyltBorINorge = (forelder: IForelder) => {
 };
 
 export const erForelderUtfylt = (
-  forelder: IForelder,
-  harSammeAdresse: IBooleanFelt
+  harSammeAdresse: IBooleanFelt,
+  forelder?: IForelder
 ): boolean | undefined => {
+  if (forelder === undefined) return false;
   const { avtaleOmDeltBosted } = forelder;
 
   const utfyltAvtaleDeltBosted = harValgtSvar(avtaleOmDeltBosted?.verdi);

--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -11,7 +11,8 @@ import { harValgtSvar } from '../../utils/spørsmålogsvar';
 import { erDatoGyldigOgInnaforBegrensninger } from '../../components/dato/utils';
 import { DatoBegrensning } from '../../components/dato/Datovelger';
 import {
-  finnTypeBarnForMedForelder,
+  erFødselsdatoUtfyltOgGyldigEllerTomtFelt,
+  erIdentUtfyltOgGyldig,
   harValgtBorISammeHus,
 } from './barnetsBostedEndre';
 import { stringHarVerdiOgErIkkeTom } from '../../utils/typer';
@@ -28,7 +29,8 @@ export const utfyltBorINorge = (forelder: IForelder) => {
 
 export const erForelderUtfylt = (
   harSammeAdresse: IBooleanFelt,
-  forelder?: IForelder
+  forelder?: IForelder,
+  harForelderFraPdl?: boolean
 ): boolean | undefined => {
   if (forelder === undefined) return false;
   const { avtaleOmDeltBosted } = forelder;
@@ -36,6 +38,7 @@ export const erForelderUtfylt = (
   const utfyltAvtaleDeltBosted = harValgtSvar(avtaleOmDeltBosted?.verdi);
 
   const forelderInfoOgSpørsmålBesvart: boolean | undefined =
+    utfyltNavnOgIdent(forelder, harForelderFraPdl) &&
     utfyltSkalBarnetBoHosSøker(forelder, harSammeAdresse) &&
     utfyltBorINorge(forelder) &&
     utfyltAvtaleDeltBosted &&
@@ -57,6 +60,25 @@ export const utfyltSkalBarnetBoHosSøker = (
 ) => {
   return (
     harSammeAdresse.verdi || harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi)
+  );
+};
+
+export const utfyltNavnOgIdent = (
+  forelder: IForelder,
+  harForelderFraPdl: boolean | undefined
+) => {
+  const kjennerIkkeIdent =
+    stringHarVerdiOgErIkkeTom(forelder.navn?.verdi) &&
+    !stringHarVerdiOgErIkkeTom(forelder.ident?.verdi);
+  console.log('kjennerIkkeIdent: ', kjennerIkkeIdent);
+  return (
+    (stringHarVerdiOgErIkkeTom(forelder.navn) &&
+      (erIdentUtfyltOgGyldig(forelder.ident?.verdi) ||
+        (erFødselsdatoUtfyltOgGyldigEllerTomtFelt(
+          forelder?.fødselsdato?.verdi
+        ) &&
+          kjennerIkkeIdent))) ||
+    harForelderFraPdl
   );
 };
 

--- a/src/models/steg/barn.ts
+++ b/src/models/steg/barn.ts
@@ -24,6 +24,7 @@ export interface IBarn {
   harAdressesperre?: boolean;
   medforelder?: IMedforelderFelt;
   annenForelderId?: string; // Gjelder kun for visning av avhuking i frontend
+  erFraForrigeSøknad?: boolean;
 }
 
 export enum EBarn {

--- a/src/models/søknad/person.ts
+++ b/src/models/søknad/person.ts
@@ -50,7 +50,7 @@ type Medforelder = {
 };
 
 export type Barn = Omit<IBarn, 'medforelder'> & {
-  medforelder: Medforelder;
+  medforelder?: Medforelder;
 };
 
 export type PersonData = {

--- a/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
+++ b/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
@@ -106,6 +106,7 @@ const AnnenForelderKnapper: React.FC<Props> = ({
   const andreForelder = 'andre-forelder-';
   const andreForelderAnnen = 'andre-forelder-annen';
 
+  console.log('førsteBarnTilHverForelder', førsteBarnTilHverForelder);
   if (!førsteBarnTilHverForelder) return null;
 
   return (

--- a/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
+++ b/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
@@ -58,7 +58,7 @@ const AnnenForelderKnapper: React.FC<Props> = ({
   ) => {
     settBarnHarSammeForelder(true);
     const oppdatertForelder = cloneDeep(detAndreBarnet.forelder);
-    console.log('oppdatertForelder', oppdatertForelder);
+
     oppdaterAnnenForelder(detAndreBarnet.id);
 
     settForelder({
@@ -107,7 +107,6 @@ const AnnenForelderKnapper: React.FC<Props> = ({
   const andreForelder = 'andre-forelder-';
   const andreForelderAnnen = 'andre-forelder-annen';
 
-  console.log('førsteBarnTilHverForelder', førsteBarnTilHverForelder);
   if (!førsteBarnTilHverForelder) return null;
 
   return (

--- a/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
+++ b/src/søknad/steg/4-barnasbosted/AnnenForelderKnapper.tsx
@@ -58,6 +58,7 @@ const AnnenForelderKnapper: React.FC<Props> = ({
   ) => {
     settBarnHarSammeForelder(true);
     const oppdatertForelder = cloneDeep(detAndreBarnet.forelder);
+    console.log('oppdatertForelder', oppdatertForelder);
     oppdaterAnnenForelder(detAndreBarnet.id);
 
     settForelder({

--- a/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../../models/søknad/søknad';
 import { ISøknad as SøknadBarnetilsyn } from '../../../barnetilsyn/models/søknad';
 import { ISøknad as SøknadSkolepenger } from '../../../skolepenger/models/søknad';
+import { stringHarVerdiOgErIkkeTom } from '../../../utils/typer';
 
 const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
   if (!ref || !ref.current) return;

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -324,7 +324,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
           (erForelderUtfylt(
             barn.harSammeAdresse,
             forelder,
-            kjennerIkkeIdent
+            harForelderFraPdl
           ) && (
             <Button variant="secondary" onClick={leggTilForelder}>
               <LocaleTekst tekst={'knapp.neste'} />

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -188,24 +188,6 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     harValgtSvar(barn?.forelder?.avtaleOmDeltBosted?.verdi) &&
     utfyltNødvendigeSamværSpørsmål(barn?.forelder);
 
-  console.log('forelder', forelder);
-  console.log('barn', barn);
-  console.log('forelderidenterMedBarn', forelderidenterMedBarn);
-  console.log(
-    'finnTypeBarnForMedForelder(barn, forelderidenterMedBarn)',
-    finnTypeBarnForMedForelder(barn, forelderidenterMedBarn)
-  );
-  console.log(
-    'harValgtSvar(forelder.avtaleOmDeltBosted?.verdi)',
-    harValgtSvar(barn.forelder?.avtaleOmDeltBosted?.verdi)
-  );
-  console.log(
-    'utfyltNødvendigeSamværSpørsmål(forelder)',
-    utfyltNødvendigeSamværSpørsmål(barn?.forelder)
-  );
-  console.log('erForelderUtfyltForKopiertBarn', erForelderUtfyltForKopiertBarn);
-  console.log('visBorAnnenForelderINorge', visBorAnnenForelderINorge);
-  console.log('visOmAndreForelder', visOmAndreForelder);
   return (
     <div className="barnas-bosted">
       <SeksjonGruppe>

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -161,30 +161,23 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   const skalFylleUtHarBoddSammenFør =
     harValgtBorISammeHus(forelder) && utfyltBorINorge(forelder);
 
-  const barnErFraForrigSøknadOgSkalViseAnnenForelderValg =
+  const skalViseAnnenForelderKnapperForGjenbruk =
     barn.erFraForrigeSøknad &&
     finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn &&
     !barn.medforelder?.verdi &&
     barn.forelder &&
     !erForelderUtfylt(barn.forelder, barn.harSammeAdresse);
 
-  const skalViseAnnenForelderValg =
+  const skalViseAnnenForelderKnapperForFørstegangssøknad =
     barn.erFraForrigeSøknad !== true &&
     finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn &&
     !barn.medforelder?.verdi &&
     !barn.forelder;
 
-  const visAnnenForelderValg =
-    barnErFraForrigSøknadOgSkalViseAnnenForelderValg ||
-    skalViseAnnenForelderValg;
+  const skalViseAnnenForelderKnapper =
+    skalViseAnnenForelderKnapperForGjenbruk ||
+    skalViseAnnenForelderKnapperForFørstegangssøknad;
 
-  console.log(
-    'barnErFraForrigSøknadOgSkalViseAnnenForelderValg',
-    barnErFraForrigSøknadOgSkalViseAnnenForelderValg
-  );
-  console.log('skalViseAnnenForelderValg', skalViseAnnenForelderValg);
-
-  console.log('førsteBarnTilHverForelder', førsteBarnTilHverForelder);
   return (
     <div className="barnas-bosted">
       <SeksjonGruppe>
@@ -205,7 +198,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
           <SeksjonGruppe>
             <BarnetsAndreForelderTittel barn={barn} />
 
-            {visAnnenForelderValg && (
+            {skalViseAnnenForelderKnapper && (
               <AnnenForelderKnapper
                 barn={barn}
                 forelder={forelder}

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -321,9 +321,10 @@ const BarnetsBostedEndre: React.FC<Props> = ({
         {erForelderUtfyltForKopiertBarn ||
           (erForelderUtfylt(barn.harSammeAdresse, forelder) &&
             (erIdentUtfyltOgGyldig(forelder.ident?.verdi) ||
-              erFødselsdatoUtfyltOgGyldigEllerTomtFelt(
+              (erFødselsdatoUtfyltOgGyldigEllerTomtFelt(
                 forelder?.fødselsdato?.verdi
-              ) ||
+              ) &&
+                kjennerIkkeIdent) ||
               utfyltNødvendigSpørsmålUtenOppgiAnnenForelder(forelder) ||
               harForelderFraPdl) && (
               <Button variant="secondary" onClick={leggTilForelder}>

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -161,19 +161,29 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   const skalFylleUtHarBoddSammenFør =
     harValgtBorISammeHus(forelder) && utfyltBorINorge(forelder);
 
-  const skalViseAnnenForelderValg =
+  const barnErFraForrigSøknadOgSkalViseAnnenForelderValg =
+    barn.erFraForrigeSøknad &&
     finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn &&
-    (!barn.medforelder?.verdi || !barn.forelder);
+    !barn.medforelder?.verdi &&
+    barn.forelder &&
+    !erForelderUtfylt(barn.forelder, barn.harSammeAdresse);
 
+  const skalViseAnnenForelderValg =
+    barn.erFraForrigeSøknad !== true &&
+    finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn &&
+    !barn.medforelder?.verdi &&
+    !barn.forelder;
+
+  const visAnnenForelderValg =
+    barnErFraForrigSøknadOgSkalViseAnnenForelderValg ||
+    skalViseAnnenForelderValg;
+
+  console.log(
+    'barnErFraForrigSøknadOgSkalViseAnnenForelderValg',
+    barnErFraForrigSøknadOgSkalViseAnnenForelderValg
+  );
   console.log('skalViseAnnenForelderValg', skalViseAnnenForelderValg);
-  console.log(
-    'finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn',
-    finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn
-  );
-  console.log(
-    'barn.forelder && !erForelderUtfylt(barn.forelder, barn.harSammeAdresse)',
-    barn.forelder && !erForelderUtfylt(barn.forelder, barn.harSammeAdresse)
-  );
+
   return (
     <div className="barnas-bosted">
       <SeksjonGruppe>
@@ -194,7 +204,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
           <SeksjonGruppe>
             <BarnetsAndreForelderTittel barn={barn} />
 
-            {skalViseAnnenForelderValg && (
+            {visAnnenForelderValg && (
               <AnnenForelderKnapper
                 barn={barn}
                 forelder={forelder}

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -13,6 +13,7 @@ import {
   erForelderUtfylt,
   utfyltBorINorge,
   utfyltNødvendigSpørsmålUtenOppgiAnnenForelder,
+  utfyltNødvendigeSamværSpørsmål,
   visSpørsmålHvisIkkeSammeForelder,
 } from '../../../helpers/steg/forelder';
 import BorForelderINorge from './bostedOgSamvær/BorForelderINorge';
@@ -177,6 +178,12 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     skalViseAnnenForelderKnapperForGjenbruk ||
     skalViseAnnenForelderKnapperForNyttBarnEllerFørstegangssøknad;
 
+  const erForelderUtfyltForKopiertBarn =
+    typeBarn === TypeBarn.BARN_MED_KOPIERT_FORELDERINFORMASJON &&
+    harValgtSvar(forelder.avtaleOmDeltBosted?.verdi) &&
+    utfyltNødvendigeSamværSpørsmål(forelder);
+
+  console.log('erForelderUtfyltForKopiertBarn', erForelderUtfyltForKopiertBarn);
   return (
     <div className="barnas-bosted">
       <SeksjonGruppe>
@@ -291,17 +298,18 @@ const BarnetsBostedEndre: React.FC<Props> = ({
             </>
           )}
 
-        {erForelderUtfylt(barn.harSammeAdresse, forelder) &&
-          (erIdentUtfyltOgGyldig(forelder.ident?.verdi) ||
-            erFødselsdatoUtfyltOgGyldigEllerTomtFelt(
-              forelder?.fødselsdato?.verdi
-            ) ||
-            utfyltNødvendigSpørsmålUtenOppgiAnnenForelder(forelder) ||
-            harForelderFraPdl) && (
-            <Button variant="secondary" onClick={leggTilForelder}>
-              <LocaleTekst tekst={'knapp.neste'} />
-            </Button>
-          )}
+        {erForelderUtfyltForKopiertBarn ||
+          (erForelderUtfylt(barn.harSammeAdresse, forelder) &&
+            (erIdentUtfyltOgGyldig(forelder.ident?.verdi) ||
+              erFødselsdatoUtfyltOgGyldigEllerTomtFelt(
+                forelder?.fødselsdato?.verdi
+              ) ||
+              utfyltNødvendigSpørsmålUtenOppgiAnnenForelder(forelder) ||
+              harForelderFraPdl) && (
+              <Button variant="secondary" onClick={leggTilForelder}>
+                <LocaleTekst tekst={'knapp.neste'} />
+              </Button>
+            ))}
       </div>
     </div>
   );

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -165,8 +165,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     barn.erFraForrigeSøknad &&
     finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn &&
     !barn.medforelder?.verdi &&
-    barn.forelder &&
-    !erForelderUtfylt(barn.forelder, barn.harSammeAdresse);
+    !erForelderUtfylt(barn.harSammeAdresse, barn.forelder);
 
   const skalViseAnnenForelderKnapperForNyttBarnEllerFørstegangssøknad =
     barn.erFraForrigeSøknad !== true &&
@@ -292,7 +291,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
             </>
           )}
 
-        {erForelderUtfylt(forelder, barn.harSammeAdresse) &&
+        {erForelderUtfylt(barn.harSammeAdresse, forelder) &&
           (erIdentUtfyltOgGyldig(forelder.ident?.verdi) ||
             erFødselsdatoUtfyltOgGyldigEllerTomtFelt(
               forelder?.fødselsdato?.verdi

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -168,7 +168,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     barn.forelder &&
     !erForelderUtfylt(barn.forelder, barn.harSammeAdresse);
 
-  const skalViseAnnenForelderKnapperForFørstegangssøknad =
+  const skalViseAnnenForelderKnapperForNyttBarnEllerFørstegangssøknad =
     barn.erFraForrigeSøknad !== true &&
     finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn &&
     !barn.medforelder?.verdi &&
@@ -176,7 +176,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
 
   const skalViseAnnenForelderKnapper =
     skalViseAnnenForelderKnapperForGjenbruk ||
-    skalViseAnnenForelderKnapperForFørstegangssøknad;
+    skalViseAnnenForelderKnapperForNyttBarnEllerFørstegangssøknad;
 
   return (
     <div className="barnas-bosted">

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -184,6 +184,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   );
   console.log('skalViseAnnenForelderValg', skalViseAnnenForelderValg);
 
+  console.log('førsteBarnTilHverForelder', førsteBarnTilHverForelder);
   return (
     <div className="barnas-bosted">
       <SeksjonGruppe>

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -37,7 +37,7 @@ import {
   finnTypeBarnForMedForelder,
   harValgtBorISammeHus,
   skalBorAnnenForelderINorgeVises,
-  skalOmAndreForelderVises,
+  skalAnnenForelderRedigeres,
 } from '../../../helpers/steg/barnetsBostedEndre';
 import { stringHarVerdiOgErIkkeTom } from '../../../utils/typer';
 
@@ -144,7 +144,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
         b.medforelder?.verdi?.navn
     );
 
-  const visOmAndreForelder = skalOmAndreForelderVises(
+  const visOmAndreForelder = skalAnnenForelderRedigeres(
     barn,
     førsteBarnTilHverForelder,
     lagtTilAnnenForelderId,

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -167,6 +167,15 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     barn.forelder &&
     !erForelderUtfylt(barn.forelder, barn.harSammeAdresse);
 
+  console.log('skalViseAnnenForelderValg', skalViseAnnenForelderValg);
+  console.log(
+    'finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn',
+    finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn
+  );
+  console.log(
+    'barn.forelder && !erForelderUtfylt(barn.forelder, barn.harSammeAdresse)',
+    barn.forelder && !erForelderUtfylt(barn.forelder, barn.harSammeAdresse)
+  );
   return (
     <div className="barnas-bosted">
       <SeksjonGruppe>

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -183,6 +183,16 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     harValgtSvar(forelder.avtaleOmDeltBosted?.verdi) &&
     utfyltNødvendigeSamværSpørsmål(forelder);
 
+  console.log('typeBarn', typeBarn);
+  console.log(
+    'harValgtSvar(forelder.avtaleOmDeltBosted?.verdi)',
+    harValgtSvar(forelder.avtaleOmDeltBosted?.verdi)
+  );
+  console.log(
+    'utfyltNødvendigeSamværSpørsmål(forelder)',
+    utfyltNødvendigeSamværSpørsmål(forelder)
+  );
+
   console.log('erForelderUtfyltForKopiertBarn', erForelderUtfyltForKopiertBarn);
   return (
     <div className="barnas-bosted">

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -163,9 +163,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
 
   const skalViseAnnenForelderValg =
     finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn &&
-    !barn.medforelder?.verdi &&
-    barn.forelder &&
-    !erForelderUtfylt(barn.forelder, barn.harSammeAdresse);
+    (!barn.medforelder?.verdi || !barn.forelder);
 
   console.log('skalViseAnnenForelderValg', skalViseAnnenForelderValg);
   console.log(

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -186,11 +186,11 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   console.log('typeBarn', typeBarn);
   console.log(
     'harValgtSvar(forelder.avtaleOmDeltBosted?.verdi)',
-    harValgtSvar(forelder.avtaleOmDeltBosted?.verdi)
+    harValgtSvar(barn.forelder?.avtaleOmDeltBosted?.verdi)
   );
   console.log(
     'utfyltNødvendigeSamværSpørsmål(forelder)',
-    utfyltNødvendigeSamværSpørsmål(forelder)
+    utfyltNødvendigeSamværSpørsmål(barn?.forelder)
   );
 
   console.log('erForelderUtfyltForKopiertBarn', erForelderUtfyltForKopiertBarn);

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -179,7 +179,8 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     skalViseAnnenForelderKnapperForNyttBarnEllerFørstegangssøknad;
 
   const erForelderUtfyltForKopiertBarn =
-    typeBarn === TypeBarn.BARN_MED_KOPIERT_FORELDERINFORMASJON &&
+    finnTypeBarnForMedForelder(barn, forelderidenterMedBarn) ===
+      TypeBarn.BARN_MED_KOPIERT_FORELDERINFORMASJON &&
     harValgtSvar(forelder.avtaleOmDeltBosted?.verdi) &&
     utfyltNødvendigeSamværSpørsmål(forelder);
 

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -99,7 +99,9 @@ const BarnetsBostedEndre: React.FC<Props> = ({
 
   const { boddSammenFør, flyttetFra, fødselsdato, ident } = forelder;
 
-  const harForelderFraPdl = barn?.medforelder?.verdi?.navn || false;
+  const harForelderFraPdl = stringHarVerdiOgErIkkeTom(
+    barn?.medforelder?.verdi?.navn
+  );
 
   const førsteBarnTilHverForelder = finnFørsteBarnTilHverForelder(
     barneListe,
@@ -168,7 +170,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     barn.erFraForrigeSøknad &&
     finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn &&
     !barn.medforelder?.verdi &&
-    !erForelderUtfylt(barn.harSammeAdresse, barn.forelder);
+    !erForelderUtfylt(barn.harSammeAdresse, barn.forelder, harForelderFraPdl);
 
   const skalViseAnnenForelderKnapperForNyttBarnEllerFørstegangssøknad =
     barn.erFraForrigeSøknad !== true &&
@@ -319,18 +321,15 @@ const BarnetsBostedEndre: React.FC<Props> = ({
           )}
 
         {erForelderUtfyltForKopiertBarn ||
-          (erForelderUtfylt(barn.harSammeAdresse, forelder) &&
-            (erIdentUtfyltOgGyldig(forelder.ident?.verdi) ||
-              (erFødselsdatoUtfyltOgGyldigEllerTomtFelt(
-                forelder?.fødselsdato?.verdi
-              ) &&
-                kjennerIkkeIdent) ||
-              utfyltNødvendigSpørsmålUtenOppgiAnnenForelder(forelder) ||
-              harForelderFraPdl) && (
-              <Button variant="secondary" onClick={leggTilForelder}>
-                <LocaleTekst tekst={'knapp.neste'} />
-              </Button>
-            ))}
+          (erForelderUtfylt(
+            barn.harSammeAdresse,
+            forelder,
+            kjennerIkkeIdent
+          ) && (
+            <Button variant="secondary" onClick={leggTilForelder}>
+              <LocaleTekst tekst={'knapp.neste'} />
+            </Button>
+          ))}
       </div>
     </div>
   );

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -182,12 +182,6 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     skalViseAnnenForelderKnapperForGjenbruk ||
     skalViseAnnenForelderKnapperForNyttBarnEllerFørstegangssøknad;
 
-  const erForelderUtfyltForKopiertBarn =
-    finnTypeBarnForMedForelder(barn, forelderidenterMedBarn) ===
-      TypeBarn.BARN_MED_KOPIERT_FORELDERINFORMASJON &&
-    harValgtSvar(barn?.forelder?.avtaleOmDeltBosted?.verdi) &&
-    utfyltNødvendigeSamværSpørsmål(barn?.forelder);
-
   return (
     <div className="barnas-bosted">
       <SeksjonGruppe>
@@ -302,16 +296,15 @@ const BarnetsBostedEndre: React.FC<Props> = ({
             </>
           )}
 
-        {erForelderUtfyltForKopiertBarn ||
-          (erForelderUtfylt(
-            barn.harSammeAdresse,
-            forelder,
-            harForelderFraPdl
-          ) && (
-            <Button variant="secondary" onClick={leggTilForelder}>
-              <LocaleTekst tekst={'knapp.neste'} />
-            </Button>
-          ))}
+        {erForelderUtfylt(
+          barn.harSammeAdresse,
+          forelder,
+          harForelderFraPdl
+        ) && (
+          <Button variant="secondary" onClick={leggTilForelder}>
+            <LocaleTekst tekst={'knapp.neste'} />
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -203,6 +203,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   );
   console.log('erForelderUtfyltForKopiertBarn', erForelderUtfyltForKopiertBarn);
   console.log('visBorAnnenForelderINorge', visBorAnnenForelderINorge);
+  console.log('visOmAndreForelder', visOmAndreForelder);
   return (
     <div className="barnas-bosted">
       <SeksjonGruppe>

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -200,6 +200,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     utfyltNødvendigeSamværSpørsmål(barn?.forelder)
   );
   console.log('erForelderUtfyltForKopiertBarn', erForelderUtfyltForKopiertBarn);
+  console.log('visBorAnnenForelderINorge', visBorAnnenForelderINorge);
   return (
     <div className="barnas-bosted">
       <SeksjonGruppe>

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -163,7 +163,9 @@ const BarnetsBostedEndre: React.FC<Props> = ({
 
   const skalViseAnnenForelderValg =
     finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn &&
-    !barn.medforelder?.verdi;
+    !barn.medforelder?.verdi &&
+    barn.forelder &&
+    !erForelderUtfylt(barn.forelder, barn.harSammeAdresse);
 
   return (
     <div className="barnas-bosted">

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -39,6 +39,7 @@ import {
   skalBorAnnenForelderINorgeVises,
   skalOmAndreForelderVises,
 } from '../../../helpers/steg/barnetsBostedEndre';
+import { stringHarVerdiOgErIkkeTom } from '../../../utils/typer';
 
 const AlertMedTopMargin = styled(Alert)`
   margin-top: 1rem;
@@ -92,7 +93,8 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   );
 
   const [kjennerIkkeIdent, settKjennerIkkeIdent] = useState<boolean>(
-    forelder.fødselsdato?.verdi ? true : false
+    stringHarVerdiOgErIkkeTom(forelder.navn?.verdi) &&
+      !stringHarVerdiOgErIkkeTom(forelder.ident?.verdi)
   );
 
   const { boddSammenFør, flyttetFra, fødselsdato, ident } = forelder;

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -181,10 +181,16 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   const erForelderUtfyltForKopiertBarn =
     finnTypeBarnForMedForelder(barn, forelderidenterMedBarn) ===
       TypeBarn.BARN_MED_KOPIERT_FORELDERINFORMASJON &&
-    harValgtSvar(forelder.avtaleOmDeltBosted?.verdi) &&
-    utfyltNødvendigeSamværSpørsmål(forelder);
+    harValgtSvar(barn?.forelder?.avtaleOmDeltBosted?.verdi) &&
+    utfyltNødvendigeSamværSpørsmål(barn?.forelder);
 
-  console.log('typeBarn', typeBarn);
+  console.log('forelder', forelder);
+  console.log('barn', barn);
+  console.log('forelderidenterMedBarn', forelderidenterMedBarn);
+  console.log(
+    'finnTypeBarnForMedForelder(barn, forelderidenterMedBarn)',
+    finnTypeBarnForMedForelder(barn, forelderidenterMedBarn)
+  );
   console.log(
     'harValgtSvar(forelder.avtaleOmDeltBosted?.verdi)',
     harValgtSvar(barn.forelder?.avtaleOmDeltBosted?.verdi)
@@ -193,7 +199,6 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     'utfyltNødvendigeSamværSpørsmål(forelder)',
     utfyltNødvendigeSamværSpørsmål(barn?.forelder)
   );
-
   console.log('erForelderUtfyltForKopiertBarn', erForelderUtfyltForKopiertBarn);
   return (
     <div className="barnas-bosted">

--- a/src/utils/barn.ts
+++ b/src/utils/barn.ts
@@ -7,7 +7,7 @@ import { storeForbokstaver } from './tekst';
 import { erForelderUtfylt } from '../helpers/steg/forelder';
 import { LokalIntlShape } from '../language/typer';
 import { IForelder } from '../models/steg/forelder';
-import { harVerdi } from './typer';
+import { harVerdi, stringHarVerdiOgErIkkeTom } from './typer';
 
 export const hentSpørsmålTekstMedNavnEllerBarn = (
   spørsmålTekstid: string,
@@ -115,14 +115,23 @@ export const hentIndexFørsteBarnSomIkkeErUtfylt = (barna: IBarn[]): number => {
   return barna.findIndex(
     (barn) =>
       barn.forelder === undefined ||
-      !erForelderUtfylt(barn.harSammeAdresse, barn.forelder)
+      !erForelderUtfylt(
+        barn.harSammeAdresse,
+        barn.forelder,
+        stringHarVerdiOgErIkkeTom(barn.medforelder?.verdi)
+      )
   );
 };
 
 export const antallBarnMedForeldreUtfylt = (barna: IBarn[]): number => {
   return barna.filter(
     (barn) =>
-      barn.forelder && erForelderUtfylt(barn.harSammeAdresse, barn.forelder)
+      barn.forelder &&
+      erForelderUtfylt(
+        barn.harSammeAdresse,
+        barn.forelder,
+        stringHarVerdiOgErIkkeTom(barn.medforelder?.verdi)
+      )
   ).length;
 };
 

--- a/src/utils/barn.ts
+++ b/src/utils/barn.ts
@@ -92,14 +92,32 @@ export const oppdaterBarnIBarneliste = (
       barn.id === nyttBarn.id ? nyttBarn : barn
     );
   }
-  return [...barneListe, nyttBarn];
+  return [...barneListe, nyttBarn].sort((a, b) => {
+    if (a.medforelder?.verdi && !b.medforelder?.verdi) {
+      return -1;
+    }
+    if (!a.medforelder?.verdi && b.medforelder?.verdi) {
+      return 1;
+    }
+    return 0;
+  });
 };
 
 export const oppdaterBarneliste = (barneListe: IBarn[], nyeBarn: IBarn[]) => {
-  return barneListe.map(
-    (barn) =>
-      nyeBarn.find((oppdatertBarn) => oppdatertBarn.id === barn.id) || barn
-  );
+  return barneListe
+    .map(
+      (barn) =>
+        nyeBarn.find((oppdatertBarn) => oppdatertBarn.id === barn.id) || barn
+    )
+    .sort((a, b) => {
+      if (a.medforelder?.verdi && !b.medforelder?.verdi) {
+        return -1;
+      }
+      if (!a.medforelder?.verdi && b.medforelder?.verdi) {
+        return 1;
+      }
+      return 0;
+    });
 };
 
 export const formatterBarnetsNavn = (barn: IBarn) => {

--- a/src/utils/barn.ts
+++ b/src/utils/barn.ts
@@ -92,32 +92,14 @@ export const oppdaterBarnIBarneliste = (
       barn.id === nyttBarn.id ? nyttBarn : barn
     );
   }
-  return [...barneListe, nyttBarn].sort((a, b) => {
-    if (a.medforelder?.verdi && !b.medforelder?.verdi) {
-      return -1;
-    }
-    if (!a.medforelder?.verdi && b.medforelder?.verdi) {
-      return 1;
-    }
-    return 0;
-  });
+  return [...barneListe, nyttBarn];
 };
 
 export const oppdaterBarneliste = (barneListe: IBarn[], nyeBarn: IBarn[]) => {
-  return barneListe
-    .map(
-      (barn) =>
-        nyeBarn.find((oppdatertBarn) => oppdatertBarn.id === barn.id) || barn
-    )
-    .sort((a, b) => {
-      if (a.medforelder?.verdi && !b.medforelder?.verdi) {
-        return -1;
-      }
-      if (!a.medforelder?.verdi && b.medforelder?.verdi) {
-        return 1;
-      }
-      return 0;
-    });
+  return barneListe.map(
+    (barn) =>
+      nyeBarn.find((oppdatertBarn) => oppdatertBarn.id === barn.id) || barn
+  );
 };
 
 export const formatterBarnetsNavn = (barn: IBarn) => {

--- a/src/utils/barn.ts
+++ b/src/utils/barn.ts
@@ -115,14 +115,14 @@ export const hentIndexFørsteBarnSomIkkeErUtfylt = (barna: IBarn[]): number => {
   return barna.findIndex(
     (barn) =>
       barn.forelder === undefined ||
-      !erForelderUtfylt(barn.forelder, barn.harSammeAdresse)
+      !erForelderUtfylt(barn.harSammeAdresse, barn.forelder)
   );
 };
 
 export const antallBarnMedForeldreUtfylt = (barna: IBarn[]): number => {
   return barna.filter(
     (barn) =>
-      barn.forelder && erForelderUtfylt(barn.forelder, barn.harSammeAdresse)
+      barn.forelder && erForelderUtfylt(barn.harSammeAdresse, barn.forelder)
   ).length;
 };
 

--- a/src/utils/søknad.ts
+++ b/src/utils/søknad.ts
@@ -175,17 +175,27 @@ export const oppdaterBarnMedLabel = (
   barneliste: IBarn[],
   intl: LokalIntlShape
 ) =>
-  barneliste.map((barn: IBarn) => {
-    const barnMedLabel = settBarnMedLabelOgVerdi(barn);
-    barnMedLabel['ident'] = barnMedLabel['fnr'];
-    delete barnMedLabel.fnr;
+  barneliste
+    .map((barn: IBarn) => {
+      const barnMedLabel = settBarnMedLabelOgVerdi(barn);
+      barnMedLabel['ident'] = barnMedLabel['fnr'];
+      delete barnMedLabel.fnr;
 
-    if (barnMedLabel.medforelder?.verdi) {
-      barnMedLabel['forelder'] = medforelderMedLabel(
-        barnMedLabel.medforelder,
-        intl
-      );
-    }
+      if (barnMedLabel.medforelder?.verdi) {
+        barnMedLabel['forelder'] = medforelderMedLabel(
+          barnMedLabel.medforelder,
+          intl
+        );
+      }
 
-    return barnMedLabel;
-  });
+      return barnMedLabel;
+    })
+    .sort((a, b) => {
+      if (a.medforelder?.verdi && !b.medforelder?.verdi) {
+        return -1;
+      }
+      if (!a.medforelder?.verdi && b.medforelder?.verdi) {
+        return 1;
+      }
+      return 0;
+    });

--- a/src/utils/søknad.ts
+++ b/src/utils/søknad.ts
@@ -175,19 +175,17 @@ export const oppdaterBarnMedLabel = (
   barneliste: IBarn[],
   intl: LokalIntlShape
 ) =>
-  barneliste
-    .map((barn: IBarn) => {
-      const barnMedLabel = settBarnMedLabelOgVerdi(barn);
-      barnMedLabel['ident'] = barnMedLabel['fnr'];
-      delete barnMedLabel.fnr;
+  barneliste.map((barn: IBarn) => {
+    const barnMedLabel = settBarnMedLabelOgVerdi(barn);
+    barnMedLabel['ident'] = barnMedLabel['fnr'];
+    delete barnMedLabel.fnr;
 
-      if (barnMedLabel.medforelder?.verdi) {
-        barnMedLabel['forelder'] = medforelderMedLabel(
-          barnMedLabel.medforelder,
-          intl
-        );
-      }
+    if (barnMedLabel.medforelder?.verdi) {
+      barnMedLabel['forelder'] = medforelderMedLabel(
+        barnMedLabel.medforelder,
+        intl
+      );
+    }
 
-      return barnMedLabel;
-    })
-    .sort((_, b) => (b.medforelder.verdi ? 1 : -1));
+    return barnMedLabel;
+  });

--- a/src/utils/søknad.ts
+++ b/src/utils/søknad.ts
@@ -175,17 +175,19 @@ export const oppdaterBarnMedLabel = (
   barneliste: IBarn[],
   intl: LokalIntlShape
 ) =>
-  barneliste.map((barn: IBarn) => {
-    const barnMedLabel = settBarnMedLabelOgVerdi(barn);
-    barnMedLabel['ident'] = barnMedLabel['fnr'];
-    delete barnMedLabel.fnr;
+  barneliste
+    .map((barn: IBarn) => {
+      const barnMedLabel = settBarnMedLabelOgVerdi(barn);
+      barnMedLabel['ident'] = barnMedLabel['fnr'];
+      delete barnMedLabel.fnr;
 
-    if (barnMedLabel.medforelder?.verdi) {
-      barnMedLabel['forelder'] = medforelderMedLabel(
-        barnMedLabel.medforelder,
-        intl
-      );
-    }
+      if (barnMedLabel.medforelder?.verdi) {
+        barnMedLabel['forelder'] = medforelderMedLabel(
+          barnMedLabel.medforelder,
+          intl
+        );
+      }
 
-    return barnMedLabel;
-  });
+      return barnMedLabel;
+    })
+    .sort((_, b) => (b.medforelder.verdi ? 1 : -1));

--- a/src/utils/søknad.ts
+++ b/src/utils/søknad.ts
@@ -175,27 +175,17 @@ export const oppdaterBarnMedLabel = (
   barneliste: IBarn[],
   intl: LokalIntlShape
 ) =>
-  barneliste
-    .map((barn: IBarn) => {
-      const barnMedLabel = settBarnMedLabelOgVerdi(barn);
-      barnMedLabel['ident'] = barnMedLabel['fnr'];
-      delete barnMedLabel.fnr;
+  barneliste.map((barn: IBarn) => {
+    const barnMedLabel = settBarnMedLabelOgVerdi(barn);
+    barnMedLabel['ident'] = barnMedLabel['fnr'];
+    delete barnMedLabel.fnr;
 
-      if (barnMedLabel.medforelder?.verdi) {
-        barnMedLabel['forelder'] = medforelderMedLabel(
-          barnMedLabel.medforelder,
-          intl
-        );
-      }
+    if (barnMedLabel.medforelder?.verdi) {
+      barnMedLabel['forelder'] = medforelderMedLabel(
+        barnMedLabel.medforelder,
+        intl
+      );
+    }
 
-      return barnMedLabel;
-    })
-    .sort((a, b) => {
-      if (a.medforelder?.verdi && !b.medforelder?.verdi) {
-        return -1;
-      }
-      if (!a.medforelder?.verdi && b.medforelder?.verdi) {
-        return 1;
-      }
-      return 0;
-    });
+    return barnMedLabel;
+  });

--- a/src/utils/typer.ts
+++ b/src/utils/typer.ts
@@ -2,6 +2,14 @@ export function harVerdi<T>(verdi: T | null | undefined): verdi is T {
   return verdi !== null && verdi !== undefined;
 }
 
-export function stringHarVerdiOgErIkkeTom<T>(verdi: T | null | undefined): verdi is T {
-  return harVerdi(verdi) && verdi !== "";
+export function stringHarVerdiOgErIkkeTom<T>(
+  verdi: T | null | undefined
+): verdi is T {
+  return harVerdi(verdi) && verdi !== '';
+}
+
+export function stringErNullEllerTom(
+  verdi: string | null | undefined
+): boolean {
+  return verdi === null || verdi === undefined || verdi === '';
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal ikke ta med barn som er døde i ny søknad. Dette måtte fikses for gjenbruk. Dersom annen forelder har dødd siden forrige gang det ble søkt, skal annen forelder nullstilles.

Det er også forbedret logikk for at knapper som skal kopiere info fra annen forelder vises riktig. For at dette skulle bli greit å løse uten altfor mye kode ble det innført et flagg som sier om barn er hentet fra forrige søknad eller ikke.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-17705