### PR TITLE
Vite hmr port

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,11 @@ export default defineConfig({
     'process.env.BRUK_DEV_API': JSON.stringify(process.env.BRUK_DEV_API || false),
     'process.env.SENTRY_RELEASE': JSON.stringify(process.env.SENTRY_RELEASE ?? ''),
   },
+  server: {
+    hmr: {
+      port: 24679,
+    },
+  },
   build: {
     outDir: 'build',
     sourcemap: true,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Setter vite hmr port til noe annet enn default. Ønsker å gjøre dette for at flere apper skal kunne kjøre lokalt, med den endringen kan ef-sak-frontend (som bruker default) og soknad kjører samtidig uten feilmelding: 'WebSocket server error: Port 24678 is already in use'.