### PR TITLE
Legger kun ved spm i aktivitetscontext ved gammelt regelverk

### DIFF
--- a/src/søknader/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/søknader/barnetilsyn/BarnetilsynContext.tsx
@@ -40,6 +40,7 @@ import { stringHarVerdiOgErIkkeTom } from '../../utils/typer';
 import { hentTekst } from '../../utils/teksthåndtering';
 import { useToggles } from '../../context/TogglesContext';
 import { ToggleName } from '../../models/søknad/toggles';
+import { useTidligereVedtak } from '../../context/TidligereVedtakContext';
 
 const initialState = (intl: LokalIntlShape): SøknadBarnetilsyn => {
   return {
@@ -82,6 +83,13 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(() 
 
   const { toggles } = useToggles();
   const gjenbrukBarnetilsynToggle = toggles[ToggleName.gjenbrukBarnetilsyn];
+  const { harTidligereOvergangsstønadStatus, harLøpendeBarnetilsynVedRegelendring2026 } =
+    useTidligereVedtak();
+
+  const skalBrukeRegelendringer2026 =
+    harTidligereOvergangsstønadStatus !== 'JA' &&
+    !harLøpendeBarnetilsynVedRegelendring2026 &&
+    toggles[ToggleName.overgangsstønadRegelendringer2026];
 
   useEffect(() => {
     if (mellomlagretBarnetilsyn?.locale && mellomlagretBarnetilsyn?.locale !== locale) {
@@ -440,6 +448,7 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(() 
     nullstillSøknadBarnetilsyn,
     oppdaterBarnISøknaden,
     oppdaterFlereBarnISøknaden,
+    skalBrukeRegelendringer2026,
   };
 });
 

--- a/src/søknader/barnetilsyn/steg/5-aktivitet/AktivitetArbeid.tsx
+++ b/src/søknader/barnetilsyn/steg/5-aktivitet/AktivitetArbeid.tsx
@@ -12,10 +12,12 @@ import { hvaErDinArbeidssituasjonSpm } from './AktivitetConfig';
 import { AktivitetOppfølgingSpørsmål } from './AktivitetOppfølgingSpørsmål';
 import { useAktivitet } from './AktivitetContext';
 import { VStack } from '@navikt/ds-react';
+import { useBarnetilsynSøknad } from '../../BarnetilsynContext';
 
 export const AktivitetArbeid: React.FC = () => {
   const intl = useLokalIntlContext();
   const { søknad, aktivitet, settAktivitet, settDokumentasjonsbehov } = useAktivitet();
+  const { skalBrukeRegelendringer2026 } = useBarnetilsynSøknad();
   const { hvaErDinArbeidssituasjon } = aktivitet;
 
   const settArbeidssituasjonFelt = (spørsmål: ISpørsmål, svarHuketAv: boolean, svar: ISvar) => {
@@ -44,7 +46,7 @@ export const AktivitetArbeid: React.FC = () => {
       <CheckboxSpørsmål
         spørsmål={filtrerAktivitetSvaralternativer(
           søknad.person,
-          hvaErDinArbeidssituasjonSpm(intl)
+          hvaErDinArbeidssituasjonSpm(intl, skalBrukeRegelendringer2026)
         )}
         settValgteSvar={settArbeidssituasjonFelt}
         valgteSvar={hvaErDinArbeidssituasjon?.verdi ? hvaErDinArbeidssituasjon?.verdi : []}

--- a/src/søknader/barnetilsyn/steg/5-aktivitet/AktivitetConfig.tsx
+++ b/src/søknader/barnetilsyn/steg/5-aktivitet/AktivitetConfig.tsx
@@ -36,7 +36,10 @@ export const ErDuIArbeidSpm = (intl: LokalIntlShape): ISpørsmål => ({
   ],
 });
 
-export const hvaErDinArbeidssituasjonSpm = (intl: LokalIntlShape): ISpørsmål => ({
+export const hvaErDinArbeidssituasjonSpm = (
+  intl: LokalIntlShape,
+  er2026regelverk?: boolean
+): ISpørsmål => ({
   søknadid: EArbeidssituasjon.hvaErDinArbeidssituasjon,
   tekstid: 'arbeidssituasjon.spm',
   lesmer: {
@@ -63,10 +66,14 @@ export const hvaErDinArbeidssituasjonSpm = (intl: LokalIntlShape): ISpørsmål =
       id: EAktivitet.erAnsattIEgetAS,
       svar_tekst: hentTekst('arbeidssituasjon.svar.erAnsattIEgetAS', intl),
     },
-    {
-      id: EAktivitet.etablererEgenVirksomhet,
-      svar_tekst: hentTekst('arbeidssituasjon.svar.etablererEgenVirksomhet', intl),
-      dokumentasjonsbehov: DokumentasjonOmVirksomhetenDuEtablerer,
-    },
+    ...(!er2026regelverk
+      ? [
+          {
+            id: EAktivitet.etablererEgenVirksomhet,
+            svar_tekst: hentTekst('arbeidssituasjon.svar.etablererEgenVirksomhet', intl),
+            dokumentasjonsbehov: DokumentasjonOmVirksomhetenDuEtablerer,
+          },
+        ]
+      : []),
   ],
 });

--- a/src/søknader/barnetilsyn/steg/6-barnepass/Barnepass.tsx
+++ b/src/søknader/barnetilsyn/steg/6-barnepass/Barnepass.tsx
@@ -27,6 +27,7 @@ import { kommerFraOppsummeringen } from '../../../../utils/locationState';
 import { BodyShort, VStack } from '@navikt/ds-react';
 import { useBarnepass } from './BarnepassContext';
 import { BarneHeader } from '../../../../components/barneheader/BarneHeader';
+import { useBarnetilsynSøknad } from '../../BarnetilsynContext';
 
 export const Barnepass: FC = () => {
   const intl = useLokalIntlContext();
@@ -45,7 +46,7 @@ export const Barnepass: FC = () => {
     settBarn,
     mellomlagreSteg,
   } = useBarnepass();
-  const { skalBrukeRegelendringer2026 } = useBarnepass();
+  const { skalBrukeRegelendringer2026 } = useBarnetilsynSøknad();
   const barnSomSkalHaBarnepass = barn.filter((barn: IBarn) => barn.skalHaBarnepass?.verdi);
 
   const datovelgerLabel = 'søkerStønadFraBestemtMnd.datovelger.barnepass';

--- a/src/søknader/barnetilsyn/steg/6-barnepass/BarnepassContext.ts
+++ b/src/søknader/barnetilsyn/steg/6-barnepass/BarnepassContext.ts
@@ -6,9 +6,6 @@ import { SøknadBarnetilsyn } from '../../models/søknad';
 import { useState } from 'react';
 import { sanerBarnepassSteg } from './sanerBarnepassSteg';
 import { SettDokumentasjonsbehovBarn } from '../../../overgangsstønad/models/søknad';
-import { ToggleName } from '../../../../models/søknad/toggles';
-import { useToggles } from '../../../../context/TogglesContext';
-import { useTidligereVedtak } from '../../../../context/TidligereVedtakContext';
 
 export interface Props {
   søknad: SøknadBarnetilsyn;
@@ -30,18 +27,10 @@ export const [BarnepassProvider, useBarnepass] = constate(
     settDokumentasjonsbehovForBarn,
   }: Props) => {
     const location = useLocation();
-    const { toggles } = useToggles();
-    const { harTidligereOvergangsstønadStatus, harLøpendeBarnetilsynVedRegelendring2026 } =
-      useTidligereVedtak();
 
     const [barn, settBarn] = useState(søknad.person.barn);
     const [søknadsdato, settSøknadsdato] = useState(søknad.søknadsdato);
     const [søkerFraBestemtMåned, settSøkerFraBestemtMåned] = useState(søknad.søkerFraBestemtMåned);
-
-    const skalBrukeRegelendringer2026 =
-      harTidligereOvergangsstønadStatus !== 'JA' &&
-      !harLøpendeBarnetilsynVedRegelendring2026 &&
-      toggles[ToggleName.overgangsstønadRegelendringer2026];
 
     const mellomlagreSteg = () => {
       const oppdatertSøknad = sanerBarnepassSteg(søknad, barn, søknadsdato, søkerFraBestemtMåned);
@@ -58,7 +47,6 @@ export const [BarnepassProvider, useBarnepass] = constate(
       settSøknadsdato,
       søkerFraBestemtMåned,
       settSøkerFraBestemtMåned,
-      skalBrukeRegelendringer2026,
       mellomlagreSteg,
       søknad,
       oppdaterSøknad,

--- a/src/søknader/barnetilsyn/steg/6-barnepass/BarnepassSpørsmål.tsx
+++ b/src/søknader/barnetilsyn/steg/6-barnepass/BarnepassSpørsmål.tsx
@@ -20,7 +20,7 @@ import { Heading, TextField, VStack } from '@navikt/ds-react';
 import { SettDokumentasjonsbehovBarn } from '../../../overgangsstønad/models/søknad';
 import { TittelOgSlettKnapp } from '../../../../components/knapper/TittelOgSlettKnapp';
 import { GyldigeDatoer } from '../../../../components/dato/GyldigeDatoer';
-import { useBarnepass } from './BarnepassContext';
+import { useBarnetilsynSøknad } from '../../BarnetilsynContext';
 
 interface Props {
   barn: IBarn;
@@ -40,7 +40,7 @@ export const BarnepassSpørsmål: FC<Props> = ({
   barnIndeks,
 }) => {
   const intl = useLokalIntlContext();
-  const { skalBrukeRegelendringer2026 } = useBarnepass();
+  const { skalBrukeRegelendringer2026 } = useBarnetilsynSøknad();
   const { hvaSlagsBarnepassOrdning, periode } = barnepassOrdning;
 
   const navnLabel =


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

De reelle endringene ligger i AktivitetArbeid og AktivitetConfig, der vi nå kun legger ved siste alternativet om man er i gammel søknad (!ny)

Resten av endringene er å flytte skalBrukeRegelendringer2026 fra barnepasscontext til barnetilsyncontext