### PR TITLE
Setter rate limit til 100 requests i minuttet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4393,9 +4393,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,6 +12,7 @@
         "@types/express": "^5.0.6",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.3.1",
         "http-proxy-middleware": "^3.0.5",
         "typescript": "^5.9.3",
         "uuid": "^13.0.0",
@@ -1060,6 +1061,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/cookie-signature": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
@@ -1423,6 +1442,15 @@
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/server/package.json
+++ b/server/package.json
@@ -11,10 +11,11 @@
     "@types/express": "^5.0.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.3.1",
     "http-proxy-middleware": "^3.0.5",
+    "typescript": "^5.9.3",
     "uuid": "^13.0.0",
-    "winston": "^3.19.0",
-    "typescript": "^5.9.3"
+    "winston": "^3.19.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2"

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response, Router } from 'express';
 import path from 'path';
 import fs from 'fs';
+import rateLimit from 'express-rate-limit';
 import { hentHtmlMedDekoratør, injectDekoratørIHtml } from './decorator';
 import logger from './logger';
 import { leggTilRequestInfo, lagProxy } from './proxy';
@@ -49,11 +50,19 @@ const lagApiProxyer = (): Router => {
 const lagHtmlRouter = (vite?: ViteDevServer): Router => {
   const router = express.Router();
 
+  const htmlRateLimiter = rateLimit({
+    windowMs: 1 * 60 * 1000,
+    limit: 100,
+    message: 'For mange forespørsler, vennligst prøv igjen senere',
+    standardHeaders: 'draft-8',
+    legacyHeaders: false,
+  });
+
   if (!erUtvikling) {
     router.use(BASE_PATH, express.static(buildPath, { index: false }));
   }
 
-  router.use(`${BASE_PATH}/{*path}`, async (_req: Request, res: Response) => {
+  router.use(`${BASE_PATH}/{*path}`, htmlRateLimiter, async (_req: Request, res: Response) => {
     try {
       if (erUtvikling && vite) {
         const rawHtml = fs.readFileSync(path.resolve(process.cwd(), 'index.html'), 'utf-8');

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -51,7 +51,7 @@ const lagHtmlRouter = (vite?: ViteDevServer): Router => {
   const router = express.Router();
 
   const htmlRateLimiter = rateLimit({
-    windowMs: 1 * 60 * 1000,
+    windowMs: 60 * 1000,
     limit: 100,
     message: 'For mange forespørsler, vennligst prøv igjen senere',
     standardHeaders: 'draft-8',


### PR DESCRIPTION
# Setter rate limit til 100 requests i minuttet

### Hvorfor er denne endringen nødvendig? ✨ 

Dependabot formidler at vi har en svakhet der vi ikke rate limiter requests. Denne PRen har som hensikt å begrense til 100 requests i minuttet for å stoppe det værste av ondsinnede angrep eller scraping. 

### Verdt å nevne

Deployet denne siden 25 mars 2026, latt den stå siden. Ser ut til å fungere som forventet. Følger med. 