### PR TITLE
Fikser spam av refresh kall ved scrolling

### DIFF
--- a/server/decorator.ts
+++ b/server/decorator.ts
@@ -19,6 +19,7 @@ const hentDekoratørConfig = () => {
     simple: true,
     redirectToApp: true,
     level: 'Level4',
+    logoutWarning: false,
   };
 
   return {


### PR DESCRIPTION
# Fikser spam av refresh kall ved scrolling

### Hvorfor er denne endringen nødvendig? ✨

Når man scrollet på siden ble det fyrt av et auth-kall (`/oauth2/session/refresh`) om og om igjen, opp mot 120 ganger bare ved litt scrolling.

Det viste seg at det ikke var noe i vår egen kode som gjorde dette. Kallet kommer fra dekoratøren sitt eget script. Dekoratøren har en funksjon (`logoutWarning`) som prøver å holde sesjonen i live ved å fornye token når brukeren er aktiv (scroll, mus, tastatur). Den funksjonen er på som standard. I dette tilfellet endte den opp med å fyre én fornyelse per scroll-event.

Fiksen er å skru av denne funksjonen for vår app ved å sette `logoutWarning: false` i dekoratør-oppsettet. Da slutter dekoratøren å fornye på aktivitet, og kallene forsvinner.

Verdt å vite: dette skrur også av "du blir snart logget ut"-dialogen. Den egentlige feilen ligger hos dekoratøren (den mangler en grense for hvor ofte den kan fornye), så dette er en grei midlertidig løsning til det eventuelt fikses der.

### Verdt å nevne

Testet i dev og lokalt:

* Scrollet mye på siden og bekreftet at `/oauth2/session/refresh` ikke lenger spammes.
* Sjekket at `window.__DECORATOR_DATA__.params.logoutWarning` er `false` i nettleseren.
* Bekreftet at dekoratør, header og footer fortsatt rendres som før.