### PR TITLE
Tekstfelt skal ikke være brede enn mobilskjerm bredde

### DIFF
--- a/src/overgangsstønad/steg/4-barnasbosted/BarnasBosted.css
+++ b/src/overgangsstønad/steg/4-barnasbosted/BarnasBosted.css
@@ -12,10 +12,6 @@
   margin-left: 2rem;
   margin-right: 2rem;
 }
-.barnas-bosted .foreldre-navn-input {
-  width: 400px;
-  font-weight: normal;
-}
 .barnas-bosted .fødselsnummer {
   display: flex;
   flex-direction: row;

--- a/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
+++ b/src/søknad/steg/4-barnasbosted/OmAndreForelder.tsx
@@ -10,12 +10,13 @@ import { ISpørsmål, ISvar } from '../../../models/felles/spørsmålogsvar';
 import { hentUid } from '../../../utils/autentiseringogvalidering/uuid';
 import { useLokalIntlContext } from '../../../context/LokalIntlContext';
 import IdentEllerFødselsdatoGruppe from '../../../components/gruppe/IdentEllerFødselsdatoGruppe';
-import { Checkbox, ErrorMessage, Textarea, TextField } from '@navikt/ds-react';
+import { Checkbox, ErrorMessage, Textarea } from '@navikt/ds-react';
 import {
   erIkkeOppgittPgaAnnet,
   slettIrrelevantPropertiesHvisHuketAvKanIkkeOppgiAnnenForelder,
 } from '../../../helpers/steg/forelder';
 import { useSpråkContext } from '../../../context/SpråkContext';
+import { TextFieldMedBredde } from '../../../components/TextFieldMedBredde';
 
 interface Props {
   settForelder: (verdi: IForelder) => void;
@@ -156,9 +157,9 @@ const OmAndreForelder: React.FC<Props> = ({
     <>
       <KomponentGruppe>
         <FeltGruppe>
-          <TextField
-            className="foreldre-navn-input"
-            onChange={(e) => {
+          <TextFieldMedBredde
+            bredde={'L'}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               settForelder({
                 ...forelder,
                 navn: {
@@ -168,7 +169,7 @@ const OmAndreForelder: React.FC<Props> = ({
               });
               e.target.value === '' && settSisteBarnUtfylt(false);
             }}
-            onBlur={(e) =>
+            onBlur={(e: React.ChangeEvent<HTMLInputElement>) =>
               e.target.value === ''
                 ? settFeilmeldingNavn(true)
                 : settFeilmeldingNavn(false)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Har Gjort om til å bruke TextFieldMedBredde for at det skal være mer konsistent med resten av søknaden. Har fjernet styling som ikke lenger blir brukt. Bredden var satt 400px som var bredere enn mobilskjerm, det så derfor ikke noe bra ut.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-18248)

Bilde av slik det er nå:
![image](https://github.com/navikt/familie-ef-soknad/assets/141132903/106d464b-31e9-4579-80a4-7d4396bc5366)

Slik det var før:
![image](https://github.com/navikt/familie-ef-soknad/assets/141132903/30b92a3f-3344-44ce-ad42-e074ac883839)
