### PR TITLE
Sentry rydding: source maps, filtre, ErrorBoundary og AbortController

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@navikt/ds-tokens": "^8.2.2",
         "@navikt/fnrvalidator": "^2.2.0",
         "@navikt/nav-dekoratoren-moduler": "^3.6.3",
-        "@sentry/browser": "^10.44.0",
+        "@sentry/react": "^10.44.0",
         "axios": "^1.15.0",
         "constate": "^3.3.3",
         "date-fns": "^4.1.0",
@@ -1563,50 +1563,50 @@
       ]
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.44.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.44.0.tgz",
-      "integrity": "sha512-z9xz3T/v+MnfHY6kdUCmOZI8CiAl3LlKYtGH2p3rAsrxhwX+BTnUp01VhMVnEZIDgUXNt3AhJac+4kcDIPu1Hg==",
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.51.0.tgz",
+      "integrity": "sha512-lNKBS4P7RUvf1niojXQWe9bU3gnBUCbST4Dj0pSiyat1N96cXVyHkeE+uGxowD0RrVWhs+kGHiVX3FcmRWF6sA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.44.0"
+        "@sentry/core": "10.51.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "10.44.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.44.0.tgz",
-      "integrity": "sha512-yNS2EGK1bNm8YUI+Orzpa7yr05Da+b1VEe/9x7dl7gTjw/+tfutoXlG6Y+iFZBB3gQ9QU+nxZAhU+KcxiPEURw==",
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.51.0.tgz",
+      "integrity": "sha512-bCM95bcpphx28e6aU0bwRLxOgwosYsdNzezM1sM0pVOkb0TB3hDFRamramVDK+/Hp1o8qmRxS4c5w/A7YBZGkA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.44.0"
+        "@sentry/core": "10.51.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "10.44.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.44.0.tgz",
-      "integrity": "sha512-KDmoqBsRmkaoc+eKLR2CbScd2eBmLcw+1+D441lLttAO3WWhvYyCaYdu/HIGGUoybuSgt+IcpCJdi7hFuCvYqw==",
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.51.0.tgz",
+      "integrity": "sha512-jCpI5HXSwK6ZT2HX70+mDRciAocHzSiDk4DTgvzV69Wvd+Ei5WLgE+d39eaEPsm8lUC0Ydntb5sJIB6uG9D4bw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.44.0",
-        "@sentry/core": "10.44.0"
+        "@sentry-internal/browser-utils": "10.51.0",
+        "@sentry/core": "10.51.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.44.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.44.0.tgz",
-      "integrity": "sha512-RA7XgYZWHY7M+vaHvuMxDFT51wCs4puS2smElM5oh+j3YqbFXY7P16fOCwIAGoyI4gVsj8aTeBgVqUmrmzhAXQ==",
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.51.0.tgz",
+      "integrity": "sha512-8PW1Pp+Yl3lPwYqhBCr5SgkuhDanu9ZLzUqD2bPKL/ElqbM2eDVIWxq4z4ZzePrmZa6IcCjTv6sVQJ7Z4dLyLA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "10.44.0",
-        "@sentry/core": "10.44.0"
+        "@sentry-internal/replay": "10.51.0",
+        "@sentry/core": "10.51.0"
       },
       "engines": {
         "node": ">=18"
@@ -1623,16 +1623,16 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.44.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.44.0.tgz",
-      "integrity": "sha512-UpMx5forbVKieNULma3gT2SsLYqsYT4nLXa6s1io/Y8BFej9sH2dD5ExA8TrkQThQwAWFI3qKsQzYnF+EX/Bfg==",
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.51.0.tgz",
+      "integrity": "sha512-Zdc0sKfenxUtW/OGhtJ7xHFN44bXR7YqxJ1zBDzlZfW0nTbeTTUZBq9z5NUw6qdS0Vs/i3V4qzAKTbRKWfqSEA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.44.0",
-        "@sentry-internal/feedback": "10.44.0",
-        "@sentry-internal/replay": "10.44.0",
-        "@sentry-internal/replay-canvas": "10.44.0",
-        "@sentry/core": "10.44.0"
+        "@sentry-internal/browser-utils": "10.51.0",
+        "@sentry-internal/feedback": "10.51.0",
+        "@sentry-internal/replay": "10.51.0",
+        "@sentry-internal/replay-canvas": "10.51.0",
+        "@sentry/core": "10.51.0"
       },
       "engines": {
         "node": ">=18"
@@ -1846,12 +1846,28 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.44.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.44.0.tgz",
-      "integrity": "sha512-aa7CiDaNFZvHpqd97LJhuskolfJ/4IH5xyuVVLnv7l6B0v9KTwskPUxb0tH1ej3FxuzfH+i8iTiTFuqpfHS3QA==",
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
+      "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.51.0.tgz",
+      "integrity": "sha512-RRHHqjNvjji6ebIqdlAr453AkST8Vm4cxdu1vWm772IgbzTO7Jx46Cj6Bt2/GjMyH0YLE5euDaAOQhFMmpvAOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.51.0",
+        "@sentry/core": "10.51.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
     "node_modules/@sentry/vite-plugin": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@navikt/ds-tokens": "^8.2.2",
     "@navikt/fnrvalidator": "^2.2.0",
     "@navikt/nav-dekoratoren-moduler": "^3.6.3",
-    "@sentry/browser": "^10.44.0",
+    "@sentry/react": "^10.44.0",
     "axios": "^1.15.0",
     "constate": "^3.3.3",
     "date-fns": "^4.1.0",

--- a/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
+++ b/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { Alert, Heading } from '@navikt/ds-react';
 import { Stønadstype, stønadsTypeTilEngelsk } from '../../models/søknad/stønadstyper';
@@ -30,10 +30,12 @@ export const TidligereInnsendteSøknaderAlert: React.FC<TidligereInnsendteSøkna
 
   const [innsendteSøknader, settInnsendteSøknader] = useState<SistInnsendteSøknad[]>([]);
 
-  const hentInnsendteSøknader = useCallback(() => {
+  useEffect(() => {
+    const controller = new AbortController();
     axios
       .get<SistInnsendteSøknad[]>(
-        `${Environment().apiProxyUrl}/api/soknad/sist-innsendt-per-stonad`
+        `${Environment().apiProxyUrl}/api/soknad/sist-innsendt-per-stonad`,
+        { signal: controller.signal }
       )
       .then((response) => {
         const normalisertSøknad = response.data.map((søknad) => ({
@@ -44,13 +46,11 @@ export const TidligereInnsendteSøknaderAlert: React.FC<TidligereInnsendteSøkna
         settInnsendteSøknader(normalisertSøknad);
       })
       .catch((error) => {
+        if (axios.isCancel(error)) return;
         console.error('Klarte ikke å hente tidligere innsendte søknader.', error);
       });
+    return () => controller.abort();
   }, []);
-
-  useEffect(() => {
-    hentInnsendteSøknader();
-  }, [hentInnsendteSøknader]);
 
   const gjeldeneSøknad = innsendteSøknader.find((søknad) => søknad.stønadType === stønadType);
 

--- a/src/context/PersonContext.tsx
+++ b/src/context/PersonContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useReducer, useState } from 'react';
+import axios from 'axios';
 import { Barn, IPerson, PersonData } from '../models/søknad/person';
 import tomPerson from '../mock/initialState.json';
 import { hentPersonData } from '../utils/søknad';
@@ -25,7 +26,8 @@ type PersonContextType = {
   alvorlighetsgrad: EAlvorlighetsgrad | undefined;
   fetchPersonData: (
     oppdaterSøknadMedBarn: (person: PersonData, barneliste: Barn[] | IBarn[]) => void,
-    skjemanavn: ESkjemanavn
+    skjemanavn: ESkjemanavn,
+    signal?: AbortSignal
   ) => Promise<void>;
 };
 
@@ -84,9 +86,11 @@ const PersonProvider: React.FC<{ children?: React.ReactNode }> = ({ children }) 
   };
 
   const fetchPersonData = (
-    oppdaterSøknadMedBarn: (person: PersonData, barneliste: Barn[]) => void
+    oppdaterSøknadMedBarn: (person: PersonData, barneliste: Barn[]) => void,
+    _skjemanavn?: ESkjemanavn,
+    signal?: AbortSignal
   ) => {
-    return hentPersonData()
+    return hentPersonData(signal)
       .then((response) => {
         settPerson({
           type: PersonActionTypes.HENT_PERSON,
@@ -95,7 +99,10 @@ const PersonProvider: React.FC<{ children?: React.ReactNode }> = ({ children }) 
 
         oppdaterSøknadMedBarn(response, response.barn);
       })
-      .catch((e) => håndterError(e));
+      .catch((e) => {
+        if (axios.isCancel(e)) return;
+        håndterError(e);
+      });
   };
 
   const value = {

--- a/src/context/PersonContext.tsx
+++ b/src/context/PersonContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useReducer, useState } from 'react';
 import axios from 'axios';
+import * as Sentry from '@sentry/react';
 import { Barn, IPerson, PersonData } from '../models/søknad/person';
 import tomPerson from '../mock/initialState.json';
 import { hentPersonData } from '../utils/søknad';
@@ -87,9 +88,13 @@ const PersonProvider: React.FC<{ children?: React.ReactNode }> = ({ children }) 
 
   const fetchPersonData = (
     oppdaterSøknadMedBarn: (person: PersonData, barneliste: Barn[]) => void,
-    _skjemanavn?: ESkjemanavn,
+    skjemanavn?: ESkjemanavn,
     signal?: AbortSignal
   ) => {
+    if (skjemanavn) {
+      Sentry.setTag('skjemanavn', skjemanavn);
+    }
+
     return hentPersonData(signal)
       .then((response) => {
         settPerson({

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,7 @@ import { SpråkProvider } from './context/SpråkContext';
 import ContextProviders from './context/ContextProviders';
 import { ScrollToTop } from './utils/visning';
 import * as Sentry from '@sentry/browser';
+import { isAxiosError } from 'axios';
 import Environment from './Environment';
 import SkolepengerApp from './søknader/skolepenger/SkolepengerApp';
 import { createRoot } from 'react-dom/client';
@@ -27,9 +28,27 @@ if (Environment().sentryUrl) {
   Sentry.init({
     dsn: Environment().sentryUrl,
     environment: Environment().miljø,
+
+    beforeSend(event, hint) {
+      const error = hint?.originalException;
+
+      if (isAxiosError(error) && error.code === 'ERR_NETWORK') {
+        if (Environment().miljø !== 'production') {
+          console.warn(
+            'AxiosError ERR_NETWORK filtrert fra Sentry:',
+            error.message,
+            error.config?.url
+          );
+        }
+        return null;
+      }
+      return event;
+    },
   });
 }
+
 const container = document.getElementById('root');
+
 if (container == null) {
   throw new Error('Mangler container for appen');
 } else {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -68,8 +68,12 @@ const SentryRouteTagger: React.FC = () => {
   const location = useLocation();
 
   useEffect(() => {
-    const stønadstype = location.pathname.split('/').filter(Boolean)[0] ?? 'ukjent';
-    Sentry.setTag('stønadstype', stønadstype);
+    const første = location.pathname.split('/').filter(Boolean)[0] ?? '';
+    const stønadstype =
+      første === 'barnetilsyn' || første === 'skolepenger' || første === 'arbeidssoker'
+        ? første
+        : 'overgangsstonad';
+    Sentry.setTag('stonadstype', stønadstype);
   }, [location.pathname]);
 
   return null;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
 import '@navikt/ds-css';
 import './index.css';
 import './søknader/overgangsstønad/Forside.css';
@@ -14,28 +14,45 @@ import './søknader/arbeidssøkerskjema/Forside.css';
 import { OvergangsstønadApp } from './søknader/overgangsstønad/OvergangsstønadApp';
 import ArbeidssøkerApp from './søknader/arbeidssøkerskjema/SkjemaApp';
 import BarnetilsynApp from './søknader/barnetilsyn/BarnetilsynApp';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { SpråkProvider } from './context/SpråkContext';
 import ContextProviders from './context/ContextProviders';
 import { ScrollToTop } from './utils/visning';
-import * as Sentry from '@sentry/browser';
+import * as Sentry from '@sentry/react';
 import { isAxiosError } from 'axios';
 import Environment from './Environment';
 import SkolepengerApp from './søknader/skolepenger/SkolepengerApp';
 import { createRoot } from 'react-dom/client';
+import Feilside from './components/feil/Feilside';
 
 if (Environment().sentryUrl) {
   Sentry.init({
     dsn: Environment().sentryUrl,
     environment: Environment().miljø,
+    release: process.env.SENTRY_RELEASE || undefined,
+
+    denyUrls: [
+      /^chrome-extension:\/\//,
+      /^moz-extension:\/\//,
+      /^safari-extension:\/\//,
+      /^safari-web-extension:\/\//,
+      /^webkit-masked-url:\/\//,
+    ],
+
+    ignoreErrors: [
+      'OpsMessages.connectedCallback',
+      'ResizeObserver loop limit exceeded',
+      'ResizeObserver loop completed with undelivered notifications',
+      "evaluating 'response.showSearchResults'",
+    ],
 
     beforeSend(event, hint) {
       const error = hint?.originalException;
 
-      if (isAxiosError(error) && error.code === 'ERR_NETWORK') {
+      if (isAxiosError(error) && (error.code === 'ERR_NETWORK' || error.code === 'ERR_CANCELED')) {
         if (Environment().miljø !== 'production') {
           console.warn(
-            'AxiosError ERR_NETWORK filtrert fra Sentry:',
+            `AxiosError ${error.code} filtrert fra Sentry:`,
             error.message,
             error.config?.url
           );
@@ -46,6 +63,17 @@ if (Environment().sentryUrl) {
     },
   });
 }
+
+const SentryRouteTagger: React.FC = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    const stønadstype = location.pathname.split('/').filter(Boolean)[0] ?? 'ukjent';
+    Sentry.setTag('stønadstype', stønadstype);
+  }, [location.pathname]);
+
+  return null;
+};
 
 const container = document.getElementById('root');
 
@@ -58,15 +86,18 @@ if (container == null) {
   root.render(
     <SpråkProvider>
       <ContextProviders>
-        <Router basename={process.env.PUBLIC_URL}>
-          <ScrollToTop />
-          <Routes>
-            <Route path={'/arbeidssoker/*'} element={<ArbeidssøkerApp />} />
-            <Route path={'/barnetilsyn/*'} element={<BarnetilsynApp />} />
-            <Route path={'/skolepenger/*'} element={<SkolepengerApp />} />
-            <Route path={'*'} element={<OvergangsstønadApp />} />
-          </Routes>
-        </Router>
+        <Sentry.ErrorBoundary fallback={<Feilside />}>
+          <Router basename={process.env.PUBLIC_URL}>
+            <ScrollToTop />
+            <SentryRouteTagger />
+            <Routes>
+              <Route path={'/arbeidssoker/*'} element={<ArbeidssøkerApp />} />
+              <Route path={'/barnetilsyn/*'} element={<BarnetilsynApp />} />
+              <Route path={'/skolepenger/*'} element={<SkolepengerApp />} />
+              <Route path={'*'} element={<OvergangsstønadApp />} />
+            </Routes>
+          </Router>
+        </Sentry.ErrorBoundary>
       </ContextProviders>
     </SpråkProvider>
   );

--- a/src/søknader/arbeidssøkerskjema/SkjemaApp.tsx
+++ b/src/søknader/arbeidssøkerskjema/SkjemaApp.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import axios from 'axios';
 import Feilside from '../../components/feil/Feilside';
 import { hentPersonDataArbeidssoker } from '../../utils/søknad';
 import { Route, Routes } from 'react-router-dom';
@@ -36,9 +37,10 @@ const App = () => {
   }, [autentisert]);
 
   useEffect(() => {
+    const controller = new AbortController();
     const fetchData = () => {
       const fetchPersonData = () => {
-        hentPersonDataArbeidssoker()
+        hentPersonDataArbeidssoker(controller.signal)
           .then((response) => {
             settIdent(response.ident);
             settVisningsnavn(response.visningsnavn);
@@ -51,7 +53,8 @@ const App = () => {
             settError(false);
             settFeilmelding('');
           })
-          .catch(() => {
+          .catch((error) => {
+            if (axios.isCancel(error)) return;
             settError(true);
             settFeilmelding('skjema.feilmelding.uthenting');
           });
@@ -60,6 +63,7 @@ const App = () => {
       settFetching(false);
     };
     fetchData();
+    return () => controller.abort();
   }, [settToggles]);
 
   if (!fetching && autentisert) {

--- a/src/søknader/barnetilsyn/BarnetilsynApp.tsx
+++ b/src/søknader/barnetilsyn/BarnetilsynApp.tsx
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useState } from 'react';
+import axios from 'axios';
 import Feilside from '../../components/feil/Feilside';
 import hentToggles from '../../toggles/api';
 import { oppdaterBarnMedLabel } from '../../utils/søknad';
@@ -55,19 +56,25 @@ const BarnetilsynApp = () => {
   };
 
   useEffect(() => {
+    const controller = new AbortController();
     Promise.all([
       fetchToggles(),
-      fetchPersonData(oppdaterSøknadMedBarn, ESkjemanavn.Barnetilsyn),
-      hentMellomlagretBarnetilsyn(),
+      fetchPersonData(oppdaterSøknadMedBarn, ESkjemanavn.Barnetilsyn, controller.signal),
+      hentMellomlagretBarnetilsyn(controller.signal),
     ])
       .then(() => settFetching(false))
       .catch(() => settFetching(false));
+    return () => controller.abort();
   }, []);
 
   useEffect(() => {
-    if (skalGjenbrukeSøknad) {
-      hentForrigeSøknadBarnetilsyn();
-    }
+    if (!skalGjenbrukeSøknad) return;
+    const controller = new AbortController();
+    hentForrigeSøknadBarnetilsyn(controller.signal).catch((error) => {
+      if (axios.isCancel(error)) return;
+      throw error;
+    });
+    return () => controller.abort();
   }, [fetching, skalGjenbrukeSøknad]);
 
   if (!fetching && autentisert) {

--- a/src/søknader/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/søknader/barnetilsyn/BarnetilsynContext.tsx
@@ -89,9 +89,10 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(() 
     }
   }, [mellomlagretBarnetilsyn, locale, setLocale]);
 
-  const hentMellomlagretBarnetilsyn = (): Promise<void> => {
+  const hentMellomlagretBarnetilsyn = (signal?: AbortSignal): Promise<void> => {
     return hentMellomlagretSøknadFraDokument<MellomlagretSøknadBarnetilsyn>(
-      MellomlagredeStønadstyper.barnetilsyn
+      MellomlagredeStønadstyper.barnetilsyn,
+      signal
     ).then((mellomlagretVersjon?: MellomlagretSøknadBarnetilsyn) => {
       if (mellomlagretVersjon) {
         settMellomlagretBarnetilsyn(mellomlagretVersjon);
@@ -105,9 +106,9 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(() 
     }
   };
 
-  const hentForrigeSøknadBarnetilsyn = async (): Promise<void> => {
-    const forrigeSøknad = await hentDataFraForrigeBarnetilsynSøknad();
-    const personData = await hentPersonData();
+  const hentForrigeSøknadBarnetilsyn = async (signal?: AbortSignal): Promise<void> => {
+    const forrigeSøknad = await hentDataFraForrigeBarnetilsynSøknad(signal);
+    const personData = await hentPersonData(signal);
     if (gjenbrukBarnetilsynToggle && forrigeSøknad) {
       settSøknad((prevSøknad) => {
         const aktuelleBarn = forrigeSøknad.person.barn.filter((barn) =>

--- a/src/søknader/felles/steg/1-omdeg/OmDeg.tsx
+++ b/src/søknader/felles/steg/1-omdeg/OmDeg.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import {
   erSivilstandSpørsmålBesvart,
@@ -13,6 +13,35 @@ import { kommerFraOppsummeringen } from '../../../../utils/locationState';
 import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
 import { useOmDeg } from './OmDegContext';
 import { hentTekst } from '../../../../utils/teksthåndtering';
+import { Button, Heading, VStack } from '@navikt/ds-react';
+
+// TODO: Fjern SentryTestPanel når preprod-verifisering av Sentry-oppsettet er ferdig.
+const SentryTestPanel: FC = () => {
+  const [krasjRender, settKrasjRender] = useState(false);
+  if (krasjRender) {
+    throw new Error('Sentry ErrorBoundary-test ' + Date.now());
+  }
+
+  return (
+    <VStack gap="space-8">
+      <Heading size="xsmall" level="3">
+        Sentry-testknapper (midlertidig — slett etter test)
+      </Heading>
+      <Button
+        variant="secondary"
+        size="small"
+        onClick={() => {
+          throw new Error('Sentry kildekart-test ' + Date.now());
+        }}
+      >
+        Trigg event handler-feil
+      </Button>
+      <Button variant="secondary" size="small" onClick={() => settKrasjRender(true)}>
+        Trigg render-feil (ErrorBoundary)
+      </Button>
+    </VStack>
+  );
+};
 
 const OmDeg: FC = () => {
   const intl = useLokalIntlContext();
@@ -63,6 +92,7 @@ const OmDeg: FC = () => {
       tilbakeTilOppsummeringPath={pathOppsummering}
       mellomlagreSteg={mellomlagreSteg}
     >
+      <SentryTestPanel />
       <Personopplysninger />
       {skalViseSivilstatusdialog && <Sivilstatus />}
       {skalViseMedlemskapsdialog && <Medlemskap />}

--- a/src/søknader/felles/steg/1-omdeg/OmDeg.tsx
+++ b/src/søknader/felles/steg/1-omdeg/OmDeg.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC } from 'react';
 import { useLocation } from 'react-router-dom';
 import {
   erSivilstandSpørsmålBesvart,
@@ -13,35 +13,6 @@ import { kommerFraOppsummeringen } from '../../../../utils/locationState';
 import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
 import { useOmDeg } from './OmDegContext';
 import { hentTekst } from '../../../../utils/teksthåndtering';
-import { Button, Heading, VStack } from '@navikt/ds-react';
-
-// TODO: Fjern SentryTestPanel når preprod-verifisering av Sentry-oppsettet er ferdig.
-const SentryTestPanel: FC = () => {
-  const [krasjRender, settKrasjRender] = useState(false);
-  if (krasjRender) {
-    throw new Error('Sentry ErrorBoundary-test ' + Date.now());
-  }
-
-  return (
-    <VStack gap="space-8">
-      <Heading size="xsmall" level="3">
-        Sentry-testknapper (midlertidig — slett etter test)
-      </Heading>
-      <Button
-        variant="secondary"
-        size="small"
-        onClick={() => {
-          throw new Error('Sentry kildekart-test ' + Date.now());
-        }}
-      >
-        Trigg event handler-feil
-      </Button>
-      <Button variant="secondary" size="small" onClick={() => settKrasjRender(true)}>
-        Trigg render-feil (ErrorBoundary)
-      </Button>
-    </VStack>
-  );
-};
 
 const OmDeg: FC = () => {
   const intl = useLokalIntlContext();
@@ -92,7 +63,6 @@ const OmDeg: FC = () => {
       tilbakeTilOppsummeringPath={pathOppsummering}
       mellomlagreSteg={mellomlagreSteg}
     >
-      <SentryTestPanel />
       <Personopplysninger />
       {skalViseSivilstatusdialog && <Sivilstatus />}
       {skalViseMedlemskapsdialog && <Medlemskap />}

--- a/src/søknader/felles/steg/8-dokumentasjon/Dokumentasjon.tsx
+++ b/src/søknader/felles/steg/8-dokumentasjon/Dokumentasjon.tsx
@@ -5,7 +5,7 @@ import LastOppVedlegg from '../../../felles/steg/8-dokumentasjon/LastOppVedlegg'
 import { NavigasjonState, Side } from '../../../../components/side/Side';
 import { IDokumentasjon } from '../../../../models/steg/dokumentasjon';
 import { erVedleggstidspunktGyldig } from '../../../../utils/dato';
-import * as Sentry from '@sentry/browser';
+import * as Sentry from '@sentry/react';
 import { useDebouncedCallback } from 'use-debounce';
 import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
 import { hentHTMLTekst, hentTekst } from '../../../../utils/teksthåndtering';

--- a/src/søknader/overgangsstønad/OvergangsstønadApp.tsx
+++ b/src/søknader/overgangsstønad/OvergangsstønadApp.tsx
@@ -47,13 +47,15 @@ export const OvergangsstønadApp = () => {
   };
 
   useEffect(() => {
+    const controller = new AbortController();
     Promise.all([
       fetchToggles(),
-      fetchPersonData(oppdaterSøknadMedBarn, ESkjemanavn.Overgangsstønad),
-      hentMellomlagretOvergangsstønad(),
+      fetchPersonData(oppdaterSøknadMedBarn, ESkjemanavn.Overgangsstønad, controller.signal),
+      hentMellomlagretOvergangsstønad(controller.signal),
     ])
       .then(() => settFetching(false))
       .catch(() => settFetching(false));
+    return () => controller.abort();
   }, []);
 
   if (!fetching && autentisert) {

--- a/src/søknader/overgangsstønad/OvergangsstønadContext.tsx
+++ b/src/søknader/overgangsstønad/OvergangsstønadContext.tsx
@@ -87,9 +87,10 @@ const [OvergangsstønadSøknadProvider, useOvergangsstønadSøknad] = createUseC
     }
   }, [mellomlagretOvergangsstønad, locale, setLocale]);
 
-  const hentMellomlagretOvergangsstønad = (): Promise<void> => {
+  const hentMellomlagretOvergangsstønad = (signal?: AbortSignal): Promise<void> => {
     return hentMellomlagretSøknadFraDokument<MellomlagretSøknadOvergangsstønad>(
-      MellomlagredeStønadstyper.overgangsstønad
+      MellomlagredeStønadstyper.overgangsstønad,
+      signal
     ).then((mellomlagretVersjon?: MellomlagretSøknadOvergangsstønad) => {
       if (mellomlagretVersjon) {
         settMellomlagretOvergangsstønad(mellomlagretVersjon);

--- a/src/søknader/skolepenger/SkolepengerApp.tsx
+++ b/src/søknader/skolepenger/SkolepengerApp.tsx
@@ -44,13 +44,15 @@ const SkolepengerApp = () => {
   };
 
   useEffect(() => {
+    const controller = new AbortController();
     Promise.all([
       fetchToggles(),
-      fetchPersonData(oppdaterSøknadMedBarn, ESkjemanavn.Skolepenger),
-      hentMellomlagretSkolepenger(),
+      fetchPersonData(oppdaterSøknadMedBarn, ESkjemanavn.Skolepenger, controller.signal),
+      hentMellomlagretSkolepenger(controller.signal),
     ])
       .then(() => settFetching(false))
       .catch(() => settFetching(false));
+    return () => controller.abort();
   }, []);
 
   if (!fetching && autentisert) {

--- a/src/søknader/skolepenger/SkolepengerContext.tsx
+++ b/src/søknader/skolepenger/SkolepengerContext.tsx
@@ -80,9 +80,10 @@ const [SkolepengerSøknadProvider, useSkolepengerSøknad] = createUseContext(() 
     }
   }, [mellomlagretSkolepenger, locale, setLocale]);
 
-  const hentMellomlagretSkolepenger = (): Promise<void> => {
+  const hentMellomlagretSkolepenger = (signal?: AbortSignal): Promise<void> => {
     return hentMellomlagretSøknadFraDokument<MellomlagretSøknadSkolepenger>(
-      MellomlagredeStønadstyper.skolepenger
+      MellomlagredeStønadstyper.skolepenger,
+      signal
     ).then((mellomlagretVersjon?: MellomlagretSøknadSkolepenger) => {
       if (mellomlagretVersjon) {
         settMellomlagretSkolepenger(mellomlagretVersjon);

--- a/src/utils/søknad.ts
+++ b/src/utils/søknad.ts
@@ -2,7 +2,7 @@ import Environment from '../Environment';
 import axios from 'axios';
 import { hentUid } from './autentiseringogvalidering/uuid';
 import { ISpørsmål } from '../models/felles/spørsmålogsvar';
-import * as Sentry from '@sentry/browser';
+import * as Sentry from '@sentry/react';
 import { MellomlagredeStønadstyper } from '../models/søknad/stønadstyper';
 import { IDokumentasjon } from '../models/steg/dokumentasjon';
 import { skalMappeBarnefeltUtenLabel, standardLabelsBarn } from '../helpers/labels';
@@ -20,11 +20,11 @@ const axiosConfig = {
   },
 };
 
-export const hentPersonData = async (): Promise<PersonData> => {
-  const response = await axios.get(
-    `${Environment().apiProxyUrl}/api/oppslag/sokerinfo`,
-    axiosConfig
-  );
+export const hentPersonData = async (signal?: AbortSignal): Promise<PersonData> => {
+  const response = await axios.get(`${Environment().apiProxyUrl}/api/oppslag/sokerinfo`, {
+    ...axiosConfig,
+    signal,
+  });
   return response && response.data;
 };
 
@@ -37,10 +37,11 @@ export const hentPersonDataArbeidssoker = () => {
 };
 
 export const hentMellomlagretSøknadFraDokument = <T>(
-  stønadstype: MellomlagredeStønadstyper
+  stønadstype: MellomlagredeStønadstyper,
+  signal?: AbortSignal
 ): Promise<T | undefined> => {
   return axios
-    .get(`${Environment().mellomlagerProxyUrl + stønadstype}`, axiosConfig)
+    .get(`${Environment().mellomlagerProxyUrl + stønadstype}`, { ...axiosConfig, signal })
     .then((response: { data?: T }) => {
       return response.data;
     });
@@ -53,10 +54,12 @@ export const mellomlagreSøknadTilDokument = <T>(
   return axios.post(`${Environment().mellomlagerProxyUrl + stønadstype}`, søknad, axiosConfig);
 };
 
-export const hentDataFraForrigeBarnetilsynSøknad = async (): Promise<ForrigeSøknad> => {
+export const hentDataFraForrigeBarnetilsynSøknad = async (
+  signal?: AbortSignal
+): Promise<ForrigeSøknad> => {
   const response = await axios.get(
     `${Environment().apiProxyUrl + '/api/soknad/barnetilsyn/forrige'}`,
-    axiosConfig
+    { ...axiosConfig, signal }
   );
   return response.data;
 };

--- a/src/utils/søknad.ts
+++ b/src/utils/søknad.ts
@@ -28,9 +28,9 @@ export const hentPersonData = async (signal?: AbortSignal): Promise<PersonData> 
   return response && response.data;
 };
 
-export const hentPersonDataArbeidssoker = () => {
+export const hentPersonDataArbeidssoker = (signal?: AbortSignal) => {
   return axios
-    .get(`${Environment().apiProxyUrl}/api/oppslag/sokerminimum`, axiosConfig)
+    .get(`${Environment().apiProxyUrl}/api/oppslag/sokerminimum`, { ...axiosConfig, signal })
     .then((response: { data: any }) => {
       return response && response.data;
     });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
             name: process.env.SENTRY_RELEASE,
           },
           errorHandler: (err) => {
-            console.warn('Sentry Vite Plugin: ' + err.message);
+            throw err;
           },
         })
       : undefined,
@@ -28,6 +28,7 @@ export default defineConfig({
     'process.env.PUBLIC_URL': JSON.stringify(basePath.slice(0, -1)),
     'process.env.BRUK_MOCK_LOKALT': JSON.stringify(process.env.BRUK_MOCK_LOKALT || false),
     'process.env.BRUK_DEV_API': JSON.stringify(process.env.BRUK_DEV_API || false),
+    'process.env.SENTRY_RELEASE': JSON.stringify(process.env.SENTRY_RELEASE ?? ''),
   },
   build: {
     outDir: 'build',


### PR DESCRIPTION
# Sentry rydding: source maps, filtre, ErrorBoundary og AbortController

### Hvorfor er denne endringen nødvendig? ✨

Sentry har overtid gitt lite verdi der den melder feil, men sjelden nøyaktiv hva som kan forårsake dette. Stack traces kommer som ulesbare strenger (typisk noe i retning av `index-XXXXX.js:31:70`), og feeden var full av støy fra ting vi ikke kan gjøre noe med, som nettleser extensions, NAV dekoratoren og typiske Safari iOS greier. Det gjør at det meldes mye og det oppfattes som støy. 

Endringene her prøver å gjøre Sentry til et verktøy vi faktisk får bruk for, noe som kan være nice.

* Bytter fra `@sentry/browser` til `@sentry/react` for å få ErrorBoundary og bedre React integrasjon.
* Source maps lastes nå opp ordentlig. Tidligere svelget vi upload feil med `console.warn`, så vi visste ikke at det noen ganger gikk galt. Nå feiler builden hardt om opplastingen feiler. Vi sender også `release` med klient bundlen så Sentry vet hvilke source maps som hører til hvilket event.
* Lagt til `Sentry.ErrorBoundary` på app root med `Feilside` som fallback. Tidligere fikk brukeren hvit skjerm ved render feil, nå får de feilsiden vår. Dette er noe jeg har ønsket meg siden landverktoy feilen. 
* Filtrerer tredjepartsstøy via `denyUrls` (extensions) og `ignoreErrors` (dekoratoren, ResizeObserver, kjente Safari greier).
* Filtrerer `AxiosError` med kode `ERR_NETWORK` eller `ERR_CANCELED` i `beforeSend`. Disse er typisk støy fra brukere som navigerer bort midt i en request.
* Tagger events med `stonadstype` (basert på route) og `skjemanavn` (basert på `fetchPersonData` kallet). Da kan vi filtrere i Sentry på hvilken flow feilen kom fra, eg stønadstype. 
* AbortController på de viktigste forside requestene i alle fire flyter (sokerinfo, sokerminimum, mellomlagret søknad, forrige søknad, sist innsendt). Når bruker navigerer videre før requesten er ferdig, avbrytes den pent i stedet for å bli sendt til Sentry som støy.

### Verdt å nevne

Testet i preprod ved å legge inn to midlertidige test knapper på om deg steget (slettet før merge). 

Resulterte som følgende:

* **Source maps fungerer.** Trigget en feil fra knappen og fikk i Sentry frem riktig fil og linjenummer i `OmDeg.tsx`, ikke minified bundle. Release matchet commit SHA.
* **ErrorBoundary fungerer.** Trigget en render feil, fikk Feilside i nettleseren i stedet for hvit skjerm. Sentry event hadde `handled: true` og React component stack, som bekrefter at boundary fanget den.
* **stonadstype tag fungerer.** Verdier som `barnetilsyn`, `skolepenger`, `arbeidssoker` og `overgangsstonad` settes riktig basert på path. Måtte fikse en runde fordi Sentry ikke godtar `ø` i tag navn (men tag verdi går fint).
* **AbortController inkonklusiv lokalt.** Med Slow 4G throttling rakk requests å fullføre før jeg navigerte videre, så abort fyrte ikke i den testen. Men ingen nye Sentry events kom heller, så uansett om abort fungerte eller om filteret tok dem, ble feeden stille.

Det vi må la stå i ca en uke for å verifisere er filtrene. Er ikke helt lett å teste, så må bare se litt overtid hva som skjer. 

* `chrome-extension://...` events skal forsvinne :crossed_fingers:
* `OpsMessages.connectedCallback` fra dekoratoren skal forsvinne :crossed_fingers:
* `AxiosError ERR_NETWORK` og `ERR_CANCELED` skal forsvinne :crossed_fingers: (ikke støye så mye)
* Reelle 4xx og 5xx fra backend skal fortsatt logges inn :crossed_fingers:

Hvis du legger merke til at noe mangler i Sentry etter en uke som du faktisk ville hatt inn, kan vi snevre inn filtrene. Foreløpig konfigurasjon er bevisst heavy.
