### PR TITLE
Skal ikke nullstille datofelter hvis man gjenbruker søknad og velger …

### DIFF
--- a/src/søknad/steg/1-omdeg/sivilstatus/Sivilstatus.tsx
+++ b/src/søknad/steg/1-omdeg/sivilstatus/Sivilstatus.tsx
@@ -44,6 +44,8 @@ const Sivilstatus: React.FC<Props> = ({
     sivilstatus;
   const { skalGjenbrukeSøknad } = useContext(GjenbrukContext);
 
+  const gjenbrukerSøknadOgHarUbesvartSeparsjonsspørsmål = () =>
+    skalGjenbrukeSøknad && sivilstatus.harSøktSeparasjon === undefined;
   const settSivilstatusFelt = (spørsmål: ISpørsmål, valgtSvar: ISvar) => {
     const spørsmålLabel = hentTekst(spørsmål.tekstid, intl);
     const svar: boolean = hentBooleanFraValgtSvar(valgtSvar);
@@ -59,7 +61,7 @@ const Sivilstatus: React.FC<Props> = ({
     };
     if (
       spørsmål.søknadid === ESivilstatusSøknadid.harSøktSeparasjon &&
-      !skalGjenbrukeSøknad
+      !gjenbrukerSøknadOgHarUbesvartSeparsjonsspørsmål()
     ) {
       datoSøktSeparasjon && delete nySivilstatus.datoSøktSeparasjon;
       datoFlyttetFraHverandre && delete nySivilstatus.datoFlyttetFraHverandre;


### PR DESCRIPTION
…_harSøktSeparasjon_ FØRSTE gang. Dersom man endrer valget så må vi nullstille for å ikke få ugyldig tilstand i søknaden

### Hvorfor er denne endringen nødvendig? ✨

[Ref Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-20409)