### PR TITLE
Fikser knapper i arbeidssøkerskjema

### DIFF
--- a/src/søknader/arbeidssøkerskjema/side/Side.css
+++ b/src/søknader/arbeidssøkerskjema/side/Side.css
@@ -58,6 +58,8 @@
   grid-template-areas:
     'tilbake neste'
     'avbryt avbryt';
+  column-gap: 1rem;
+  justify-self: center;
 }
 .side .treKnapper .hideButton {
   display: none;
@@ -70,6 +72,8 @@
 }
 .side .treKnapper .avbryt {
   grid-area: avbryt;
+  justify-self: center;
+  margin-top: 0.5rem;
 }
 .side .tilbake-til-oppsummering {
   margin: 0 auto;

--- a/src/søknader/arbeidssøkerskjema/side/Side.tsx
+++ b/src/søknader/arbeidssøkerskjema/side/Side.tsx
@@ -4,7 +4,7 @@ import { RoutesArbeidssokerskjema } from '../routes/routesArbeidssokerskjema';
 import { useLocation } from 'react-router-dom';
 import { hentForrigeRoute, hentNesteRoute } from '../../../utils/routing';
 import { useLokalIntlContext } from '../../../context/LokalIntlContext';
-import { BodyShort, Box, Heading } from '@navikt/ds-react';
+import { BodyShort, Box, Heading, HStack, VStack } from '@navikt/ds-react';
 import { KnappLocaleTekstOgNavigate } from '../../../components/knapper/KnappLocaleTekstOgNavigate';
 import { Stegindikator } from '../../../components/stegindikator/Stegindikator';
 import { stegSomSkalVisesPåStegindikator } from '../../../utils/stegindikator';
@@ -50,13 +50,13 @@ const Side: React.FC<ISide> = ({
           </div>
         </Box>
         {skalViseKnapper && (
-          <>
+          <VStack gap="space-8" align="center" className={'side__knapper'}>
             {!erSpørsmålBesvart && (
               <BodyShort size="small" className={'side__uu-tekst'}>
                 {hentTekst('knapp.uu-tekst', intl)}
               </BodyShort>
             )}
-            <div className={erSpørsmålBesvart ? 'side__knapper treKnapper' : 'side__knapper'}>
+            <HStack gap="space-16" justify="center">
               <KnappLocaleTekstOgNavigate nesteSide={forrigeRoute.path} tekst={'knapp.tilbake'} />
               {erSpørsmålBesvart && (
                 <KnappLocaleTekstOgNavigate
@@ -65,14 +65,13 @@ const Side: React.FC<ISide> = ({
                   tekst={'knapp.neste'}
                 />
               )}
-
-              <KnappLocaleTekstOgNavigate
-                variant="tertiary"
-                nesteSide={RoutesArbeidssokerskjema[0].path}
-                tekst={'knapp.avbryt'}
-              />
-            </div>
-          </>
+            </HStack>
+            <KnappLocaleTekstOgNavigate
+              variant="tertiary"
+              nesteSide={RoutesArbeidssokerskjema[0].path}
+              tekst={'knapp.avbryt'}
+            />
+          </VStack>
         )}
       </div>
     </div>


### PR DESCRIPTION
# Fikser knapper i arbeidssøkerskjema

### Hvorfor er denne endringen nødvendig? ✨

Knappene "Tilbake", "Neste" og "Avbryt" i arbeidssøkerskjemaet var ikke sentrert og manglet mellomrom mellom seg. Problemet var at layouten brukte CSS grid-areas med klassenavn som aldri ble satt på knappene, så plasseringen fungerte ikke som forventet.

Endringene:

- Byttet fra CSS grid med klassenavn til `HStack` og `VStack` fra NAV Aksel, samme mønster som resten av skjemaene bruker
- "Tilbake" og "Neste" vises side om side med riktig mellomrom
- "Avbryt" vises sentrert under begge

### Verdt å nevne

Testet i nettleseren og alt ser bra ut:

- Steg med kun "Tilbake" viser én knapp sentrert
- Steg med "Tilbake" og "Neste" viser begge knapper side om side med mellomrom, sentrert
- "Avbryt" vises sentrert under knappeparet

<table>
  <tr>
    <th style="text-align:center">Før</th>
    <th style="text-align:center">Etter</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/6dbe3736-f6fa-46b0-be8c-a6c4d80616c7" alt="Før" width="400"/></td>
    <td><img src="https://github.com/user-attachments/assets/e6b97938-c840-4eab-9216-4a9758b57882" alt="Etter" width="400"/></td>
  </tr>