### PR TITLE
Setter 'overskuddsår' på samme måte for regelendring som med tidliger…

### DIFF
--- a/src/søknader/overgangsstønad/steg/5-regelendring-2026/Situasjon.tsx
+++ b/src/søknader/overgangsstønad/steg/5-regelendring-2026/Situasjon.tsx
@@ -28,7 +28,7 @@ import { erSisteFirmaUtfylt } from '../../../../helpers/steg/aktivitetvalidering
 import { HarSøkerSagtOppEllerRedusertStilling } from '../6-meromsituasjon/HarSøkerSagtOppEllerRedusertStilling';
 import NårSøkerDuStønadFra from '../../../../components/stegKomponenter/NårSøkerDuStønadFraGruppe';
 import { SøknadOvergangsstønad } from '../../models/søknad';
-import { datoTilStreng } from '../../../../utils/dato';
+import { datoTilStreng, nullableStrengTilDato, nåværendeÅr } from '../../../../utils/dato';
 import { useLeggTilSærligeBehovHvisHarEttBarMedSærligeBehov } from '../../../../utils/hooks';
 import { IAktivitet } from '../../../../models/steg/aktivitet/aktivitet';
 import { returnerAvhukedeSvar } from '../../../../utils/spørsmålogsvar';
@@ -260,7 +260,9 @@ export const Situasjon: React.FC = () => {
           <OmFirmaeneDine
             arbeidssituasjon={aktivitet}
             settArbeidssituasjon={settAktivitet}
-            overskuddsår={new Date().getFullYear() - 1}
+            overskuddsår={
+              nullableStrengTilDato(søknad.datoPåbegyntSøknad)?.getFullYear() || nåværendeÅr
+            }
           />
         )}
 


### PR DESCRIPTION
…e versjon for overgangsstønad. Det ble feil med -1 år.

### Hvorfor er denne endringen nødvendig? ✨

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29764)