### PR TITLE
Bugfix - skal ikke redigere annen forelder dersom medforelder finnes.…

### DIFF
--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -98,8 +98,9 @@ export const skalAnnenForelderRedigeres = (
       barnHarSammeForelder !== true &&
       (barn.harSammeAdresse.verdi ||
         harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi))) ||
-    finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn ===
-      false
+    (finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn ===
+      false &&
+      !barn.medforelder)
   );
 };
 

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -12,8 +12,6 @@ import { hentTekst } from '../../../utils/søknad';
 import {
   erForelderUtfylt,
   utfyltBorINorge,
-  utfyltNødvendigSpørsmålUtenOppgiAnnenForelder,
-  utfyltNødvendigeSamværSpørsmål,
   visSpørsmålHvisIkkeSammeForelder,
 } from '../../../helpers/steg/forelder';
 import BorForelderINorge from './bostedOgSamvær/BorForelderINorge';
@@ -31,8 +29,6 @@ import { SettDokumentasjonsbehovBarn } from '../../../models/søknad/søknad';
 import styled from 'styled-components';
 import { lagtTilAnnenForelderId } from '../../../utils/barn';
 import {
-  erFødselsdatoUtfyltOgGyldigEllerTomtFelt,
-  erIdentUtfyltOgGyldig,
   finnFørsteBarnTilHverForelder,
   finnTypeBarnForMedForelder,
   harValgtBorISammeHus,
@@ -144,7 +140,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
         b.medforelder?.verdi?.navn
     );
 
-  const visOmAndreForelder = skalAnnenForelderRedigeres(
+  const visAnnenForelderRedigering = skalAnnenForelderRedigeres(
     barn,
     førsteBarnTilHverForelder,
     lagtTilAnnenForelderId,
@@ -214,7 +210,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
               />
             )}
 
-            {visOmAndreForelder && (
+            {visAnnenForelderRedigering && (
               <OmAndreForelder
                 settForelder={settForelder}
                 forelder={forelder}


### PR DESCRIPTION
… Må ta høyde for at skalHaBarnepass-verdien ikke finnes i overgangsstønad.

### Hvorfor er denne endringen nødvendig? ✨
Skal ikke vise fødselsnummer og skal heller ikke være mulig å redigere navn/ident dersom annen forelder finnes i PDL