### PR TITLE
Skal kunne gjenbruke BT søknad på engelsk

### DIFF
--- a/src/barnetilsyn/BarnetilsynInformasjon.tsx
+++ b/src/barnetilsyn/BarnetilsynInformasjon.tsx
@@ -22,7 +22,6 @@ import { useSpråkContext } from '../context/SpråkContext';
 import { KnappLocaleTekstOgNavigate } from '../components/knapper/KnappLocaleTekstOgNavigate';
 import { ForrigeSøknad } from './models/søknad';
 import { useLokalIntlContext } from '../context/LokalIntlContext';
-import { stringHarVerdiOgErIkkeTom } from '../utils/typer';
 
 export const BarnetilsynInformasjon: React.FC<InformasjonProps> = ({
   person,
@@ -40,9 +39,9 @@ export const BarnetilsynInformasjon: React.FC<InformasjonProps> = ({
   ) => {
     if (forrigeSøknad) {
       return (
-        locale === 'nb' &&
+        // locale === 'nb' &&
         forrigeSøknad.sivilstatus?.årsakEnslig?.label ===
-          hentTekst('sivilstatus.spm.begrunnelse', intl)
+        hentTekst('sivilstatus.spm.begrunnelse', intl)
       );
     }
     return false;

--- a/src/barnetilsyn/BarnetilsynInformasjon.tsx
+++ b/src/barnetilsyn/BarnetilsynInformasjon.tsx
@@ -39,7 +39,6 @@ export const BarnetilsynInformasjon: React.FC<InformasjonProps> = ({
   ) => {
     if (forrigeSøknad) {
       return (
-        // locale === 'nb' &&
         forrigeSøknad.sivilstatus?.årsakEnslig?.label ===
         hentTekst('sivilstatus.spm.begrunnelse', intl)
       );

--- a/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
+++ b/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
@@ -15,6 +15,7 @@ import {
   erIkkeOppgittPgaAnnet,
   slettIrrelevantPropertiesHvisHuketAvKanIkkeOppgiAnnenForelder,
 } from '../../../helpers/steg/forelder';
+import { useSpråkContext } from '../../../context/SpråkContext';
 
 interface Props {
   settForelder: (verdi: IForelder) => void;
@@ -32,6 +33,7 @@ const OmAndreForelder: React.FC<Props> = ({
   settSisteBarnUtfylt,
 }) => {
   const intl = useLokalIntlContext();
+  const [locale] = useSpråkContext();
   const { fødselsdato, ident } = forelder;
   const [feilmeldingNavn, settFeilmeldingNavn] = useState<boolean>(false);
   const hvorforIkkeOppgiLabel = hentTekst(hvorforIkkeOppgi(intl).tekstid, intl);
@@ -221,7 +223,11 @@ const OmAndreForelder: React.FC<Props> = ({
           <MultiSvarSpørsmål
             spørsmål={hvorforIkkeOppgi(intl)}
             settSpørsmålOgSvar={settHvorforIkkeOppgi}
-            valgtSvar={forelder.hvorforIkkeOppgi?.verdi}
+            valgtSvar={
+              locale === 'en' && forelder.hvorforIkkeOppgi?.verdi === 'Annet'
+                ? 'Other'
+                : forelder.hvorforIkkeOppgi?.verdi
+            }
           />
         </KomponentGruppe>
       )}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Har rettet opp i en feil med at Annet/Other ikke ble utfylt i gjenbruk på engelsk. Søknad-api returnere Annet, det er vanskelig å utlede Other fra API uten å kjenne til locale. Derfor er det endret til forentend håndterer dette.

Dette var siste kjente feil med at gjenbruk ikke kunne brukes på engelsk. Dette er nå fikset og har derfor fjernet sjekke på at det er norsk.