### PR TITLE
OS regelverksendring tidligere vedtakshistorikk 

### DIFF
--- a/src/context/ContextProviders.tsx
+++ b/src/context/ContextProviders.tsx
@@ -5,20 +5,23 @@ import { TogglesProvider } from './TogglesContext';
 import { BarnetilsynSøknadProvider } from '../søknader/barnetilsyn/BarnetilsynContext';
 import { SkolepengerSøknadProvider } from '../søknader/skolepenger/SkolepengerContext';
 import { GjenbrukProvider } from './GjenbrukContext';
+import { TidligereVedtakProvider } from './TidligereVedtakContext';
 
 const ContextProviders: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   ContextProviders.displayName = 'CONTEXT_PROVIDERS';
   return (
     <TogglesProvider>
-      <GjenbrukProvider>
-        <PersonProvider>
-          <OvergangsstønadSøknadProvider>
-            <BarnetilsynSøknadProvider>
-              <SkolepengerSøknadProvider>{children}</SkolepengerSøknadProvider>
-            </BarnetilsynSøknadProvider>
-          </OvergangsstønadSøknadProvider>
-        </PersonProvider>
-      </GjenbrukProvider>
+      <TidligereVedtakProvider>
+        <GjenbrukProvider>
+          <PersonProvider>
+            <OvergangsstønadSøknadProvider>
+              <BarnetilsynSøknadProvider>
+                <SkolepengerSøknadProvider>{children}</SkolepengerSøknadProvider>
+              </BarnetilsynSøknadProvider>
+            </OvergangsstønadSøknadProvider>
+          </PersonProvider>
+        </GjenbrukProvider>
+      </TidligereVedtakProvider>
     </TogglesProvider>
   );
 };

--- a/src/context/TidligereVedtakContext.tsx
+++ b/src/context/TidligereVedtakContext.tsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, useState } from 'react';
+import { TidligereVedtakStatus } from '../innsending/api';
+
+interface TidligereVedtakContextType {
+  tidligereVedtakStatus: TidligereVedtakStatus | null;
+  settTidligereVedtakStatus: (status: TidligereVedtakStatus | null) => void;
+}
+
+const TidligereVedtakContext = createContext<TidligereVedtakContextType | undefined>(undefined);
+
+const TidligereVedtakProvider = ({ children }: { children: React.ReactNode }) => {
+  const [tidligereVedtakStatus, settTidligereVedtakStatus] = useState<TidligereVedtakStatus | null>(
+    null
+  );
+
+  return (
+    <TidligereVedtakContext.Provider value={{ tidligereVedtakStatus, settTidligereVedtakStatus }}>
+      {children}
+    </TidligereVedtakContext.Provider>
+  );
+};
+
+const useTidligereVedtak = (): TidligereVedtakContextType => {
+  const context = useContext(TidligereVedtakContext);
+  if (!context) {
+    throw new Error('useTidligereVedtak må brukes innenfor TidligereVedtakProvider');
+  }
+  return context;
+};
+
+export { TidligereVedtakProvider, useTidligereVedtak };

--- a/src/context/TidligereVedtakContext.tsx
+++ b/src/context/TidligereVedtakContext.tsx
@@ -2,16 +2,15 @@ import { createContext, useContext, useState } from 'react';
 import { TidligereVedtakStatus } from '../innsending/api';
 
 interface TidligereVedtakContextType {
-  tidligereVedtakStatus: TidligereVedtakStatus | null;
-  settTidligereVedtakStatus: (status: TidligereVedtakStatus | null) => void;
+  tidligereVedtakStatus: TidligereVedtakStatus;
+  settTidligereVedtakStatus: (status: TidligereVedtakStatus) => void;
 }
 
 const TidligereVedtakContext = createContext<TidligereVedtakContextType | undefined>(undefined);
 
 const TidligereVedtakProvider = ({ children }: { children: React.ReactNode }) => {
-  const [tidligereVedtakStatus, settTidligereVedtakStatus] = useState<TidligereVedtakStatus | null>(
-    null
-  );
+  const [tidligereVedtakStatus, settTidligereVedtakStatus] =
+    useState<TidligereVedtakStatus>('VET_IKKE');
 
   return (
     <TidligereVedtakContext.Provider value={{ tidligereVedtakStatus, settTidligereVedtakStatus }}>

--- a/src/innsending/api.ts
+++ b/src/innsending/api.ts
@@ -2,6 +2,16 @@ import axios from 'axios';
 import Environment from '../Environment';
 import { IBarn } from '../models/steg/barn';
 
+export type TidligereVedtakStatus = 'JA' | 'NEI' | 'VET_IKKE';
+
+export const hentHarTidligereInnvilgetVedtak = async (): Promise<TidligereVedtakStatus> => {
+  const response = await axios.get<TidligereVedtakStatus>(
+    `${Environment().apiProxyUrl}/api/saksbehandling/har-tidligere-innvilget-vedtak`,
+    { withCredentials: true }
+  );
+  return response.data;
+};
+
 export const sendInnOvergangstønadSøknad = (søknad: object) => {
   return axios
     .post(`${Environment().apiProxyUrl}/api/soknad/overgangsstonad`, søknad, {

--- a/src/models/søknad/toggles.ts
+++ b/src/models/søknad/toggles.ts
@@ -5,4 +5,5 @@ export interface Toggles {
 export enum ToggleName {
   leggTilNynorsk = 'familie.ef.soknad.nynorsk',
   gjenbrukBarnetilsyn = 'familie.ef.soknad.gjenbruk-barnetilsyn',
+  overgangsstønadRegelendringer2026 = 'familie.ef.soknad.overgangsstonad-regelendringer-2026',
 }

--- a/src/søknader/overgangsstønad/OvergangsstønadApp.tsx
+++ b/src/søknader/overgangsstønad/OvergangsstønadApp.tsx
@@ -18,6 +18,7 @@ import { ESkjemanavn } from '../../utils/skjemanavn';
 import { hentTekst } from '../../utils/teksthåndtering';
 import { hentHarTidligereInnvilgetVedtak } from '../../innsending/api';
 import { useTidligereVedtak } from '../../context/TidligereVedtakContext';
+import { ToggleName } from '../../models/søknad/toggles';
 
 export const OvergangsstønadApp = () => {
   const [autentisert, settAutentisering] = useState<boolean>(false);
@@ -49,19 +50,25 @@ export const OvergangsstønadApp = () => {
     });
   };
 
-  const hentTidligereVedtak = () => {
+  const fetchTidligereVedtakHvisToggleErPå = (toggles: Record<string, boolean> | void) => {
+    if (!toggles || !toggles[ToggleName.overgangsstønadRegelendringer2026]) {
+      settTidligereVedtakStatus('VET_IKKE');
+      return Promise.resolve();
+    }
     return hentHarTidligereInnvilgetVedtak()
       .then((status) => settTidligereVedtakStatus(status))
       .catch(() => settTidligereVedtakStatus('VET_IKKE'));
   };
 
   useEffect(() => {
-    Promise.all([
-      fetchToggles(),
-      fetchPersonData(oppdaterSøknadMedBarn, ESkjemanavn.Overgangsstønad),
-      hentMellomlagretOvergangsstønad(),
-      hentTidligereVedtak(),
-    ])
+    fetchToggles()
+      .then((toggles) =>
+        Promise.all([
+          fetchPersonData(oppdaterSøknadMedBarn, ESkjemanavn.Overgangsstønad),
+          hentMellomlagretOvergangsstønad(),
+          fetchTidligereVedtakHvisToggleErPå(toggles),
+        ])
+      )
       .then(() => settFetching(false))
       .catch(() => settFetching(false));
   }, []);

--- a/src/søknader/overgangsstønad/OvergangsstønadApp.tsx
+++ b/src/søknader/overgangsstønad/OvergangsstønadApp.tsx
@@ -16,6 +16,8 @@ import { Loader } from '@navikt/ds-react';
 import { IBarn } from '../../models/steg/barn';
 import { ESkjemanavn } from '../../utils/skjemanavn';
 import { hentTekst } from '../../utils/teksthåndtering';
+import { hentHarTidligereInnvilgetVedtak } from '../../innsending/api';
+import { useTidligereVedtak } from '../../context/TidligereVedtakContext';
 
 export const OvergangsstønadApp = () => {
   const [autentisert, settAutentisering] = useState<boolean>(false);
@@ -23,6 +25,7 @@ export const OvergangsstønadApp = () => {
   const { fetchPersonData, error, settError, feilmelding, alvorlighetsgrad } = usePersonContext();
   const { settSøknad, hentMellomlagretOvergangsstønad } = useOvergangsstønadSøknad();
   const { settToggles } = useToggles();
+  const { settTidligereVedtakStatus } = useTidligereVedtak();
 
   const intl = useLokalIntlContext();
   autentiseringsInterceptor();
@@ -46,11 +49,18 @@ export const OvergangsstønadApp = () => {
     });
   };
 
+  const hentTidligereVedtak = () => {
+    return hentHarTidligereInnvilgetVedtak()
+      .then((status) => settTidligereVedtakStatus(status))
+      .catch(() => settTidligereVedtakStatus('VET_IKKE'));
+  };
+
   useEffect(() => {
     Promise.all([
       fetchToggles(),
       fetchPersonData(oppdaterSøknadMedBarn, ESkjemanavn.Overgangsstønad),
       hentMellomlagretOvergangsstønad(),
+      hentTidligereVedtak(),
     ])
       .then(() => settFetching(false))
       .catch(() => settFetching(false));

--- a/src/toggles/api.ts
+++ b/src/toggles/api.ts
@@ -7,8 +7,9 @@ const hentToggles = (settToggles: (toggles: Toggles) => void) => {
     .get(`${Environment().apiProxyUrl}/api/featuretoggle`, {
       withCredentials: true,
     })
-    .then((response: { data: any }) => {
+    .then((response: { data: Toggles }) => {
       settToggles(response.data);
+      return response.data;
     });
 };
 


### PR DESCRIPTION
Gjør kall mot nytt endepunkt for å finne ut om en søker har tidligere vedtak. Verdien av dette skal brukes til å bestemme hvilken versjon av overgangsstønad søknaden skal bruke.

Kallet ligger back toggle slik at ikke unødvendig kall blir gjort frem til 1. juli

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-28467)