### PR TITLE
ikkeOppgittAnnenForelderBegrunnelse mangler validering på engelsk. Må være med slik at man kan komme videre.

### DIFF
--- a/src/helpers/steg/forelder.ts
+++ b/src/helpers/steg/forelder.ts
@@ -105,7 +105,8 @@ export const utfyltNødvendigSpørsmålUtenOppgiAnnenForelder = (
 
   const pgaDonorBarn = hvorforIkkeOppgi?.verdi === EHvorforIkkeOppgi.donor;
   const pgaAnnet =
-    hvorforIkkeOppgi?.verdi === EHvorforIkkeOppgi.Annet &&
+    (hvorforIkkeOppgi?.verdi === EHvorforIkkeOppgi.Annet ||
+      hvorforIkkeOppgi?.verdi === EHvorforIkkeOppgi.Other) &&
     harValgtSvar(forelder?.ikkeOppgittAnnenForelderBegrunnelse?.verdi) &&
     ikkeOppgittAnnenForelderBegrunnelse?.verdi !== hvorforIkkeOppgi?.verdi;
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Slik at søknaden kan fylles ut på engelsk.