### PR TITLE
Barnetilsyn barnepass spørsmål regelendring 2026

### DIFF
--- a/src/context/TidligereVedtakContext.tsx
+++ b/src/context/TidligereVedtakContext.tsx
@@ -2,18 +2,23 @@ import { createContext, useContext, useState } from 'react';
 import { TidligereVedtakStatus } from '../innsending/api';
 
 interface TidligereVedtakContextType {
-  tidligereVedtakStatus: TidligereVedtakStatus;
-  settTidligereVedtakStatus: (status: TidligereVedtakStatus) => void;
+  harTidligereVedtakStatus: TidligereVedtakStatus;
+  settHarTidligereVedtakStatus: (status: TidligereVedtakStatus) => void;
 }
 
 const TidligereVedtakContext = createContext<TidligereVedtakContextType | undefined>(undefined);
 
 const TidligereVedtakProvider = ({ children }: { children: React.ReactNode }) => {
-  const [tidligereVedtakStatus, settTidligereVedtakStatus] =
+  const [harTidligereVedtakStatus, settHarTidligereVedtakStatus] =
     useState<TidligereVedtakStatus>('VET_IKKE');
 
   return (
-    <TidligereVedtakContext.Provider value={{ tidligereVedtakStatus, settTidligereVedtakStatus }}>
+    <TidligereVedtakContext.Provider
+      value={{
+        harTidligereVedtakStatus,
+        settHarTidligereVedtakStatus,
+      }}
+    >
       {children}
     </TidligereVedtakContext.Provider>
   );

--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -787,6 +787,8 @@ export default {
   'barnepass.spm.årsak': 'Why does [0] need looking after?',
   'barnepass.alert-advarsel.årsak':
     '<b>The main rule is that you can receive child care benefit until your child has completed their fourth year at school.\n </b> <br/><br/>At this stage, children have normally become sufficiently self-reliant and mature that they can cope on their own outside school hours both at home and in their usual local environment while you are absent due to work.',
+  'barnepass.alert-advarsel.årsak-regelendring-2026':
+    '<b>The main rule is that you can receive child care benefit until your child is 14 months old.</b>',
   'barnepass.svar.trengerMerPassEnnJevnaldrede':
     'The child needs significantly more looking after than is usual for children of this age',
   'barnepass.dokumentasjon.trengerMerPassEnnJevnaldrede':

--- a/src/language/tekster_nb.ts
+++ b/src/language/tekster_nb.ts
@@ -761,6 +761,8 @@ export default {
   'barnepass.spm.årsak': 'Hvorfor trenger [0] pass?',
   'barnepass.alert-advarsel.årsak':
     '<b>Hovedregelen er at du kan få stønad til barnetilsyn frem til barnet ditt har fullført 4. skoleår. </b> <br/><br/>På dette alderstrinnet er barn normalt blitt tilstrekkelig selvhjulpne og modne slik at de klarer seg utenfor skoletiden både i hjemmet og i sitt vanlige nærmiljø i den tiden du er fraværende på grunn av arbeid.',
+  'barnepass.alert-advarsel.årsak-regelendring-2026':
+    '<b>Hovedregelen er at du kan få stønad til barnetilsyn frem til barnet ditt er 14 måneder.</b>',
   'barnepass.svar.trengerMerPassEnnJevnaldrede':
     'Barnet har behov for vesentlig mer pass enn det som er vanlig for jevnaldrende',
   'barnepass.dokumentasjon.trengerMerPassEnnJevnaldrede':

--- a/src/søknader/barnetilsyn/BarnetilsynApp.tsx
+++ b/src/søknader/barnetilsyn/BarnetilsynApp.tsx
@@ -29,7 +29,7 @@ const BarnetilsynApp = () => {
   const { settToggles } = useToggles();
   const intl = useLokalIntlContext();
   const { skalGjenbrukeSøknad } = useContext(GjenbrukContext);
-  const { settTidligereVedtakStatus } = useTidligereVedtak();
+  const { settHarTidligereVedtakStatus } = useTidligereVedtak();
 
   autentiseringsInterceptor();
 
@@ -59,8 +59,8 @@ const BarnetilsynApp = () => {
 
   const hentOgSettTidligereVedtakStatus = () => {
     return hentVedtakPåGammeltRegelverk()
-      .then((status) => settTidligereVedtakStatus(status))
-      .catch(() => settTidligereVedtakStatus('VET_IKKE'));
+      .then((status) => settHarTidligereVedtakStatus(status))
+      .catch(() => settHarTidligereVedtakStatus('VET_IKKE'));
   };
 
   useEffect(() => {

--- a/src/søknader/barnetilsyn/BarnetilsynApp.tsx
+++ b/src/søknader/barnetilsyn/BarnetilsynApp.tsx
@@ -17,6 +17,8 @@ import { Loader } from '@navikt/ds-react';
 import { IBarn } from '../../models/steg/barn';
 import { GjenbrukContext } from '../../context/GjenbrukContext';
 import { hentTekst } from '../../utils/teksthåndtering';
+import { hentVedtakPåGammeltRegelverk } from '../../innsending/api';
+import { useTidligereVedtak } from '../../context/TidligereVedtakContext';
 
 const BarnetilsynApp = () => {
   const [autentisert, settAutentisering] = useState<boolean>(false);
@@ -27,6 +29,7 @@ const BarnetilsynApp = () => {
   const { settToggles } = useToggles();
   const intl = useLokalIntlContext();
   const { skalGjenbrukeSøknad } = useContext(GjenbrukContext);
+  const { settTidligereVedtakStatus } = useTidligereVedtak();
 
   autentiseringsInterceptor();
 
@@ -54,11 +57,18 @@ const BarnetilsynApp = () => {
     });
   };
 
+  const hentOgSettTidligereVedtakStatus = () => {
+    return hentVedtakPåGammeltRegelverk()
+      .then((status) => settTidligereVedtakStatus(status))
+      .catch(() => settTidligereVedtakStatus('VET_IKKE'));
+  };
+
   useEffect(() => {
     Promise.all([
       fetchToggles(),
       fetchPersonData(oppdaterSøknadMedBarn, ESkjemanavn.Barnetilsyn),
       hentMellomlagretBarnetilsyn(),
+      hentOgSettTidligereVedtakStatus(),
     ])
       .then(() => settFetching(false))
       .catch(() => settFetching(false));

--- a/src/søknader/barnetilsyn/steg/6-barnepass/Barnepass.test.ts
+++ b/src/søknader/barnetilsyn/steg/6-barnepass/Barnepass.test.ts
@@ -12,12 +12,15 @@ import {
   formatMånederTilbake,
 } from '../../../../utils/dato';
 import {
+  lagBarnepass,
   lagIBarn,
   lagPerson,
   lagSpørsmålBooleanFelt,
+  lagSpørsmålFelt,
   lagSøknadBarnetilsyn,
   lagTekstfelt,
 } from '../../../../test/domeneUtils';
+import { EBarnepass, EÅrsakBarnepass } from '../../models/barnepass';
 
 const søkerFraBestemtMånedSpørsmålBarnetilsyn = `Søker du om stønad til barnetilsyn fra en bestemt måned? Om å søke fra et bestemt tidspunkt Du kan få stønad til barnetilsyn fra og med den måneden du har rett til stønaden. Du kan ha rett til stønad i inntil 3 måneder før du søker. Det vil si fra og med ${formatMånederTilbake(dagensDato, 3)}. Selv om du søker fra en bestemt måned vil vi vurdere om du har rett til stønad fra denne måneden eller senere.`;
 
@@ -525,6 +528,14 @@ describe('Barnepass-Steg', () => {
                 label: '',
                 verdi: true,
               }),
+              barnepass: lagBarnepass({
+                årsakBarnepass: lagSpørsmålFelt({
+                  spørsmålid: EBarnepass.årsakBarnepass,
+                  svarid: EÅrsakBarnepass.myeBortePgaJobb,
+                  label: 'Hvorfor trenger barnet pass?',
+                  verdi: 'Jeg er mye borte.',
+                }),
+              }),
             }),
             lagIBarn({
               navn: lagTekstfelt({ label: 'Navn', verdi: 'BARN TO' }),
@@ -538,6 +549,14 @@ describe('Barnepass-Steg', () => {
                 svarid: '',
                 label: '',
                 verdi: true,
+              }),
+              barnepass: lagBarnepass({
+                årsakBarnepass: lagSpørsmålFelt({
+                  spørsmålid: EBarnepass.årsakBarnepass,
+                  svarid: EÅrsakBarnepass.myeBortePgaJobb,
+                  label: 'Hvorfor trenger barnet pass?',
+                  verdi: 'Jeg er mye borte.',
+                }),
               }),
             }),
           ],

--- a/src/søknader/barnetilsyn/steg/6-barnepass/Barnepass.test.ts
+++ b/src/søknader/barnetilsyn/steg/6-barnepass/Barnepass.test.ts
@@ -405,12 +405,7 @@ describe('Barnepass-Steg', () => {
     expect(screen.getByRole('heading', { level: 3, name: 'GÅEN PC' })).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Hovedregelen er at du kan få stønad til barnetilsyn frem til barnet ditt har fullført 4. skoleår.'
-      )
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'På dette alderstrinnet er barn normalt blitt tilstrekkelig selvhjulpne og modne slik at de klarer seg utenfor skoletiden både i hjemmet og i sitt vanlige nærmiljø i den tiden du er fraværende på grunn av arbeid.'
+        'Hovedregelen er at du kan få stønad til barnetilsyn frem til barnet ditt er 14 måneder.'
       )
     ).toBeInTheDocument();
 

--- a/src/søknader/barnetilsyn/steg/6-barnepass/Barnepass.tsx
+++ b/src/søknader/barnetilsyn/steg/6-barnepass/Barnepass.tsx
@@ -46,7 +46,7 @@ export const Barnepass: FC = () => {
     settBarn,
     mellomlagreSteg,
   } = useBarnepass();
-  const { tidligereVedtakStatus } = useTidligereVedtak();
+  const { harTidligereVedtakStatus } = useTidligereVedtak();
   const barnSomSkalHaBarnepass = barn.filter((barn: IBarn) => barn.skalHaBarnepass?.verdi);
 
   const datovelgerLabel = 'søkerStønadFraBestemtMnd.datovelger.barnepass';
@@ -121,16 +121,22 @@ export const Barnepass: FC = () => {
             erBarnepassForBarnFørNåværendeUtfylt(
               barn,
               barnSomSkalHaBarnepass,
-              tidligereVedtakStatus
+              harTidligereVedtakStatus
             );
           return (
             visSeksjon && (
               <React.Fragment key={barn.id}>
                 <BarneHeader barn={barn} />
-                {skalViseÅrsakBarnepass(barn, tidligereVedtakStatus) && (
-                  <ÅrsakBarnepass barn={barn} settBarnepass={settBarnepass} />
+
+                {skalViseÅrsakBarnepass(barn, harTidligereVedtakStatus) && (
+                  <ÅrsakBarnepass
+                    barn={barn}
+                    settBarnepass={settBarnepass}
+                    tidligereVedtakStatus={harTidligereVedtakStatus}
+                  />
                 )}
-                {erÅrsakBarnepassSpmBesvart(barn, tidligereVedtakStatus) && (
+
+                {erÅrsakBarnepassSpmBesvart(barn, harTidligereVedtakStatus) && (
                   <BarnepassOrdninger barn={barn} settBarnepass={settBarnepass} indeks={index} />
                 )}
               </React.Fragment>

--- a/src/søknader/barnetilsyn/steg/6-barnepass/Barnepass.tsx
+++ b/src/søknader/barnetilsyn/steg/6-barnepass/Barnepass.tsx
@@ -13,7 +13,7 @@ import {
   erBarnepassForBarnFørNåværendeUtfylt,
   erBarnepassStegFerdigUtfylt,
   erÅrsakBarnepassSpmBesvart,
-  harBarnAvsluttetFjerdeKlasse,
+  skalViseÅrsakBarnepass,
   skalDokumentereTidligereFakturaer,
 } from './hjelper';
 import { NavigasjonState, Side } from '../../../../components/side/Side';
@@ -27,6 +27,7 @@ import { kommerFraOppsummeringen } from '../../../../utils/locationState';
 import { BodyShort, VStack } from '@navikt/ds-react';
 import { useBarnepass } from './BarnepassContext';
 import { BarneHeader } from '../../../../components/barneheader/BarneHeader';
+import { useTidligereVedtak } from '../../../../context/TidligereVedtakContext';
 
 export const Barnepass: FC = () => {
   const intl = useLokalIntlContext();
@@ -45,6 +46,7 @@ export const Barnepass: FC = () => {
     settBarn,
     mellomlagreSteg,
   } = useBarnepass();
+  const { tidligereVedtakStatus } = useTidligereVedtak();
   const barnSomSkalHaBarnepass = barn.filter((barn: IBarn) => barn.skalHaBarnepass?.verdi);
 
   const datovelgerLabel = 'søkerStønadFraBestemtMnd.datovelger.barnepass';
@@ -115,15 +117,20 @@ export const Barnepass: FC = () => {
       <VStack gap={'space-64'}>
         {barnSomSkalHaBarnepass.map((barn: IBarn, index: number) => {
           const visSeksjon =
-            index === 0 || erBarnepassForBarnFørNåværendeUtfylt(barn, barnSomSkalHaBarnepass);
+            index === 0 ||
+            erBarnepassForBarnFørNåværendeUtfylt(
+              barn,
+              barnSomSkalHaBarnepass,
+              tidligereVedtakStatus
+            );
           return (
             visSeksjon && (
               <React.Fragment key={barn.id}>
                 <BarneHeader barn={barn} />
-                {harBarnAvsluttetFjerdeKlasse(barn.fødselsdato.verdi) && (
+                {skalViseÅrsakBarnepass(barn, tidligereVedtakStatus) && (
                   <ÅrsakBarnepass barn={barn} settBarnepass={settBarnepass} />
                 )}
-                {erÅrsakBarnepassSpmBesvart(barn) && (
+                {erÅrsakBarnepassSpmBesvart(barn, tidligereVedtakStatus) && (
                   <BarnepassOrdninger barn={barn} settBarnepass={settBarnepass} indeks={index} />
                 )}
               </React.Fragment>

--- a/src/søknader/barnetilsyn/steg/6-barnepass/BarnepassSpørsmål.tsx
+++ b/src/søknader/barnetilsyn/steg/6-barnepass/BarnepassSpørsmål.tsx
@@ -20,6 +20,7 @@ import { Heading, TextField, VStack } from '@navikt/ds-react';
 import { SettDokumentasjonsbehovBarn } from '../../../overgangsstønad/models/søknad';
 import { TittelOgSlettKnapp } from '../../../../components/knapper/TittelOgSlettKnapp';
 import { GyldigeDatoer } from '../../../../components/dato/GyldigeDatoer';
+import { useTidligereVedtak } from '../../../../context/TidligereVedtakContext';
 
 interface Props {
   barn: IBarn;
@@ -39,6 +40,7 @@ export const BarnepassSpørsmål: FC<Props> = ({
   barnIndeks,
 }) => {
   const intl = useLokalIntlContext();
+  const { tidligereVedtakStatus } = useTidligereVedtak();
   const { hvaSlagsBarnepassOrdning, periode } = barnepassOrdning;
 
   const navnLabel =
@@ -129,7 +131,7 @@ export const BarnepassSpørsmål: FC<Props> = ({
             />
           )}
         </TittelOgSlettKnapp>
-        {erÅrsakBarnepassSpmBesvart(barn) && (
+        {erÅrsakBarnepassSpmBesvart(barn, tidligereVedtakStatus) && (
           <MultiSvarSpørsmålMedNavn
             spørsmål={HvaSlagsBarnepassOrdningSpm(intl)}
             spørsmålTekst={spørsmålTekstBarnepassOrdning}

--- a/src/søknader/barnetilsyn/steg/6-barnepass/BarnepassSpørsmål.tsx
+++ b/src/søknader/barnetilsyn/steg/6-barnepass/BarnepassSpørsmål.tsx
@@ -40,7 +40,7 @@ export const BarnepassSpørsmål: FC<Props> = ({
   barnIndeks,
 }) => {
   const intl = useLokalIntlContext();
-  const { tidligereVedtakStatus } = useTidligereVedtak();
+  const { harTidligereVedtakStatus } = useTidligereVedtak();
   const { hvaSlagsBarnepassOrdning, periode } = barnepassOrdning;
 
   const navnLabel =
@@ -131,7 +131,7 @@ export const BarnepassSpørsmål: FC<Props> = ({
             />
           )}
         </TittelOgSlettKnapp>
-        {erÅrsakBarnepassSpmBesvart(barn, tidligereVedtakStatus) && (
+        {erÅrsakBarnepassSpmBesvart(barn, harTidligereVedtakStatus) && (
           <MultiSvarSpørsmålMedNavn
             spørsmål={HvaSlagsBarnepassOrdningSpm(intl)}
             spørsmålTekst={spørsmålTekstBarnepassOrdning}

--- a/src/søknader/barnetilsyn/steg/6-barnepass/hjelper.ts
+++ b/src/søknader/barnetilsyn/steg/6-barnepass/hjelper.ts
@@ -1,3 +1,4 @@
+import { differenceInMonths } from 'date-fns';
 import { IBarn } from '../../../../models/steg/barn';
 import {
   dagensDato,
@@ -10,6 +11,7 @@ import { ESøkerFraBestemtMåned } from '../../../../models/steg/dinsituasjon/me
 import { harValgtSvar } from '../../../../utils/spørsmålogsvar';
 import { erStrengGyldigTall } from '../../../../utils/autentiseringogvalidering/feltvalidering';
 import { IDatoFelt, ISpørsmålBooleanFelt } from '../../../../models/søknad/søknadsfelter';
+import { TidligereVedtakStatus } from '../../../../innsending/api';
 
 export const harBarnAvsluttetFjerdeKlasse = (fødselsdato: string): boolean => {
   const juniEllerFør = dagensDato.getMonth() < 6;
@@ -23,12 +25,26 @@ export const harBarnAvsluttetFjerdeKlasse = (fødselsdato: string): boolean => {
   }
 };
 
-export const erÅrsakBarnepassSpmBesvart = (barn: IBarn): boolean => {
-  return (
-    (harBarnAvsluttetFjerdeKlasse(barn.fødselsdato.verdi) &&
-      barn.barnepass?.årsakBarnepass?.verdi !== undefined) ||
-    !harBarnAvsluttetFjerdeKlasse(barn.fødselsdato.verdi)
-  );
+export const erBarnMinstFjortenMåneder = (fødselsdato: string): boolean => {
+  return differenceInMonths(dagensDato, strengTilDato(fødselsdato)) >= 14;
+};
+
+export const skalViseÅrsakBarnepass = (
+  barn: IBarn,
+  tidligereVedtakStatus: TidligereVedtakStatus
+): boolean => {
+  if (tidligereVedtakStatus === 'JA') {
+    return harBarnAvsluttetFjerdeKlasse(barn.fødselsdato.verdi);
+  }
+  return erBarnMinstFjortenMåneder(barn.fødselsdato.verdi);
+};
+
+export const erÅrsakBarnepassSpmBesvart = (
+  barn: IBarn,
+  tidligereVedtakStatus: TidligereVedtakStatus
+): boolean => {
+  const skalVise = skalViseÅrsakBarnepass(barn, tidligereVedtakStatus);
+  return !skalVise || barn.barnepass?.årsakBarnepass?.verdi !== undefined;
 };
 
 export const erBarnepassOrdningerUtfylt = (barnepassordninger: BarnepassOrdning[]): boolean => {
@@ -67,10 +83,13 @@ export const erBarnepassForAlleBarnUtfylt = (barn: IBarn[]) => {
   );
 };
 
-export const erSpørsmålSeksjonForBarnFerdigUtfylt = (barn: IBarn) => {
+export const erSpørsmålSeksjonForBarnFerdigUtfylt = (
+  barn: IBarn,
+  tidligereVedtakStatus: TidligereVedtakStatus
+) => {
   const barnepass = barn.barnepass;
   return (
-    erÅrsakBarnepassSpmBesvart(barn) &&
+    erÅrsakBarnepassSpmBesvart(barn, tidligereVedtakStatus) &&
     barnepass?.barnepassordninger &&
     erBarnepassOrdningerUtfylt(barnepass?.barnepassordninger)
   );
@@ -78,13 +97,14 @@ export const erSpørsmålSeksjonForBarnFerdigUtfylt = (barn: IBarn) => {
 
 export const erBarnepassForBarnFørNåværendeUtfylt = (
   barn: IBarn,
-  barnSomSkalHaBarnepass: IBarn[]
+  barnSomSkalHaBarnepass: IBarn[],
+  tidligereVedtakStatus: TidligereVedtakStatus
 ): boolean => {
   const barnIndex: number = barnSomSkalHaBarnepass.indexOf(barn);
 
   return barnSomSkalHaBarnepass
     .filter((barn, index) => index < barnIndex)
-    .every((barn) => erSpørsmålSeksjonForBarnFerdigUtfylt(barn));
+    .every((barn) => erSpørsmålSeksjonForBarnFerdigUtfylt(barn, tidligereVedtakStatus));
 };
 
 const harBarnMedBarbehageOgLignende = (barn: IBarn[]): boolean => {

--- a/src/søknader/barnetilsyn/steg/6-barnepass/ÅrsakBarnepass.tsx
+++ b/src/søknader/barnetilsyn/steg/6-barnepass/ÅrsakBarnepass.tsx
@@ -54,7 +54,7 @@ export const ÅrsakBarnepass: FC<Props> = ({ barn, settBarnepass, tidligereVedta
   };
 
   const alertAdvarselTekst =
-    tidligereVedtakStatus === 'NEI'
+    tidligereVedtakStatus === 'JA'
       ? 'barnepass.alert-advarsel.årsak'
       : 'barnepass.alert-advarsel.årsak-regelendring-2026';
 

--- a/src/søknader/barnetilsyn/steg/6-barnepass/ÅrsakBarnepass.tsx
+++ b/src/søknader/barnetilsyn/steg/6-barnepass/ÅrsakBarnepass.tsx
@@ -11,13 +11,15 @@ import { Alert, VStack } from '@navikt/ds-react';
 import { hentHTMLTekst, hentTekst } from '../../../../utils/teksthåndtering';
 import { useBarnepass } from './BarnepassContext';
 import { AlertStripeDokumentasjon } from '../../../../components/AlertstripeDokumentasjon';
+import { TidligereVedtakStatus } from '../../../../innsending/api';
 
 interface Props {
   barn: IBarn;
   settBarnepass: (barnepass: IBarnepass, barneid: string) => void;
+  tidligereVedtakStatus: TidligereVedtakStatus;
 }
 
-export const ÅrsakBarnepass: FC<Props> = ({ barn, settBarnepass }) => {
+export const ÅrsakBarnepass: FC<Props> = ({ barn, settBarnepass, tidligereVedtakStatus }) => {
   const intl = useLokalIntlContext();
   const { settDokumentasjonsbehovForBarn } = useBarnepass();
   const { barnepass } = barn;
@@ -50,10 +52,16 @@ export const ÅrsakBarnepass: FC<Props> = ({ barn, settBarnepass }) => {
     );
     settDokumentasjonsbehovForBarn(spørsmål, svar, barn.id);
   };
+
+  const alertAdvarselTekst =
+    tidligereVedtakStatus === 'NEI'
+      ? 'barnepass.alert-advarsel.årsak'
+      : 'barnepass.alert-advarsel.årsak-regelendring-2026';
+
   return (
     <VStack gap={'space-48'}>
       <Alert size="small" variant="warning" inline>
-        {hentHTMLTekst('barnepass.alert-advarsel.årsak', intl)}
+        {hentHTMLTekst(alertAdvarselTekst, intl)}
       </Alert>
       <MultiSvarSpørsmålMedNavn
         spørsmål={årsakBarnepassConfig}

--- a/src/søknader/overgangsstønad/OvergangsstønadApp.tsx
+++ b/src/søknader/overgangsstønad/OvergangsstønadApp.tsx
@@ -26,7 +26,7 @@ export const OvergangsstønadApp = () => {
   const { fetchPersonData, error, settError, feilmelding, alvorlighetsgrad } = usePersonContext();
   const { settSøknad, hentMellomlagretOvergangsstønad } = useOvergangsstønadSøknad();
   const { settToggles } = useToggles();
-  const { settTidligereVedtakStatus } = useTidligereVedtak();
+  const { settHarTidligereVedtakStatus } = useTidligereVedtak();
 
   const intl = useLokalIntlContext();
   autentiseringsInterceptor();
@@ -52,13 +52,13 @@ export const OvergangsstønadApp = () => {
 
   const hentTidligereVedtakGammeltRegelverk = (toggles: Record<string, boolean> | void) => {
     if (!toggles || !toggles[ToggleName.overgangsstønadRegelendringer2026]) {
-      settTidligereVedtakStatus('VET_IKKE');
+      settHarTidligereVedtakStatus('VET_IKKE');
       return Promise.resolve();
     }
 
     return hentVedtakPåGammeltRegelverk()
-      .then((status) => settTidligereVedtakStatus(status))
-      .catch(() => settTidligereVedtakStatus('VET_IKKE'));
+      .then((status) => settHarTidligereVedtakStatus(status))
+      .catch(() => settHarTidligereVedtakStatus('VET_IKKE'));
   };
 
   useEffect(() => {

--- a/src/søknader/overgangsstønad/OvergangsstønadContext.tsx
+++ b/src/søknader/overgangsstønad/OvergangsstønadContext.tsx
@@ -82,9 +82,9 @@ const [OvergangsstønadSøknadProvider, useOvergangsstønadSøknad] = createUseC
   const [søknad, settSøknad] = useState<SøknadOvergangsstønad>(initialState(intl));
 
   const { toggles } = useToggles();
-  const { tidligereVedtakStatus } = useTidligereVedtak();
+  const { harTidligereVedtakStatus } = useTidligereVedtak();
 
-  const harIkkeTidligereVedtak = tidligereVedtakStatus !== 'JA';
+  const harIkkeTidligereVedtak = harTidligereVedtakStatus !== 'JA';
   const skalBrukeRegelendringer2026 =
     harIkkeTidligereVedtak && toggles[ToggleName.overgangsstønadRegelendringer2026];
 

--- a/src/test/axios.ts
+++ b/src/test/axios.ts
@@ -1,5 +1,6 @@
 import Environment from '../Environment';
 import {
+  lagBarnepass,
   lagBooleanFelt,
   lagDatoFelt,
   lagIBarn,
@@ -28,6 +29,7 @@ import { isoDatoEnMånedTilbake } from './dato';
 import { dagensIsoDatoMinusMåneder } from '../utils/dato';
 import { SøknadBarnetilsyn } from '../søknader/barnetilsyn/models/søknad';
 import { SøknadSkolepenger } from '../søknader/skolepenger/models/søknad';
+import { EBarnepass, EÅrsakBarnepass } from '../søknader/barnetilsyn/models/barnepass';
 
 type StønadType =
   | 'overgangsstonad'
@@ -98,6 +100,9 @@ export const mockGet = (url: string, stønadType: StønadType) => {
     return Promise.resolve({
       data: [],
     });
+  }
+  if (url === `${Environment().apiProxyUrl}/api/saksbehandling/har-vedtak-pa-gammelt-regelverk`) {
+    return Promise.resolve({ data: 'VET_IKKE' });
   }
   return Promise.resolve({ data: {} });
 };
@@ -544,6 +549,14 @@ const søknadBarnetilsynBarnasBosted = (søknad?: Partial<SøknadBarnetilsyn>) =
             svarid: '',
             label: '',
             verdi: true,
+          }),
+          barnepass: lagBarnepass({
+            årsakBarnepass: lagSpørsmålFelt({
+              spørsmålid: EBarnepass.årsakBarnepass,
+              svarid: EÅrsakBarnepass.myeBortePgaJobb,
+              label: 'Hvorfor trenger barnet pass?',
+              verdi: 'Jeg er mye borte.',
+            }),
           }),
         }),
       ],


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Med regelendring 2026 skal vi stille spørsmål om hvorfor barn trenger barnepass hvis det er mer enn 14 mnd. Ved gammel søknad (ingen tidligere innvilget vedtak) skal spørsmål være likt som i dag.

Skal vise annen tekst på alert til spørsmål om barnepass når det er søknad med regelendring 2026 og barnet er over 14 måneder.

<img width="976" height="886" alt="image" src="https://github.com/user-attachments/assets/d3c92d64-cabc-44ec-a604-f08ee3ba19bc" />


[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29097)