### PR TITLE
Fix på oppsummering BT gjenbruk

### DIFF
--- a/src/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
 import OppsummeringAktiviteter from '../../../søknad/steg/7-oppsummering/OppsummeringAktiviteter';
 import OppsummeringBarnaDine from '../../../søknad/steg/7-oppsummering/OppsummeringBarnaDine';
@@ -10,7 +10,6 @@ import {
   ERouteBarnetilsyn,
   RoutesBarnetilsyn,
 } from '../../routing/routesBarnetilsyn';
-import { ESkjemanavn, skjemanavnIdMapping } from '../../../utils/skjemanavn';
 import { IBarn } from '../../../models/steg/barn';
 import { useBarnetilsynSøknad } from '../../BarnetilsynContext';
 import { useLokalIntlContext } from '../../../context/LokalIntlContext';
@@ -18,51 +17,18 @@ import { hentPath } from '../../../utils/routing';
 import Side, { ESide } from '../../../components/side/Side';
 import { hentTekst } from '../../../utils/søknad';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
-import {
-  logManglendeFelter,
-  logSidevisningBarnetilsyn,
-} from '../../../utils/amplitude';
+import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 import { useMount } from '../../../utils/hooks';
-import {
-  aktivitetSchemaBT,
-  listManglendeFelter,
-  ManglendeFelter,
-  manglendeFelterTilTekst,
-} from '../../../utils/validering/validering';
-import { Accordion, Alert, BodyShort } from '@navikt/ds-react';
+import { Accordion, BodyShort } from '@navikt/ds-react';
 
 const Oppsummering: React.FC = () => {
   const intl = useLokalIntlContext();
   const { mellomlagreBarnetilsyn, søknad } = useBarnetilsynSøknad();
-  const skjemaId = skjemanavnIdMapping[ESkjemanavn.Barnetilsyn];
   const barnSomSkalHaBarnepass: IBarn[] = søknad.person.barn.filter(
     (barn: IBarn) => barn.skalHaBarnepass?.verdi
   );
-  const [manglendeFelter, settManglendeFelter] = useState<string[]>([]);
 
   useMount(() => logSidevisningBarnetilsyn('Oppsummering'));
-
-  useEffect(() => {
-    aktivitetSchemaBT
-      .validate(søknad.aktivitet)
-      .then()
-      .catch((e) => {
-        if (
-          !manglendeFelter.includes(
-            manglendeFelterTilTekst[ManglendeFelter.AKTIVITET]
-          )
-        ) {
-          settManglendeFelter((prev: string[]): string[] => [
-            ...prev,
-            manglendeFelterTilTekst[ManglendeFelter.AKTIVITET],
-          ]);
-        }
-
-        logManglendeFelter(ESkjemanavn.Barnetilsyn, skjemaId, e);
-      });
-  }, [søknad, manglendeFelter, skjemaId]);
-
-  const harManglendeFelter = manglendeFelter.length > 0;
 
   return (
     <>
@@ -143,6 +109,7 @@ const Oppsummering: React.FC = () => {
                       RoutesBarnetilsyn,
                       ERouteBarnetilsyn.BostedOgSamvær
                     )}
+                    stønadstype={Stønadstype.barnetilsyn}
                   />
                 </Accordion.Content>
               </Accordion.Item>
@@ -178,13 +145,6 @@ const Oppsummering: React.FC = () => {
               </Accordion.Item>
             </Accordion>
           </KomponentGruppe>
-          {harManglendeFelter && (
-            <Alert size="small" variant="warning">
-              Det er felter i søknaden som ikke er fylt ut eller har ugyldig
-              verdi. Gå til {listManglendeFelter(manglendeFelter)} for å legge
-              inn gyldige verdier før du sender inn søknaden.
-            </Alert>
-          )}
         </div>
       </Side>
     </>

--- a/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/overgangsstønad/steg/7-oppsummering/Oppsummering.tsx
@@ -237,6 +237,7 @@ const Oppsummering: React.FC = () => {
                       RoutesOvergangsstonad,
                       ERouteOvergangsstønad.BarnasBosted
                     )}
+                    stønadstype={Stønadstype.overgangsstønad}
                   />
                 </Accordion.Content>
               </Accordion.Item>

--- a/src/skolepenger/steg/6-oppsummering/Oppsummering.tsx
+++ b/src/skolepenger/steg/6-oppsummering/Oppsummering.tsx
@@ -101,6 +101,7 @@ const Oppsummering: React.FC = () => {
                       RoutesSkolepenger,
                       ERouteSkolepenger.BostedOgSamvær
                     )}
+                    stønadstype={Stønadstype.skolepenger}
                   />
                 </Accordion.Content>
               </Accordion.Item>

--- a/src/søknad/steg/7-oppsummering/OppsummeringBarnasBosituasjon.tsx
+++ b/src/søknad/steg/7-oppsummering/OppsummeringBarnasBosituasjon.tsx
@@ -9,21 +9,28 @@ import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
 import { hentTekst } from '../../../utils/søknad';
 import { useLokalIntlContext } from '../../../context/LokalIntlContext';
 import { useNavigate } from 'react-router-dom';
+import { Stønadstype } from '../../../models/søknad/stønadstyper';
 
 interface Props {
   barn: IBarn[];
   endreInformasjonPath?: string;
+  stønadstype: Stønadstype;
 }
 
 const OppsummeringBarnasBosituasjon: FC<Props> = ({
   barn,
   endreInformasjonPath,
+  stønadstype,
 }) => {
   const navigate = useNavigate();
   const intl = useLokalIntlContext();
 
   const felterAlleForeldrene = barn
-    .filter((barn) => barn.forelder)
+    .filter((barn) =>
+      stønadstype == Stønadstype.barnetilsyn
+        ? barn.skalHaBarnepass?.verdi
+        : true
+    )
     .map((barn) => {
       if (!barn.forelder) return null;
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

- Fjernet validering på aktivitet da den lagde mer trøbbel enn den var til hjelp med å finne mangler. 
- Viser kun barn som skal ha barnepass i oppsummering på 'Den andre forelderen og samvær'.