### PR TITLE
Ikke vis infoboks om å vente med å søke til august, i 2026 

### DIFF
--- a/src/søknader/barnetilsyn/Forside.tsx
+++ b/src/søknader/barnetilsyn/Forside.tsx
@@ -56,7 +56,7 @@ const Forside: React.FC = () => {
             {hentTekst('barnetilsyn.sidetittel', intl)}
           </Heading>
 
-          {erDagensDatoMellomMaiOgAugust && (
+          {erDagensDatoMellomMaiOgAugust && nåværendeÅr !== 2026 && (
             <Alert variant="info" style={{ marginBottom: '2rem' }}>
               <Heading spacing size="small" level="3">
                 {hentTekstMedEnVariabel('barnetilsyn.søkerFraAugustTittel', intl, `${nåværendeÅr}`)}


### PR DESCRIPTION
Viser ikke infoboks i 2026 som ber bruker om å vente til august, pga. overgang til nytt regelverk