### PR TITLE
Fix andre forelder førstegangssøknad

### DIFF
--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -60,6 +60,10 @@ export const barnUtenForelderFraPDLOgIngenAndreForeldreDetKanKopieresFra = (
   barn: IBarn,
   førsteBarnTilHverForelder: IBarn[]
 ) => {
+  console.log(
+    'førsteBarnTilHverForelder.length === 0',
+    førsteBarnTilHverForelder.length === 0
+  );
   return !barn.medforelder?.verdi && førsteBarnTilHverForelder.length === 0;
 };
 
@@ -71,7 +75,7 @@ export const barnUtenForelderFraPdlOgErIkkeKopiert = (
   return (
     førsteBarnTilHverForelder.length > 0 &&
     barnHarSammeForelder !== true &&
-    !barn.medforelder
+    !barn.medforelder?.verdi
   );
 };
 
@@ -100,7 +104,7 @@ export const skalAnnenForelderRedigeres = (
         harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi))) ||
     (finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn ===
       false &&
-      !barn.medforelder)
+      !barn.medforelder?.verdi)
   );
 };
 

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -44,7 +44,7 @@ export const finnFørsteBarnTilHverForelder = (
   });
   console.log('andreBarnMedForelder', andreBarnMedForelder);
   const unikeForeldreIDer = Array.from(
-    new Set(andreBarnMedForelder.map((b) => b.medforelder?.verdi.ident))
+    new Set(andreBarnMedForelder.map((b) => b.medforelder?.verdi?.ident))
   );
 
   console.log('unikeForeldreIDer', unikeForeldreIDer);
@@ -52,7 +52,7 @@ export const finnFørsteBarnTilHverForelder = (
     .map((ident) => {
       if (!ident) return null;
       return andreBarnMedForelder.find(
-        (b) => b.medforelder?.verdi.ident === ident
+        (b) => b.medforelder?.verdi?.ident === ident
       );
     })
     .filter(Boolean) as IBarn[];

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -44,14 +44,16 @@ export const finnFørsteBarnTilHverForelder = (
   });
   console.log('andreBarnMedForelder', andreBarnMedForelder);
   const unikeForeldreIDer = Array.from(
-    new Set(andreBarnMedForelder.map((b) => b.forelder?.id))
+    new Set(andreBarnMedForelder.map((b) => b.medforelder?.verdi.ident))
   );
 
   console.log('unikeForeldreIDer', unikeForeldreIDer);
   return unikeForeldreIDer
-    .map((id) => {
-      if (!id) return null;
-      return andreBarnMedForelder.find((b) => b.forelder?.id === id);
+    .map((ident) => {
+      if (!ident) return null;
+      return andreBarnMedForelder.find(
+        (b) => b.medforelder?.verdi.ident === ident
+      );
     })
     .filter(Boolean) as IBarn[];
 };

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -42,12 +42,10 @@ export const finnFørsteBarnTilHverForelder = (
   const andreBarnMedForelder: IBarn[] = barneListe.filter((b) => {
     return b !== barn && b.forelder;
   });
-  console.log('andreBarnMedForelder', andreBarnMedForelder);
   const unikeForeldreIDer = Array.from(
     new Set(andreBarnMedForelder.map((b) => b.medforelder?.verdi?.ident))
   );
 
-  console.log('unikeForeldreIDer', unikeForeldreIDer);
   return unikeForeldreIDer
     .map((ident) => {
       if (!ident) return null;
@@ -62,10 +60,6 @@ export const barnUtenForelderFraPDLOgIngenAndreForeldreDetKanKopieresFra = (
   barn: IBarn,
   førsteBarnTilHverForelder: IBarn[]
 ) => {
-  console.log(
-    'førsteBarnTilHverForelder.length === 0',
-    førsteBarnTilHverForelder.length === 0
-  );
   return !barn.medforelder?.verdi && førsteBarnTilHverForelder.length === 0;
 };
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Hvis en søker hadde flere enn ett barn og ønsket å søke om BT eller OS for disse var det ikke mulig å skrive/legge til noe om andre forelder på barn 2 og utover. 