### PR TITLE
OS regelendring 2026 hva situasjon - nytt alternativ

### DIFF
--- a/src/language/tekster_nb.ts
+++ b/src/language/tekster_nb.ts
@@ -333,6 +333,9 @@ export default {
   'nySituasjon.svar.barnSærligTilsyn':
     'Jeg har barn som trenger særlig tilsyn på grunn av fysiske, psykiske eller store sosiale problemer',
   'nySituasjon.svar.barnSykdomIkkeVarig': 'Barnet mitt har en sykdom som ikke er varig',
+  'nySituasjon.svar.ingenAvDisseGjelderMeg': 'Ingen av disse gjelder meg',
+  'nySituasjon.alert-advarsel.ingenAvDisseGjelderMeg':
+    'Hvis ingen av disse gjelder deg, kan det hende du ikke har rett til overgangsstønad til enslig mor eller far',
 
   'inntekter.hjelpetekst.innhold':
     'Inntekten din avgjør hvor mye du får utbetalt i overgangsstønad. <br/><br/> Du kan lese mer om hvordan vi beregner inntekten din på <a href="https://www.nav.no/overgangsstonad-enslig#hvor-mye">nav.no/overgangsstonad-enslig#hvor-mye</a>.',

--- a/src/models/steg/dinsituasjon/situasjonTyper.ts
+++ b/src/models/steg/dinsituasjon/situasjonTyper.ts
@@ -7,6 +7,7 @@ export enum HvaSituasjon {
   barnUnder14Måneder = 'barnUnder14Måneder',
   barnSærligTilsyn = 'barnSærligTilsyn',
   barnSykdomIkkeVarig = 'barnSykdomIkkeVarig',
+  ingenAvDisseGjelderMeg = 'ingenAvDisseGjelderMeg',
 }
 
 export enum InntekterId {

--- a/src/søknader/overgangsstønad/steg/5-regelendring-2026/Situasjon.tsx
+++ b/src/søknader/overgangsstønad/steg/5-regelendring-2026/Situasjon.tsx
@@ -8,7 +8,7 @@ import { kommerFraOppsummeringen } from '../../../../utils/locationState';
 import { useLocation } from 'react-router-dom';
 import { NavigasjonState, Side } from '../../../../components/side/Side';
 import { useOvergangsstønadSøknad } from '../../OvergangsstønadContext';
-import { VStack } from '@navikt/ds-react';
+import { Alert, VStack } from '@navikt/ds-react';
 import { ISpørsmål, ISvar } from '../../../../models/felles/spørsmålogsvar';
 import {
   ESøkerFraBestemtMåned,
@@ -175,6 +175,8 @@ export const Situasjon: React.FC = () => {
 
   const valgteSituasjoner = hvaSituasjon?.svarid ?? [];
   const harValgtMinstEttAlternativ = valgteSituasjoner.length > 0;
+  const harKunValgtIngenAvDisseGjelderMeg =
+    valgteSituasjoner.length === 1 && valgteSituasjoner[0] === HvaSituasjon.ingenAvDisseGjelderMeg;
 
   const erBarnSærligTilsyn = valgteSituasjoner.includes(HvaSituasjon.barnSærligTilsyn);
   const erBarnSykdomIkkeVarig = valgteSituasjoner.includes(HvaSituasjon.barnSykdomIkkeVarig);
@@ -238,6 +240,12 @@ export const Situasjon: React.FC = () => {
           <AlertStripeDokumentasjon>
             {hentHTMLTekst('dinSituasjon.alert.harSyktBarn', intl)}
           </AlertStripeDokumentasjon>
+        )}
+
+        {harKunValgtIngenAvDisseGjelderMeg && (
+          <Alert variant={'warning'} size={'small'} inline>
+            {hentTekst('nySituasjon.alert-advarsel.ingenAvDisseGjelderMeg', intl)}
+          </Alert>
         )}
 
         {visSpørsmålInntekter && (

--- a/src/søknader/overgangsstønad/steg/5-regelendring-2026/SituasjonConfig.ts
+++ b/src/søknader/overgangsstønad/steg/5-regelendring-2026/SituasjonConfig.ts
@@ -32,6 +32,10 @@ export const hvaSituasjonSpm = (intl: LokalIntlShape): ISpørsmål => ({
       svar_tekst: hentTekst('nySituasjon.svar.barnSykdomIkkeVarig', intl),
       dokumentasjonsbehov: DokumentasjonsConfig.DokumentasjonSyktBarn,
     },
+    {
+      id: HvaSituasjon.ingenAvDisseGjelderMeg,
+      svar_tekst: hentTekst('nySituasjon.svar.ingenAvDisseGjelderMeg', intl),
+    },
   ],
 });
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Ønsker et alternativ på hva situasjonen til søker er som dekker andre muligheter enn det som kan gi stønad.
Uten dette alternativet kan søkere måtte "lyve" for å komme videre i søknaden.
Hvis "Ingen av disse gjelder meg" blir valgt vises det en advarsel med at søker ikke har rett på overgangsstønad.