### PR TITLE
Skal ikke vise annen foreldre knapper hvis det ikke er valgt barn å kopiere fra

### DIFF
--- a/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
@@ -122,6 +122,7 @@ const BarnasBostedInnhold: React.FC<Props> = ({
               oppdaterBarnISøknaden={oppdaterBarnMedNyForelderInformasjon}
               barneListe={søknad.person.barn}
               forelderidenterMedBarn={forelderIdenterMedBarn}
+              søknad={søknad}
             />
           );
         } else {

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -25,7 +25,10 @@ import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
 import BarnetsAndreForelderTittel from './BarnetsAndreForelderTittel';
 import LocaleTekst from '../../../language/LocaleTekst';
 import { Alert, BodyShort, Button, Label } from '@navikt/ds-react';
-import { SettDokumentasjonsbehovBarn } from '../../../models/søknad/søknad';
+import {
+  ISøknad as SøknadOvergangsstønad,
+  SettDokumentasjonsbehovBarn,
+} from '../../../models/søknad/søknad';
 import styled from 'styled-components';
 import {
   finnFørsteBarnTilHverForelder,
@@ -35,7 +38,8 @@ import {
   skalAnnenForelderRedigeres,
 } from '../../../helpers/steg/barnetsBostedEndre';
 import { stringHarVerdiOgErIkkeTom } from '../../../utils/typer';
-import { useSøknad } from '../../../context/SøknadContext';
+import { ISøknad as SøknadBarnetilsyn } from '../../../barnetilsyn/models/søknad';
+import { ISøknad as SøknadSkolepenger } from '../../../skolepenger/models/søknad';
 
 const AlertMedTopMargin = styled(Alert)`
   margin-top: 1rem;
@@ -60,6 +64,7 @@ interface Props {
   barneListe: IBarn[];
   oppdaterBarnISøknaden: (endretBarn: IBarn, erFørstebarn: boolean) => void;
   forelderidenterMedBarn: Map<string, IBarn[]>;
+  søknad: SøknadOvergangsstønad | SøknadBarnetilsyn | SøknadSkolepenger;
 }
 
 const BarnetsBostedEndre: React.FC<Props> = ({
@@ -72,9 +77,9 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   oppdaterBarnISøknaden,
   settDokumentasjonsbehovForBarn,
   forelderidenterMedBarn,
+  søknad,
 }) => {
   const intl = useLokalIntlContext();
-  const { søknad } = useSøknad();
   const [forelder, settForelder] = useState<IForelder>(
     barn.forelder
       ? {
@@ -134,11 +139,7 @@ const BarnetsBostedEndre: React.FC<Props> = ({
   };
 
   const erBarnMedISøknad = (barn: IBarn): boolean => {
-    if (erBarnetilsynSøknad(søknad)) {
-      return barn.skalHaBarnepass?.verdi === true;
-    }
-
-    return true;
+    return !erBarnetilsynSøknad(søknad) || barn.skalHaBarnepass?.verdi === true;
   };
 
   const finnesBarnISøknadMedRegistrertAnnenForelder = barneListe.some(

--- a/src/utils/søknad.ts
+++ b/src/utils/søknad.ts
@@ -191,8 +191,8 @@ export const oppdaterBarnMedLabel = (
 
 export const erBarnetilsynSøknad = (søknad: any): boolean => {
   return (
-    'søkerFraBestemtMåned' in søknad &&
-    'søknadsdato' in søknad &&
+    !('merOmDinSituasjon' in søknad) &&
+    !('utdanning' in søknad) &&
     'aktivitet' in søknad
   );
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Endret på sjekken erBarnetilsynSøknad for å gjøre den mer korrekt, søkerFraBestemtMåned er optional og kan derfor mangle fra søknad. Tar med søknad som prop fordi den inneholder oppdatert state og har derfor verdiene som det blir sjekket på.

Før: 
![image](https://github.com/navikt/familie-ef-soknad/assets/141132903/468b48bf-cf6e-474a-8141-796e27291ac1)

Nå:
![image](https://github.com/navikt/familie-ef-soknad/assets/141132903/143474a2-972d-49bc-bef6-385b3b237029)
