### PR TITLE
Tekst på alert prosent student  validering skal være på norsk og engelsk

### DIFF
--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -1041,4 +1041,7 @@ export default {
     'If you receive transitional benefit, you must inform us of any major changes in your life, such as changes in your living and family situation, or changes in your work or education. The same applies if there are any changes in your income.',
   'forside.arbeidssøker.personopplysningeneDineLenke':
     '<span><a href="https://www.nav.no/personvernerklaering/en">About how we process your personal data</a></span>',
+
+  'utdanning.alert.arbeidsmengde':
+    'Percent must be less than 100 if part-time.',
 };

--- a/src/language/tekster_nb.ts
+++ b/src/language/tekster_nb.ts
@@ -1008,4 +1008,7 @@ export default {
     'Hvis du får overgangsstønad, må du melde fra når det skjer viktige endringer i livet ditt, for eksempel bo- og familiesituasjonen eller arbeid og utdanning. Det samme gjelder dersom inntekten din endrer seg.',
   'forside.arbeidssøker.personopplysningeneDineLenke':
     '<span><a href="https://www.nav.no/personvernerklaering">Slik behandler vi personopplysningene dine</a></span>',
+
+  'utdanning.alert.arbeidsmengde':
+    'Prosent må være mindre enn 100 hvis det er deltid.',
 };

--- a/src/søknad/steg/5-aktivitet/underUtdanning/StudieArbeidsmengde.tsx
+++ b/src/søknad/steg/5-aktivitet/underUtdanning/StudieArbeidsmengde.tsx
@@ -54,11 +54,11 @@ const StudieArbeidsmengde: React.FC<Props> = ({
           utdanning?.arbeidsmengde?.verdi ? utdanning?.arbeidsmengde?.verdi : ''
         }
       />
-      {erIkkeUndefinedOgMerEnnNittiNiProsent ? (
+      {erIkkeUndefinedOgMerEnnNittiNiProsent && (
         <StudereProsentVarsel size="small" variant="error">
-          Prosent må være mindre enn 100 hvis det er deltid.
+          {hentTekst('utdanning.alert.arbeidsmengde', intl)}
         </StudereProsentVarsel>
-      ) : null}
+      )}
     </KomponentGruppe>
   );
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Flyttet tekst som skal vises i alert ut i tekster. Har også laget engelsk versjon, slik at alerten bruker rett tekst basert på valgt språk.

<img width="691" alt="image" src="https://github.com/navikt/familie-ef-soknad/assets/141132903/fdd716ed-418e-4558-b8e8-53dbace46e48">

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-17920)