### PR TITLE
Skal ikke vise fnr på kopiert forelder

### DIFF
--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -195,8 +195,6 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
         forelder
       );
 
-      console.log('erFraFolkeRegister', erFraFolkeRegister);
-
       if (medforelder) {
         return {
           ...forelder,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Vil ikke vise fnr på annen forelder hvis informasjon om annen forelder er kopiert fra annet barn.

Denne fiksen fungerer så lenge annet barn fremdeles er relevant og med i søknaden.

Bilder viser før og etter hvor forelder er kopiert.

Steg 5:
![image](https://github.com/navikt/familie-ef-soknad/assets/141132903/48b0e014-f6d8-46f0-a660-b95dc7d883da)
![image](https://github.com/navikt/familie-ef-soknad/assets/141132903/2a62ef9d-5434-4838-a68f-45fd0feab915)

Oppsummering:
![image](https://github.com/navikt/familie-ef-soknad/assets/141132903/f68cdd3c-5f9a-43ca-bbd9-f30cdb16bb5d)
![image](https://github.com/navikt/familie-ef-soknad/assets/141132903/899c869b-b782-4802-a7db-c780f6106d64)

