### PR TITLE
Skal kunne kopiere barn i overgangsstønad

### DIFF
--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -128,6 +128,7 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                     barn.forelder,
                     medforelder
                   );
+
                   const oppdatertForelder =
                     finnGjeldendeBarnOgNullstillAnnenForelderHvisDød(
                       barn,
@@ -135,13 +136,16 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
                       forelder
                     );
 
+                  const fraFolkeregister = lagFraFolkeregisterVerdi(
+                    prevSøknad,
+                    barn
+                  );
+
                   return {
                     ...barn,
                     medforelder,
                     forelder: oppdatertForelder,
-                    fraFolkeregister: prevSøknad.person.barn.find(
-                      (prevBarn) => prevBarn.ident.verdi === barn.ident.verdi
-                    )?.forelder?.fraFolkeregister,
+                    fraFolkeregister: fraFolkeregister,
                     erFraForrigeSøknad: true,
                   };
                 }),
@@ -151,6 +155,12 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
           };
         });
       }
+    };
+
+    const lagFraFolkeregisterVerdi = (søknad: ISøknad, barn: IBarn) => {
+      return søknad.person.barn.find(
+        (prevBarn) => prevBarn.ident.verdi === barn.ident.verdi
+      )?.forelder?.fraFolkeregister;
     };
 
     const oppdaterBarnForelderIdentOgNavn = (

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -71,8 +71,7 @@ export const barnUtenForelderFraPdlOgErIkkeKopiert = (
   return (
     førsteBarnTilHverForelder.length > 0 &&
     barnHarSammeForelder !== true &&
-    !barn.medforelder?.verdi &&
-    barn.annenForelderId === 'annen-forelder'
+    !barn.medforelder?.verdi
   );
 };
 

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -71,7 +71,8 @@ export const barnUtenForelderFraPdlOgErIkkeKopiert = (
   return (
     førsteBarnTilHverForelder.length > 0 &&
     barnHarSammeForelder !== true &&
-    !barn.medforelder?.verdi
+    !barn.medforelder?.verdi &&
+    barn.annenForelderId === 'annen-forelder'
   );
 };
 

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -119,7 +119,8 @@ export const skalAnnenForelderRedigeres = (
     ) ||
     (finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn ===
       false &&
-      !barn.medforelder?.verdi)
+      !barn.medforelder?.verdi) ||
+    (barn.erFraForrigeSøknad && barn.forelder?.hvorforIkkeOppgi?.verdi)
   );
 };
 

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -63,6 +63,10 @@ export const barnUtenForelderFraPDLOgIngenAndreForeldreDetKanKopieresFra = (
   return !barn.medforelder?.verdi && førsteBarnTilHverForelder.length === 0;
 };
 
+export const erAnnenForelderValgt = (annenForelderId: string | undefined) => {
+  annenForelderId && annenForelderId === 'annen-forelder';
+};
+
 export const barnUtenForelderFraPdlOgErIkkeKopiert = (
   førsteBarnTilHverForelder: IBarn[],
   barnHarSammeForelder: boolean | undefined,
@@ -72,12 +76,8 @@ export const barnUtenForelderFraPdlOgErIkkeKopiert = (
     førsteBarnTilHverForelder.length > 0 &&
     barnHarSammeForelder !== true &&
     !barn.medforelder?.verdi &&
-    barn.annenForelderId === 'annen-forelder'
+    erAnnenForelderValgt(barn.annenForelderId)
   );
-};
-
-export const erAnnenForelderValgt = (annenForelderId: string | undefined) => {
-  annenForelderId && annenForelderId === 'annen-forelder';
 };
 
 export const nyttBarnISøknadUtenSammeForelderOgUtfyltBarnetsBosted = (
@@ -90,7 +90,7 @@ export const nyttBarnISøknadUtenSammeForelderOgUtfyltBarnetsBosted = (
     barnHarSammeForelder !== true &&
     (barn.harSammeAdresse.verdi ||
       harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi)) &&
-    barn.annenForelderId === 'annen-forelder'
+    erAnnenForelderValgt(barn.annenForelderId)
   );
 };
 

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -71,14 +71,32 @@ export const barnUtenForelderFraPdlOgErIkkeKopiert = (
   return (
     førsteBarnTilHverForelder.length > 0 &&
     barnHarSammeForelder !== true &&
-    !barn.medforelder?.verdi
+    !barn.medforelder?.verdi &&
+    barn.annenForelderId === 'annen-forelder'
+  );
+};
+
+export const erAnnenForelderValgt = (annenForelderId: string | undefined) => {
+  annenForelderId && annenForelderId === 'annen-forelder';
+};
+
+export const nyttBarnISøknadUtenSammeForelderOgUtfyltBarnetsBosted = (
+  barn: IBarn,
+  barnHarSammeForelder: boolean | undefined,
+  forelder: IForelder
+) => {
+  return (
+    barn.erFraForrigeSøknad === false &&
+    barnHarSammeForelder !== true &&
+    (barn.harSammeAdresse.verdi ||
+      harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi)) &&
+    barn.annenForelderId === 'annen-forelder'
   );
 };
 
 export const skalAnnenForelderRedigeres = (
   barn: IBarn,
   førsteBarnTilHverForelder: IBarn[],
-  lagtTilAnnenForelderId: 'annen-forelder',
   barnHarSammeForelder: boolean | undefined,
   forelder: IForelder,
   finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn: boolean
@@ -88,16 +106,17 @@ export const skalAnnenForelderRedigeres = (
       barn,
       førsteBarnTilHverForelder
     ) ||
-    barn.annenForelderId === lagtTilAnnenForelderId ||
+    erAnnenForelderValgt(barn.annenForelderId) ||
     barnUtenForelderFraPdlOgErIkkeKopiert(
       førsteBarnTilHverForelder,
       barnHarSammeForelder,
       barn
     ) ||
-    (barn.erFraForrigeSøknad === false &&
-      barnHarSammeForelder !== true &&
-      (barn.harSammeAdresse.verdi ||
-        harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi))) ||
+    nyttBarnISøknadUtenSammeForelderOgUtfyltBarnetsBosted(
+      barn,
+      barnHarSammeForelder,
+      forelder
+    ) ||
     (finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn ===
       false &&
       !barn.medforelder?.verdi)

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -64,7 +64,7 @@ export const barnUtenForelderFraPDLOgIngenAndreForeldreDetKanKopieresFra = (
 };
 
 export const erAnnenForelderValgt = (annenForelderId: string | undefined) => {
-  annenForelderId && annenForelderId === 'annen-forelder';
+  return annenForelderId && annenForelderId === 'annen-forelder';
 };
 
 export const barnUtenForelderFraPdlOgErIkkeKopiert = (

--- a/src/helpers/steg/barnetsBostedEndre.ts
+++ b/src/helpers/steg/barnetsBostedEndre.ts
@@ -98,8 +98,9 @@ export const skalAnnenForelderRedigeres = (
       barnHarSammeForelder !== true &&
       (barn.harSammeAdresse.verdi ||
         harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi))) ||
-    finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn ===
-      false
+    (finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn ===
+      false &&
+      !barn.medforelder)
   );
 };
 

--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -15,10 +15,7 @@ import {
   erIdentUtfyltOgGyldig,
   harValgtBorISammeHus,
 } from './barnetsBostedEndre';
-import {
-  stringErNullEllerTom,
-  stringHarVerdiOgErIkkeTom,
-} from '../../utils/typer';
+import { stringHarVerdiOgErIkkeTom } from '../../utils/typer';
 import { erGyldigDato } from '../../utils/dato';
 import { IBooleanFelt } from '../../models/søknad/søknadsfelter';
 

--- a/src/søknad/steg/3-barnadine/BarnaDineInnhold.tsx
+++ b/src/søknad/steg/3-barnadine/BarnaDineInnhold.tsx
@@ -51,25 +51,35 @@ export const BarnaDineInnhold: React.FC<Props> = ({
         {hentTekst('barnadine.infohentet', intl)}
       </Alert>
       <BarneKortWrapper>
-        {barneliste.map((barn: IBarn) => (
-          <Barnekort
-            key={barn.id}
-            gjeldendeBarn={barn}
-            footer={
-              barn.lagtTil && (
-                <EndreEllerSlettBarn
-                  fjernBarnFraSøknad={fjernBarnFraSøknad}
-                  id={barn.id}
-                  settDokumentasjonsbehovForBarn={
-                    settDokumentasjonsbehovForBarn
-                  }
-                  barneListe={barneliste}
-                  oppdaterBarnISøknaden={oppdaterBarnISøknaden}
-                />
-              )
+        {barneliste
+          ?.sort((a: IBarn, b: IBarn) => {
+            if (a.medforelder?.verdi && !b.medforelder?.verdi) {
+              return -1;
             }
-          />
-        ))}
+            if (!a.medforelder?.verdi && b.medforelder?.verdi) {
+              return 1;
+            }
+            return 0;
+          })
+          .map((barn: IBarn) => (
+            <Barnekort
+              key={barn.id}
+              gjeldendeBarn={barn}
+              footer={
+                barn.lagtTil && (
+                  <EndreEllerSlettBarn
+                    fjernBarnFraSøknad={fjernBarnFraSøknad}
+                    id={barn.id}
+                    settDokumentasjonsbehovForBarn={
+                      settDokumentasjonsbehovForBarn
+                    }
+                    barneListe={barneliste}
+                    oppdaterBarnISøknaden={oppdaterBarnISøknaden}
+                  />
+                )
+              }
+            />
+          ))}
         <LeggTilBarnKort settÅpenModal={settÅpenModal} />
       </BarneKortWrapper>
       {åpenModal && (

--- a/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
@@ -19,7 +19,6 @@ import {
 } from '../../../models/søknad/søknad';
 import { ISøknad as SøknadBarnetilsyn } from '../../../barnetilsyn/models/søknad';
 import { ISøknad as SøknadSkolepenger } from '../../../skolepenger/models/søknad';
-import { stringHarVerdiOgErIkkeTom } from '../../../utils/typer';
 
 const scrollTilRef = (ref: RefObject<HTMLDivElement>) => {
   if (!ref || !ref.current) return;

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -12,8 +12,6 @@ import { hentTekst } from '../../../utils/søknad';
 import {
   erForelderUtfylt,
   utfyltBorINorge,
-  utfyltNødvendigSpørsmålUtenOppgiAnnenForelder,
-  utfyltNødvendigeSamværSpørsmål,
   visSpørsmålHvisIkkeSammeForelder,
 } from '../../../helpers/steg/forelder';
 import BorForelderINorge from './bostedOgSamvær/BorForelderINorge';
@@ -31,8 +29,6 @@ import { SettDokumentasjonsbehovBarn } from '../../../models/søknad/søknad';
 import styled from 'styled-components';
 import { lagtTilAnnenForelderId } from '../../../utils/barn';
 import {
-  erFødselsdatoUtfyltOgGyldigEllerTomtFelt,
-  erIdentUtfyltOgGyldig,
   finnFørsteBarnTilHverForelder,
   finnTypeBarnForMedForelder,
   harValgtBorISammeHus,
@@ -144,7 +140,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
         b.medforelder?.verdi?.navn
     );
 
-  const visOmAndreForelder = skalAnnenForelderRedigeres(
+  const visAnnenForelderRedigering = skalAnnenForelderRedigeres(
     barn,
     førsteBarnTilHverForelder,
     lagtTilAnnenForelderId,
@@ -214,7 +210,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
               />
             )}
 
-            {visOmAndreForelder && (
+            {visAnnenForelderRedigering && (
               <OmAndreForelder
                 settForelder={settForelder}
                 forelder={forelder}

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -133,7 +133,11 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   };
 
   const erBarnMedISøknad = (barn: IBarn): boolean => {
-    return barn.skalHaBarnepass ? barn.skalHaBarnepass?.verdi : true;
+    if (barn.barnepass === undefined) {
+      return true;
+    }
+
+    return barn.skalHaBarnepass?.verdi === true;
   };
 
   const finnesBarnISøknadMedRegistrertAnnenForelder = barneListe.some(

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -132,16 +132,16 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     );
   };
 
+  const erBarnMedISøknad = (barn: IBarn): boolean => {
+    return barn.skalHaBarnepass ? barn.skalHaBarnepass?.verdi : true;
+  };
+
   const finnesBarnISøknadMedRegistrertAnnenForelder = barneListe.some(
     (b) =>
       erBarnMedISøknad(b) &&
       b.medforelder?.verdi?.ident &&
       b.medforelder?.verdi?.navn
   );
-
-  const erBarnMedISøknad = (barn: IBarn) => {
-    return barn.barnepass !== null ? barn.skalHaBarnepass : true;
-  };
 
   const visAnnenForelderRedigering = skalAnnenForelderRedigeres(
     barn,

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -27,7 +27,6 @@ import LocaleTekst from '../../../language/LocaleTekst';
 import { Alert, BodyShort, Button, Label } from '@navikt/ds-react';
 import { SettDokumentasjonsbehovBarn } from '../../../models/søknad/søknad';
 import styled from 'styled-components';
-import { lagtTilAnnenForelderId } from '../../../utils/barn';
 import {
   finnFørsteBarnTilHverForelder,
   finnTypeBarnForMedForelder,
@@ -152,7 +151,6 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   const visAnnenForelderRedigering = skalAnnenForelderRedigeres(
     barn,
     førsteBarnTilHverForelder,
-    lagtTilAnnenForelderId,
     barnHarSammeForelder,
     forelder,
     finnesBarnISøknadMedRegistrertAnnenForelder
@@ -180,8 +178,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   const skalViseAnnenForelderKnapperForNyttBarnEllerFørstegangssøknad =
     barn.erFraForrigeSøknad !== true &&
     finnesBarnISøknadMedRegistrertAnnenForelder &&
-    !barn.medforelder?.verdi &&
-    !barn.forelder;
+    !barn.medforelder?.verdi;
 
   const skalViseAnnenForelderKnapper =
     skalViseAnnenForelderKnapperForGjenbruk ||

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -8,7 +8,7 @@ import { IBarn } from '../../../models/steg/barn';
 import { IForelder } from '../../../models/steg/forelder';
 import { useLokalIntlContext } from '../../../context/LokalIntlContext';
 import { harValgtSvar } from '../../../utils/spørsmålogsvar';
-import { hentTekst } from '../../../utils/søknad';
+import { erBarnetilsynSøknad, hentTekst } from '../../../utils/søknad';
 import {
   erForelderUtfylt,
   utfyltBorINorge,
@@ -36,6 +36,7 @@ import {
   skalAnnenForelderRedigeres,
 } from '../../../helpers/steg/barnetsBostedEndre';
 import { stringHarVerdiOgErIkkeTom } from '../../../utils/typer';
+import { useSøknad } from '../../../context/SøknadContext';
 
 const AlertMedTopMargin = styled(Alert)`
   margin-top: 1rem;
@@ -74,6 +75,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   forelderidenterMedBarn,
 }) => {
   const intl = useLokalIntlContext();
+  const { søknad } = useSøknad();
   const [forelder, settForelder] = useState<IForelder>(
     barn.forelder
       ? {
@@ -133,11 +135,11 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   };
 
   const erBarnMedISøknad = (barn: IBarn): boolean => {
-    if (barn.barnepass === undefined) {
-      return true;
+    if (erBarnetilsynSøknad(søknad)) {
+      return barn.skalHaBarnepass?.verdi === true;
     }
 
-    return barn.skalHaBarnepass?.verdi === true;
+    return true;
   };
 
   const finnesBarnISøknadMedRegistrertAnnenForelder = barneListe.some(

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -132,13 +132,16 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     );
   };
 
-  const finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn =
-    barneListe.some(
-      (b) =>
-        b.skalHaBarnepass?.verdi &&
-        b.medforelder?.verdi?.ident &&
-        b.medforelder?.verdi?.navn
-    );
+  const finnesBarnISøknadMedRegistrertAnnenForelder = barneListe.some(
+    (b) =>
+      erBarnMedISøknad(b) &&
+      b.medforelder?.verdi?.ident &&
+      b.medforelder?.verdi?.navn
+  );
+
+  const erBarnMedISøknad = (barn: IBarn) => {
+    return barn.barnepass !== null ? barn.skalHaBarnepass : true;
+  };
 
   const visAnnenForelderRedigering = skalAnnenForelderRedigeres(
     barn,
@@ -146,7 +149,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
     lagtTilAnnenForelderId,
     barnHarSammeForelder,
     forelder,
-    finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn
+    finnesBarnISøknadMedRegistrertAnnenForelder
   );
 
   const visBorAnnenForelderINorge = skalBorAnnenForelderINorgeVises(
@@ -164,13 +167,13 @@ const BarnetsBostedEndre: React.FC<Props> = ({
 
   const skalViseAnnenForelderKnapperForGjenbruk =
     barn.erFraForrigeSøknad &&
-    finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn &&
+    finnesBarnISøknadMedRegistrertAnnenForelder &&
     !barn.medforelder?.verdi &&
     !erForelderUtfylt(barn.harSammeAdresse, barn.forelder, harForelderFraPdl);
 
   const skalViseAnnenForelderKnapperForNyttBarnEllerFørstegangssøknad =
     barn.erFraForrigeSøknad !== true &&
-    finnesBarnSomSkalHaBarnepassOgRegistrertAnnenForelderBlantValgteBarn &&
+    finnesBarnISøknadMedRegistrertAnnenForelder &&
     !barn.medforelder?.verdi &&
     !barn.forelder;
 

--- a/src/utils/søknad.ts
+++ b/src/utils/søknad.ts
@@ -189,3 +189,11 @@ export const oppdaterBarnMedLabel = (
 
     return barnMedLabel;
   });
+
+export const erBarnetilsynSøknad = (søknad: any): boolean => {
+  return (
+    'søkerFraBestemtMåned' in søknad &&
+    'søknadsdato' in søknad &&
+    'aktivitet' in søknad
+  );
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Logikk for kopiering av barn med samme forelder tok ikke høyde for at barnetilsyn har noen spesifikke felter i søknad for den stønadstypen. Denne PR'n tar høyde for dette slik at kopiering av annen forelder virker.