### PR TITLE
Juster ressurser etter Nais-anbefaling

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -62,7 +62,7 @@ spec:
       value: dev
   resources:
     limits:
-      memory: 512Mi
+      memory: 256Mi
     requests:
-      memory: 512Mi
-      cpu: 20m
+      memory: 256Mi
+      cpu: 50m

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -62,7 +62,7 @@ spec:
       value: prod
   resources:
     limits:
-      memory: 768Mi
+      memory: 256Mi
     requests:
-      memory: 768Mi
-      cpu: 100m
+      memory: 256Mi
+      cpu: 50m


### PR DESCRIPTION
## Hva
Justerer CPU/memory requests og limits etter Nais console sine anbefalinger (basert på faktisk bruk). Forrige runde satte vi `memory request = limit`, men på de gamle høye verdiene, noe som ga over-reservering flagget som «dyrere ressurser enn forventet».

## Hvordan
- **Memory:** `request = limit` beholdt (Guaranteed QoS), satt til Nais sitt anbefalte limit avrundet til ren verdi.
- **CPU request** justert mot anbefaling. Ingen CPU-limit.