### PR TITLE
Vil legge til infoboks om regelendringer på skolepenger.

### DIFF
--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -825,6 +825,10 @@ export default {
   'skolepenger.søkerFraAugustTittel': 'Are you applying for a school fee benefit from August [0]?',
   'skolepenger.søkerFraAugustInnhold':
     'In order to receive benefits for a new school year, you must be able to document your school fees with an invoice. We recommend that you wait to apply until you receive the invoice.',
+  'skolepenger.skolepengerRegelendringInfoTittel':
+    'Endringer i stønadene til enslig mor eller far fra 1. juli 2026',
+  'skolepenger.skolepengerRegelendringInfoInnhold':
+    'The Storting has approved changes to the benefits for single parents. These changes mean that the support for school fees will be discontinued. In addition, the transitional benefit and the child care benefit will be phased out for the majority of recipients. <br/><br/> To be eligible for support for school fees, you must be entitled to a transitional benefit under the rules that applied before 1 July 2026. If you are entitled to a transitional benefit under the new rules that apply from 1 July 2026, you are not entitled to support for school fees.',
   'skolepenger.overskrift': 'Application for support for school fees',
   'banner.tittel.skolepenger': 'Application for support for school fees',
   'barnadine.skolepenger.info.brukpdf':

--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -826,7 +826,7 @@ export default {
   'skolepenger.søkerFraAugustInnhold':
     'In order to receive benefits for a new school year, you must be able to document your school fees with an invoice. We recommend that you wait to apply until you receive the invoice.',
   'skolepenger.skolepengerRegelendringInfoTittel':
-    'Endringer i stønadene til enslig mor eller far fra 1. juli 2026',
+    'Changes to benefits for single parents effective 1 July 2026',
   'skolepenger.skolepengerRegelendringInfoInnhold':
     'The Storting has approved changes to the benefits for single parents. These changes mean that the support for school fees will be discontinued. In addition, the transitional benefit and the child care benefit will be phased out for the majority of recipients. <br/><br/> To be eligible for support for school fees, you must be entitled to a transitional benefit under the rules that applied before 1 July 2026. If you are entitled to a transitional benefit under the new rules that apply from 1 July 2026, you are not entitled to support for school fees.',
   'skolepenger.overskrift': 'Application for support for school fees',

--- a/src/language/tekster_nb.ts
+++ b/src/language/tekster_nb.ts
@@ -799,6 +799,10 @@ export default {
   'skolepenger.søkerFraAugustTittel': 'Søker du om stønad til skolepenger fra august [0]?',
   'skolepenger.søkerFraAugustInnhold':
     'For å få stønad for nytt skoleår må du kunne dokumentere utgiftene til skolepenger med faktura. Vi anbefaler derfor at du venter med å søke frem til du får fakturaen.',
+  'skolepenger.skolepengerRegelendringInfoTittel':
+    'Endringer i stønadene til enslig mor eller far fra 1. juli 2026',
+  'skolepenger.skolepengerRegelendringInfoInnhold':
+    'Stortinget har vedtatt endringer i stønadene til enslig mor eller far. Endringene innebærer at stønad til skolepenger blir avviklet. I tillegg blir overgangsstønad og stønad til barnetilsyn faset ut for hovedgruppen av mottakere. <br/><br/> For å få stønad til skolepenger må du ha rett til overgangsstønad etter reglene som gjaldt før 1. juli 2026. Hvis du har rett til overgangsstønad etter de nye reglene som gjelder fra 1. juli 2026, har du ikke rett til stønad til skolepenger.',
   'skolepenger.overskrift': 'Søknad om stønad til skolepenger',
   'banner.tittel.skolepenger': 'Søknad om skolepenger',
   'barnadine.skolepenger.info.brukpdf':

--- a/src/søknader/skolepenger/Forside.tsx
+++ b/src/søknader/skolepenger/Forside.tsx
@@ -6,12 +6,14 @@ import FortsettSøknad from '../../components/forside/FortsettSøknad';
 import { useSpråkValg } from '../../utils/hooks';
 import { ESkjemanavn } from '../../utils/skjemanavn';
 import { useLokalIntlContext } from '../../context/LokalIntlContext';
-import { Alert, Box, Heading } from '@navikt/ds-react';
+import { Alert, BodyShort, Box, Heading } from '@navikt/ds-react';
 import { erNåværendeMånedMellomMåneder, nåværendeÅr } from '../../utils/dato';
 import { AlertUnderAtten } from '../../components/forside/AlertUnderAtten';
 import { VeilederBoks } from '../../components/forside/VeilederBoks';
 import SkolepengerInformasjon from './SkolepengerInformasjon';
-import { hentTekst, hentTekstMedEnVariabel } from '../../utils/teksthåndtering';
+import { hentHTMLTekst, hentTekst, hentTekstMedEnVariabel } from '../../utils/teksthåndtering';
+import { ToggleName } from '../../models/søknad/toggles';
+import { useToggles } from '../../context/TogglesContext';
 
 const Forside: React.FC = () => {
   const { person } = usePersonContext();
@@ -24,6 +26,8 @@ const Forside: React.FC = () => {
     settSøknad,
   } = useSkolepengerSøknad();
   const erDagensDatoMellomMaiOgAugust = erNåværendeMånedMellomMåneder(5, 8);
+  const { toggles } = useToggles();
+  const visRegelendring2026Varsel = toggles[ToggleName.overgangsstønadRegelendringer2026];
 
   const settBekreftelse = (bekreftelse: boolean) => {
     settSøknad({
@@ -55,12 +59,23 @@ const Forside: React.FC = () => {
             {hentTekst('skolepenger.overskrift', intl)}
           </Heading>
 
-          {erDagensDatoMellomMaiOgAugust && (
+          {erDagensDatoMellomMaiOgAugust && !visRegelendring2026Varsel && (
             <Alert variant="info" style={{ marginBottom: '2rem' }}>
               <Heading spacing size="small" level="3">
                 {hentTekstMedEnVariabel('skolepenger.søkerFraAugustTittel', intl, `${nåværendeÅr}`)}
               </Heading>
               {hentTekst('skolepenger.søkerFraAugustInnhold', intl)}
+            </Alert>
+          )}
+
+          {visRegelendring2026Varsel && (
+            <Alert variant="info" style={{ marginBottom: '2rem' }}>
+              <Heading spacing size="small" level="3">
+                {hentTekst('skolepenger.skolepengerRegelendringInfoTittel', intl)}
+              </Heading>
+              <BodyShort>
+                {hentHTMLTekst('skolepenger.skolepengerRegelendringInfoInnhold', intl)}
+              </BodyShort>
             </Alert>
           )}
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29827

tekst fra favro: 
`Endringer i stønadene til enslig mor eller far fra 1. juli 2026

Stortinget har vedtatt endringer i stønadene til enslig mor eller far. Endringene innebærer at stønad til skolepenger blir avviklet. I tillegg blir overgangsstønad og stønad til barnetilsyn faset ut for hovedgruppen av mottakere. 



For å få stønad til skolepenger må du ha rett til overgangsstønad etter reglene som gjaldt før 1. juli 2026. Hvis du har rett til overgangsstønad etter de nye reglene som gjelder fra 1. juli 2026, har du ikke rett til stønad til skolepenger. 





Engelsk:

Changes to benefits for single parents effective 1 July 2026

The Storting has approved changes to the benefits for single parents. These changes mean that the support for school fees will be discontinued. In addition, the transitional benefit and the child care benefit will be phased out for the majority of recipients.



To be eligible for support for school fees, you must be entitled to a transitional benefit under the rules that applied before 1 July 2026. If you are entitled to a transitional benefit under the new rules that apply from 1 July 2026, you are not entitled to support for school fees.

`


TOGGLE PÅ:
<img width="1612" height="1462" alt="image" src="https://github.com/user-attachments/assets/d467cbf1-580d-4ec7-af0c-8b529ff53e05" />

TOGGLE AV: 
<img width="1470" height="1282" alt="image" src="https://github.com/user-attachments/assets/e363d24c-a141-425c-b45c-d458713a660e" />
